### PR TITLE
chore(build): build dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
   },
   "scripts": {
     "build": "echo 'ERROR: Please specify environment by running either build:external or build:internal. This will set the correct environment variable for the build.'",
-    "build:external": "rm -rf public && ./tasks/build.sh --env external",
-    "build:internal": "rm -rf public && ./tasks/build.sh --env internal",
+    "build:packages": "lerna run build --stream --prefix --npm-client yarn",
+    "build:external": "rm -rf public && yarn build:packages && ./tasks/build.sh --env external",
+    "build:internal": "rm -rf public && yarn build:packages && ./tasks/build.sh --env internal",
     "clean": "lerna clean --yes && rm -rf build && rm -rf node_modules",
     "dev": "yarn dev:external",
     "dev:external": "rm -rf .cache && cross-env GATSBY_CARBON_ENV=external gatsby develop",


### PR DESCRIPTION
My brief look at test failure in https://github.com/carbon-design-system/carbon-website/pull/614 told me that `@carbon/addons-website` sub-package wasn't built before Gatsby build runs, causing an error complaining a missing dependency. This PR attempts to fix that problem.

#### Changelog

**New**

- `build:packages` Yarn script to build sub-packages.

**Changed**

- `build:external`/`build:internal` to run above Yarn script beforehand.