### PR TITLE
fix(ComponentExample): target date picker's floating menu inside the live demo container

### DIFF
--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -113,6 +113,20 @@ class ComponentExample extends Component {
           const TheComponent = components[name];
           if (TheComponent) {
             const options = {};
+            if (name === 'DatePicker') {
+              // Same as `this._liveContainerRef.current`, but that may not have been set up yet
+              const liveContainerRef = ref.closest('.component-example__live');
+              options.appendTo = liveContainerRef;
+              options.onPreCalendarPosition = (selectedDates, value, { _positionElement, calendarContainer }) => {
+                // Make it "post" positioning handler
+                Promise.resolve().then(() => {
+                  const { left: inputLeft, top: inputTop } = _positionElement.getBoundingClientRect();
+                  const { left: containerLeft, top: containerTop } = liveContainerRef.getBoundingClientRect();
+                  calendarContainer.style.left = `${inputLeft - containerLeft}px`;
+                  calendarContainer.style.top = `${inputTop - containerTop + _positionElement.offsetHeight}px`;
+                });
+              };
+            }
             if (name === 'OverflowMenu' || name === 'Tooltip') {
               ['objMenuOffset', 'objMenuOffsetFlip'].forEach(name => {
                 if (TheComponent.options[name]) {


### PR DESCRIPTION
Fixes #376.

#### Changelog

**New**

- A mechanism to target date picker's floating menu to the demo container (instead of `<body>`)