### PR TITLE
fix(ComponentExample): make shell UI contained in demo container

### DIFF
--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -275,7 +275,7 @@ class ComponentExample extends Component {
         .toUpperCase() + componentName.split(' ')[1].substring(1)}`;
     }
 
-    const liveBackgroundClasses = classnames('component-example__live', {
+    const liveBackgroundClasses = classnames('component-example__live', `component-example__live--${component}`, {
       'component-example__live--light':
         (currentFieldColor === 'field-01') & (hasLightVersion === 'true') ||
         hasLightBackground === 'true',

--- a/src/components/ComponentExample/component-overrides.scss
+++ b/src/components/ComponentExample/component-overrides.scss
@@ -207,6 +207,30 @@
   }
 }
 
+.component-example__live.component-example__live--ui-shell {
+  padding: 0;
+  height: 600px;
+}
+
+.component-example__live.component-example__live--ui-shell .component-example__live--rendered {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.component-example__live.component-example__live--ui-shell .component-example__live--rendered > div {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
+.component-example__live.component-example__live--ui-shell .component-example__live--rendered {
+  header, aside {
+    position: absolute;
+  }
+}
+
 .page-header + div > .bx--tabs {
   background-color: $field-01;
 


### PR DESCRIPTION
Fixes #418.

#### Changelog

**Changed**

- Made height of UI shell demo higher
- Made container `<div>`s of UI shell demo take 100% width/height of the top-level demo container
- Avoid using `position:fixed` for UI shell navs, as it makes positions become based on viewport rather than the demo container