### PR TITLE
Fixes shadow behind transparent images & makes h3 anchor links

### DIFF
--- a/src/components/markdown/Markdown.js
+++ b/src/components/markdown/Markdown.js
@@ -38,12 +38,6 @@ export class FlexGroup extends React.Component {
   }
 }
 
-export class h3 extends React.Component {
-  render() {
-    return <h3 className="page-h3">{this.props.children}</h3>;
-  }
-}
-
 export class h4 extends React.Component {
   render() {
     return <h4 className="page-h4">{this.props.children}</h4>;

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -91,6 +91,7 @@
 //----------------------------
 
 .page-h3,
+.page-content h3,
 .component-docs h3 {
   @include typescale('delta');
   color: $brand-01;
@@ -149,7 +150,7 @@
   background: $ui-02;
 }
 
-.page-content--component .gatsby-resp-image-background-image {
+.gatsby-resp-image-background-image {
   background: transparent!important; // Need important to override inline style added by gatsby-remark-images
 }
 

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -30,7 +30,6 @@ import ComponentOverview from '../components/ComponentOverview';
 
 // Custom Markdown
 import {
-  h3,
   h4,
   ul,
   ol,
@@ -43,7 +42,6 @@ import {
 const renderAst = new rehypeReact({
   createElement: React.createElement,
   components: {
-    h3: h3,
     h4: h4,
     ul: ul,
     ol: ol,


### PR DESCRIPTION
Fixes shadow behind transparent images

Removes h3 as custom markdown so that auto linking will work and adds styling so h3 looks the same as before