### PR TITLE
Fix link for tabs with multiple spaces

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -72,7 +72,7 @@ exports.createPages = ({ actions, graphql }) => {
         },
       });
       if (tabs.length > 1) {
-        const current = tabs[0].toLowerCase().replace(' ', '-');
+        const current = tabs[0].toLowerCase().split(' ').join('-');
         const lastIndex = currentPath.lastIndexOf(current);
         if (lastIndex >= 0) {
           currentPath = currentPath.slice(0, currentPath.lastIndexOf(current));

--- a/src/components/PageTabs/PageTabs.js
+++ b/src/components/PageTabs/PageTabs.js
@@ -16,10 +16,10 @@ export default class PageTabs extends React.Component {
       <li
         key={tab}
         className={
-          tab.toLowerCase().replace(' ', '-') === currentTab ? 'selected' : ''
+          tab.toLowerCase().split(' ').join('-') === currentTab ? 'selected' : ''
         }
         key={tab}>
-        <Link to={`${linkSlug}${tab.toLowerCase().replace(' ', '-')}`}>
+        <Link to={`${linkSlug}${tab.toLowerCase().split(' ').join('-')}`}>
           {tab}
         </Link>
       </li>

--- a/src/components/PageTabs/page-tabs.scss
+++ b/src/components/PageTabs/page-tabs.scss
@@ -43,7 +43,6 @@
 .page-tabs__list li a {
   @include typescale('epsilon');
   text-decoration: none;
-  text-transform: capitalize;
   color: $text-01;
   font-weight: 600;
   white-space: nowrap;


### PR DESCRIPTION
Closes #323

Updates so correct links are added for tabs w/ multiple spaces, and gets rid of css to capitalize all words. 