### PR TITLE
fix(build): go away from custom .babelrc for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,49 +85,6 @@
     "storybook-readme": "^3.3.0",
     "surge": "^0.20.1"
   },
-  "babel": {
-    "presets": [
-      [
-        "@babel/preset-env",
-        {
-          "loose": true,
-          "modules": false,
-          "useBuiltIns": false,
-          "shippedProposals": true,
-          "targets": {
-            "browsers": [
-              ">0.25%",
-              "not dead"
-            ]
-          }
-        }
-      ],
-      [
-        "@babel/preset-react",
-        {
-          "useBuiltIns": false,
-          "pragma": "React.createElement"
-        }
-      ]
-    ],
-    "plugins": [
-      [
-        "@babel/plugin-proposal-class-properties",
-        {
-          "loose": true
-        }
-      ],
-      "@babel/plugin-syntax-dynamic-import",
-      "babel-plugin-macros",
-      [
-        "@babel/plugin-transform-runtime",
-        {
-          "helpers": true,
-          "regenerator": true
-        }
-      ]
-    ]
-  },
   "eslintConfig": {
     "globals": {
       "__PATH_PREFIX__": true


### PR DESCRIPTION
Some change seems to have caused our app code, including our polyfill code, code-splitted, which caused missing `Promise` polyfill when Gatsby code uses it.

Fixes #263.

#### Changelog

**Removed**

- Custom Babel config from `package.json`.