### PR TITLE
fix: image captions

### DIFF
--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -115,6 +115,7 @@ button,
 //images 
 .gatsby-resp-image-wrapper {
   background: $ui-02;
+  margin-left: 0!important;
 
   @include breakpoint('lg') {
     margin-left: calc(25% + .5rem)!important;
@@ -122,7 +123,7 @@ button,
 }
 
 .ibm--row .gatsby-resp-image-wrapper { 
-  margin-left: auto!important;
+  margin-left: 0!important;
 }
 
 // All em on Markdown pages after images and image grid
@@ -131,7 +132,16 @@ button,
   @include type-style('body-short-01');
   font-style: normal;
   padding-top: $spacing-xs;
-  color: $text-02;
+  color: $text-01;
+  display: block;
+
+  @include breakpoint('lg') {
+    padding-right: 35%;
+  }
+
+  @include breakpoint('lg') {
+    padding-right: 44%;
+  }
 }
 
 //svg images


### PR DESCRIPTION
cc @jeanservaas 
https://github.com/carbon-design-system/carbon-website/issues/683

updates the image caption styling

FYI markdown to add a caption to an image, followed by a line break, followed by italic text.

```
![Structure and spacing measurements for a Definition Tooltip](images/tooltip-style-3.png)

_Structure and spacing measurements for a Definition Tooltip | px / rem_
```