### PR TITLE
fix(ComponentExample): fix wrong element ref

### DIFF
--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -136,7 +136,7 @@ class ComponentExample extends Component {
             if (TheComponent.prototype.createdByLauncher) {
               const initHandles = this.constructor._initHandles;
               if (!initHandles.has(TheComponent)) {
-                initHandles.set(TheComponent, TheComponent.init(elem, options));
+                initHandles.set(TheComponent, TheComponent.init(ref, options));
               }
             } else {
               const selectorInit = TheComponent.options.selectorInit;


### PR DESCRIPTION
🙏 Fixes #330.

#### Changelog

**Changed**

- Fixed the wrong DOM element reference for Carbon components instantiated by launcher buttons