### PR TITLE
feat(ComponentDocs): support experimental.md

### DIFF
--- a/src/components/ComponentDocs/ComponentDocs.js
+++ b/src/components/ComponentDocs/ComponentDocs.js
@@ -4,14 +4,22 @@ import PropTypes from 'prop-types';
 export default class ComponentDocs extends React.Component {
   static propTypes = {
     component: PropTypes.string,
+    experimental: PropTypes.string,
   };
 
   render() {
-    const { component } = this.props;
+    const { component, experimental } = this.props;
 
     let componentDocUrl = '';
+    if (experimental === 'true') {
+      try {
+        componentDocUrl = require(`carbon-components/src/components/${component}/experimental.md`);
+      } catch (err) {}
+    }
     // Loading README.md causes Storybook build failure as of now
-    componentDocUrl = require(`carbon-components/src/components/${component}/README.md`);
+    if (!componentDocUrl) {
+      componentDocUrl = require(`carbon-components/src/components/${component}/README.md`);
+    }
 
     return (
       <div className="page_md component-docs ibm--row">

--- a/src/content/experimental-components/accordion/code.md
+++ b/src/content/experimental-components/accordion/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="accordion"></component-docs>
+<component-docs component="accordion" experimental="true"></component-docs>

--- a/src/content/experimental-components/breadcrumb/code.md
+++ b/src/content/experimental-components/breadcrumb/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="breadcrumb"></component-docs>
+<component-docs component="breadcrumb" experimental="true"></component-docs>

--- a/src/content/experimental-components/button/code.md
+++ b/src/content/experimental-components/button/code.md
@@ -76,4 +76,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="button"></component-docs>
+<component-docs component="button" experimental="true"></component-docs>

--- a/src/content/experimental-components/checkbox/code.md
+++ b/src/content/experimental-components/checkbox/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="checkbox"></component-docs>
+<component-docs component="checkbox" experimental="true"></component-docs>

--- a/src/content/experimental-components/code-snippet/code.md
+++ b/src/content/experimental-components/code-snippet/code.md
@@ -29,4 +29,4 @@ variations:</page-intro>
     experimental="true"
     >
 </component>
-<component-docs component="code-snippet"></component-docs>
+<component-docs component="code-snippet" experimental="true"></component-docs>

--- a/src/content/experimental-components/content-switcher/code.md
+++ b/src/content/experimental-components/content-switcher/code.md
@@ -20,4 +20,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="content-switcher"></component-docs>
+<component-docs component="content-switcher" experimental="true"></component-docs>

--- a/src/content/experimental-components/date-picker/code.md
+++ b/src/content/experimental-components/date-picker/code.md
@@ -34,4 +34,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>-->
-<component-docs component="date-picker"></component-docs>
+<component-docs component="date-picker" experimental="true"></component-docs>

--- a/src/content/experimental-components/dropdown/code.md
+++ b/src/content/experimental-components/dropdown/code.md
@@ -23,4 +23,4 @@ variations:
     >
 </component>
 
-<component-docs component="dropdown"></component-docs>
+<component-docs component="dropdown" experimental="true"></component-docs>

--- a/src/content/experimental-components/file-uploader/code.md
+++ b/src/content/experimental-components/file-uploader/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="file-uploader"></component-docs>
+<component-docs component="file-uploader" experimental="true"></component-docs>

--- a/src/content/experimental-components/inline-loading/code.md
+++ b/src/content/experimental-components/inline-loading/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="inline-loading"></component-docs>
+<component-docs component="inline-loading" experimental="true"></component-docs>

--- a/src/content/experimental-components/list/code.md
+++ b/src/content/experimental-components/list/code.md
@@ -21,4 +21,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="list"></component-docs>
+<component-docs component="list" experimental="true"></component-docs>

--- a/src/content/experimental-components/loading/code.md
+++ b/src/content/experimental-components/loading/code.md
@@ -20,4 +20,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="loading"></component-docs>
+<component-docs component="loading" experimental="true"></component-docs>

--- a/src/content/experimental-components/notification/code.md
+++ b/src/content/experimental-components/notification/code.md
@@ -20,4 +20,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="notification"></component-docs>
+<component-docs component="notification" experimental="true"></component-docs>

--- a/src/content/experimental-components/number-input/code.md
+++ b/src/content/experimental-components/number-input/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="number-input"></component-docs>
+<component-docs component="number-input" experimental="true"></component-docs>

--- a/src/content/experimental-components/overflow-menu/code.md
+++ b/src/content/experimental-components/overflow-menu/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="overflow-menu"></component-docs>
+<component-docs component="overflow-menu" experimental="true"></component-docs>

--- a/src/content/experimental-components/progress-indicator/code.md
+++ b/src/content/experimental-components/progress-indicator/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="progress-indicator"></component-docs>
+<component-docs component="progress-indicator" experimental="true"></component-docs>

--- a/src/content/experimental-components/radio-button/code.md
+++ b/src/content/experimental-components/radio-button/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="radio-button"></component-docs>
+<component-docs component="radio-button" experimental="true"></component-docs>

--- a/src/content/experimental-components/select/code.md
+++ b/src/content/experimental-components/select/code.md
@@ -37,4 +37,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="select"></component-docs>
+<component-docs component="select" experimental="true"></component-docs>

--- a/src/content/experimental-components/slider/code.md
+++ b/src/content/experimental-components/slider/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="slider"></component-docs>
+<component-docs component="slider" experimental="true"></component-docs>

--- a/src/content/experimental-components/structured-list/code.md
+++ b/src/content/experimental-components/structured-list/code.md
@@ -20,4 +20,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="structured-list"></component-docs>
+<component-docs component="structured-list" experimental="true"></component-docs>

--- a/src/content/experimental-components/tabs/code.md
+++ b/src/content/experimental-components/tabs/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="tabs"></component-docs>
+<component-docs component="tabs" experimental="true"></component-docs>

--- a/src/content/experimental-components/tag/code.md
+++ b/src/content/experimental-components/tag/code.md
@@ -13,4 +13,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="tag"></component-docs>
+<component-docs component="tag" experimental="true"></component-docs>

--- a/src/content/experimental-components/text-input/code.md
+++ b/src/content/experimental-components/text-input/code.md
@@ -22,4 +22,4 @@ tabs: ['Code', 'Usage']
     >
 </component>
 
-<component-docs component="text-input"></component-docs>
+<component-docs component="text-input" experimental="true"></component-docs>

--- a/src/content/experimental-components/tile/code.md
+++ b/src/content/experimental-components/tile/code.md
@@ -34,4 +34,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="tile"></component-docs>
+<component-docs component="tile" experimental="true"></component-docs>

--- a/src/content/experimental-components/toggle/code.md
+++ b/src/content/experimental-components/toggle/code.md
@@ -20,4 +20,4 @@ tabs: ['Code', 'Usage']
     experimental="true"
     >
 </component>
-<component-docs component="toggle"></component-docs>
+<component-docs component="toggle" experimental="true"></component-docs>

--- a/src/content/experimental-components/tooltip/code.md
+++ b/src/content/experimental-components/tooltip/code.md
@@ -28,4 +28,4 @@ tabs: ['Code', 'Usage']
     >
 </component>
 
-<component-docs component="tooltip"></component-docs>
+<component-docs component="tooltip" experimental="true"></component-docs>


### PR DESCRIPTION
Fixes #519.

#### Changelog

**New**

- `experimental` prop support in `<ComponentDocs>`, which attempts to bring in `experimental.md` if it exists