### PR TITLE
fix(ComponentExample): use document for launcher-based instantiation

### DIFF
--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -136,7 +136,7 @@ class ComponentExample extends Component {
             if (TheComponent.prototype.createdByLauncher) {
               const initHandles = this.constructor._initHandles;
               if (!initHandles.has(TheComponent)) {
-                initHandles.set(TheComponent, TheComponent.init(ref, options));
+                initHandles.set(TheComponent, TheComponent.init(ref.ownerDocument, options));
               }
             } else {
               const selectorInit = TheComponent.options.selectorInit;


### PR DESCRIPTION
Refs #330. Fixes non-first modals, which was not able to launch without this fix. Thanks @lee-chase for reporting!

#### Changelog

**Changed**

- Use `document` instead of element ref, to instantiate modals.