### PR TITLE
fix(styles): scope experimental grid

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -39,8 +39,8 @@ class Footer extends Component {
     });
 
     return (
-      <footer className="page-footer">
-        <div className="bx--grid">
+      <footer className="page-footer carbon--grid-x">
+        <div className="carbon--grid-x--grid">
           <div className="bx--row">
             <nav className="page-footer__nav bx--col-lg-2 bx--offset-lg-4">
               <ul>

--- a/src/components/PageHeader/PageHeader.js
+++ b/src/components/PageHeader/PageHeader.js
@@ -14,8 +14,8 @@ const PageHeader = ({
     );
 
   return (
-    <div className="page-header">
-      <div className="bx--grid">
+    <div className="page-header carbon--grid-x">
+      <div className="carbon--grid-x--grid">
         <div class="bx--row">
           <div class="bx--col-lg-12 bx--offset-lg-4">
             {labelContent}

--- a/src/components/PageTabs/PageTabs.js
+++ b/src/components/PageTabs/PageTabs.js
@@ -25,8 +25,8 @@ export default class PageTabs extends React.Component {
       </li>
     ));
     return (
-      <div className="page-tabs">
-        <div className="bx--grid">
+      <div className="page-tabs carbon--grid-x">
+        <div className="carbon--grid-x--grid">
           <div class="bx--row">
             <div class="bx--col-lg-12 bx--offset-lg-4">
               <nav>

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -23,7 +23,7 @@ body {
   background: $ibm-colors__white;
 }
 
-.bx--grid {
+.bx--grid, .carbon--grid-x .carbon--grid-x--grid {
   margin: 0;
 }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -7,7 +7,13 @@ $feature-flags: (
   ui-shell: true,
 );
 //@import '@carbon/layout/scss/layout.scss';
-@import '@carbon/grid/scss/grid.scss';
+
+.carbon--grid-x {
+  $prefix: 'carbon--grid-x';
+  $imported-modules-local: ();
+  @import '@carbon/grid/scss/grid.scss';
+}
+
 //@import '@carbon/type/scss/type.scss';
 
 // There are temp files copied from carbon-elements

--- a/src/templates/page.js
+++ b/src/templates/page.js
@@ -89,7 +89,7 @@ export default ({ data, pageContent }) => {
   const { GATSBY_CARBON_ENV } = process.env;
   const isInternal = GATSBY_CARBON_ENV !== 'internal' && internal == true;
 
-  const classNames = classnames({
+  const classNames = classnames('carbon--grid-x', {
     'container--component': post.frontmatter.label === 'Components',
   });
 
@@ -111,7 +111,7 @@ export default ({ data, pageContent }) => {
               <PageTabs slug={slug} currentTab={currentPage} tabs={tabs} />
             )}
           </PageHeader>
-          <div className="page-content bx--grid">
+          <div className="page-content carbon--grid-x--grid">
             {renderAst(post.htmlAst)}
           </div>
         </div>


### PR DESCRIPTION
This PR is created as a communication tool to better understand what issue team had with stable/experimental grid style co-existence.

This change allows different parts of Carbon website to choose stable/experimental grid style:

* Stable grid can be used by keeping using `bx--grid`
* Experimental grid can be used by replacing `bx--grid` with `carbon--grid-x--grid` and putting `carbon--grid-x` to its container

What the ultimate solution should be (again, this PR should not necessarily be the one) would depend on the following:

* Whether my assumption wrt what issue team has, which presumably is `.bx--grid` overriden by experimental grid, is correct or not
* What portion in Carbon website should use experimental grid
* How temporary the co-existing would be, and how sophisticated solution would be desired for this requirement

#### Changelog

**New**

- Code to scope experimental grid.

**Changed**

- `<Footer>`, `<PageHeader>`, `<PageTabs>` as well as page content template. Not sure if those should use experimental grid or not, though.