### PR TITLE
increase sidenav z-index to be above Tabs component

### DIFF
--- a/packages/addons-website/scss/components/_website-side-nav.scss
+++ b/packages/addons-website/scss/components/_website-side-nav.scss
@@ -8,6 +8,10 @@
   }
 }
 
+.#{$prefix}--side-nav--website {
+  z-index: 16000;
+}
+
 .#{$prefix}--side-nav--website--with-header-nav.#{$prefix}--side-nav.#{$prefix}--side-nav--open {
   width: 16rem;
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/743

the `Tabs` component has a fairly high z-index, so i increase the `SideNav` z-index value.

this works as a good standalone fix. maybe also possible to update the carbon-components [_layout.scss](https://github.com/IBM/carbon-components/blob/master/src/globals/scss/_layout.scss) so this won't be an issue for anyone using carbon? idk if that would be a good fix, but we can at least fix the carbon site with this PR for now :)