### PR TITLE
WIP: fix index page links

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -350,7 +350,7 @@ class IndexPage extends React.Component {
             <ul className="overview-page__list">
               <li className="overview-page__list-item">
                 <Link
-                  to="/getting-started"
+                  to="/getting-started/designers"
                   aria-label="Getting started"
                   className="list-item__link">
                   <img src={gettingStartedIll} alt="" />
@@ -366,8 +366,8 @@ class IndexPage extends React.Component {
               </li>
               <li className="overview-page__list-item">
                 <Link
-                  to="/style"
-                  aria-label="Style"
+                  to="/guidelines/accessibility/overview"
+                  aria-label="Guidelines"
                   className="list-item__link">
                   <img src={styleIll} alt="" />
                   <div className="list-item__info">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -354,12 +354,12 @@ class IndexPage extends React.Component {
                   aria-label="Getting started"
                   className="list-item__link">
                   <img src={gettingStartedIll} alt="" />
-                
+
                   <div className="list-item__info">
                     <span className="list-item__heading">Getting Started</span>
                     <p>
-                      Onboarding for designers and developers who are using Carbon
-                      for the first time.
+                      Onboarding for designers and developers who are using
+                      Carbon for the first time.
                     </p>
                   </div>
                 </Link>
@@ -373,22 +373,23 @@ class IndexPage extends React.Component {
                   <div className="list-item__info">
                     <span className="list-item__heading">Guidelines</span>
                     <p>
-                      Guidance on usage and application for basic design elements.
+                      Guidance on usage and application for basic design
+                      elements.
                     </p>
                   </div>
                 </Link>
               </li>
               <li className="overview-page__list-item">
                 <Link
-                  to="/components"
+                  to="/components/overview"
                   aria-label="Components"
                   className="list-item__link">
                   <img src={componentsIll} alt="" />
                   <div className="list-item__info">
                     <span className="list-item__heading">Components</span>
                     <p>
-                      A library of all Carbon components, comprised of code, usage
-                      and style guidelines.
+                      A library of all Carbon components, comprised of code,
+                      usage and style guidelines.
                     </p>
                   </div>
                 </Link>


### PR DESCRIPTION
addresses https://github.com/carbon-design-system/carbon-website/issues/207

WIP! have a couple questions about where links should go.

**Changed**

- in `/src/pages/index.js`, changed:
  - line 384 `Link`, from `to="/components"` to `to="/components/overview"`

QUESTION:
Not sure if we actually have an overview page for the other sections? @alisonjoseph @carbon-design-system/design do you know what the proper landing address should be for each of these sections? the "Components" overview page was the only section with an actual landing/overview page.