### PR TITLE
159 mobile nav flickers open closed

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -72,19 +72,23 @@ class Layout extends React.Component {
   };
 
   checkWidth = () => {
-    const width = window.innerWidth;
-    if (width < 1024) {
-      this.setState({
-        isOpen: false,
-      });
-    }
-    document.addEventListener('keydown', evt => {
-      if (evt.which === 27 && this.state.isOpen) {
+    if (typeof window !== 'undefined') {
+      const width = window.innerWidth;
+
+      if (width < 1024) {
         this.setState({
           isOpen: false,
         });
       }
-    });
+
+      document.addEventListener('keydown', evt => {
+        if (evt.which === 27 && this.state.isOpen) {
+          this.setState({
+            isOpen: false,
+          });
+        }
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
This is a super temporary fix to squash this bug using an old-school lifecycle method so that we check the page width before the component is rendered rather than after.

Also adds a check that window is not undefined since window will throw an error when server side rendering the components.

Moving forward the nav logic will need to be reworked to get componentDidMount() working as intended without the nav popping in and out.