### PR TITLE
fix(website-addons): Header, switcher, nav css updates

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/addons-website/package.json
+++ b/packages/addons-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/addons-website",
-  "version": "0.0.1-alpha.4",
+  "version": "0.0.1-alpha.5",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/addons-website/package.json
+++ b/packages/addons-website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/addons-website",
-  "version": "0.0.1-alpha.3",
+  "version": "0.0.1-alpha.4",
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/addons-website/scss/components/_website-header.scss
+++ b/packages/addons-website/scss/components/_website-header.scss
@@ -1,9 +1,5 @@
 @import '../prefix';
 
-.container {
-  padding-top: 0 !important;
-}
-
 .#{$prefix}--header--website {
   z-index: 9999;
   background-color: $ui-05;
@@ -31,7 +27,7 @@ a.#{$prefix}--header__name {
   @include type-style('heading-02');
 }
 
-.#{$prefix}--header__action--memu {
+.#{$prefix}--header__action--menu {
   border-width: 2px;
   display: block;
 

--- a/packages/addons-website/scss/components/_website-switcher.scss
+++ b/packages/addons-website/scss/components/_website-switcher.scss
@@ -7,6 +7,7 @@
 .#{$prefix}--website-switcher {
   position: fixed;
   right: 0;
+  top: 0;
   width: rem(256px);
   background-color: $ibm-colors__gray--100;
   height: 100%;
@@ -17,6 +18,11 @@
   transition: transform 0.11s cubic-bezier(0.2, 0, 1, 0.9);
   overflow-y: auto;
   overflow-x: hidden;
+  border-left: 1px solid $ibm-colors__gray--80;
+}
+
+.#{$prefix}--header ~ .#{$prefix}--website-switcher {
+  top: 3rem;
 }
 
 .#{$prefix}--website-switcher--expanded {
@@ -24,25 +30,24 @@
 }
 
 .#{$prefix}--website-switcher-list__item:nth-child(1) {
-    position: relative;
-    margin-top: $spacing-md;
-    margin-bottom: $spacing-xs;
-  
-    &::after {
-      content: '';
-      display: block;
-      position: absolute;
-      bottom: rem(-9px);
-      width: rem(222px);
-      margin-left: $spacing-md;
-      border-top: 1px solid $ibm-colors__gray--80;
-    }
+  position: relative;
+  margin-top: $spacing-md;
+  margin-bottom: $spacing-xs;
+
+  &::after {
+    content: '';
+    display: block;
+    position: absolute;
+    bottom: rem(-9px);
+    width: rem(222px);
+    margin-left: $spacing-md;
+    border-top: 1px solid $ibm-colors__gray--80;
   }
+}
 
 .#{$prefix}--website-switcher-list__item:nth-child(2) {
   padding-top: rem(9px);
 }
-
 
 .#{$prefix}--website-switcher-list__item-link {
   @include type-style('heading-01');

--- a/packages/addons-website/src/components/WebsiteHeader/WebsiteHeader-story.js
+++ b/packages/addons-website/src/components/WebsiteHeader/WebsiteHeader-story.js
@@ -18,7 +18,7 @@ import {
   HeaderGlobalBar,
   HeaderGlobalAction,
 } from 'carbon-components-react/lib/components/UIShell';
-import { Close20 } from '@carbon/icons-react';
+import { Close20, AppSwitcher20 } from '@carbon/icons-react';
 import WebsiteSwitcher from '../WebsiteSwitcher/WebsiteSwitcher';
 
 storiesOf('Website Header', module)
@@ -26,9 +26,10 @@ storiesOf('Website Header', module)
     'Website Header',
     () => (
       <>
-        <Header className="bx--header--website">
+        <Header aria-label="Header" className="bx--header--website">
           <SkipToContent />
           <HeaderMenuButton
+            className="bx--header__action--menu"
             aria-label="Open menu"
             onClick={action('Menu clicked')}
           />
@@ -39,21 +40,11 @@ storiesOf('Website Header', module)
           <HeaderGlobalBar>
             <HeaderGlobalAction
               className="bx--header__action--switcher"
-              aria-label="Switch"
-            >
-              <Close20 />
+              aria-label="Switch">
+              <AppSwitcher20 />
             </HeaderGlobalAction>
           </HeaderGlobalBar>
         </Header>
-
-        <WebsiteSwitcher
-          isSwitcherOpen
-          links={[
-            { href: 'https://www.ibm.com/design/language/', linkText: 'IBM Design Language' },
-            { href: 'https://www.ibm.com/standards/web/', linkText: 'IBM Digital Design' },
-            { href: 'https://www.ibm.com/design/', linkText: 'IBM Design' }
-          ]}>
-        </WebsiteSwitcher>
       </>
     ),
     {
@@ -66,9 +57,10 @@ storiesOf('Website Header', module)
     'Website Header with Nav',
     () => (
       <>
-        <Header className="bx--header--website">
+        <Header aria-label="Header" className="bx--header--website">
           <SkipToContent />
           <HeaderMenuButton
+            className="bx--header__action--menu"
             aria-label="Open menu"
             onClick={action('Menu clicked')}
           />
@@ -87,12 +79,13 @@ storiesOf('Website Header', module)
             <HeaderMenuItem href="#">Docs</HeaderMenuItem>
             <HeaderMenuItem href="#">Support</HeaderMenuItem>
           </HeaderNavigation>
-          <HeaderGlobalAction
+          <HeaderGlobalBar>
+            <HeaderGlobalAction
               className="bx--header__action--switcher"
-              aria-label="Switch"
-            >
-              <Close20 />
-          </HeaderGlobalAction>
+              aria-label="Switch">
+              <AppSwitcher20 />
+            </HeaderGlobalAction>
+          </HeaderGlobalBar>
         </Header>
         <SideNav
           aria-label="Side navigation"
@@ -112,20 +105,56 @@ storiesOf('Website Header', module)
             <SideNavLink href="#">Support</SideNavLink>
           </SideNavItems>
         </SideNav>
-
-        <WebsiteSwitcher
-          isSwitcherOpen
-          links={[
-            { href: 'https://www.ibm.com/design/language/', linkText: 'IBM Design Language' },
-            { href: 'https://www.ibm.com/standards/web/', linkText: 'IBM Digital Design' },
-            { href: 'https://www.ibm.com/design/', linkText: 'IBM Design' }
-          ]}>
-        </WebsiteSwitcher>
       </>
     ),
     {
       info: {
         text: 'Website Header with nav',
+      },
+    }
+  )
+  .add(
+    'Website Header with Switcher',
+    () => (
+      <>
+        <Header aria-label="Header" className="bx--header--website">
+          <SkipToContent />
+          <HeaderMenuButton
+            className="bx--header__action--menu"
+            aria-label="Open menu"
+            onClick={action('Menu clicked')}
+          />
+          <HeaderName href="#" prefix="IBM">
+            Website
+          </HeaderName>
+          <HeaderGlobalBar>
+            <HeaderGlobalAction
+              className="bx--header__action--switcher"
+              aria-label="Switch">
+              <AppSwitcher20 />
+            </HeaderGlobalAction>
+          </HeaderGlobalBar>
+        </Header>
+
+        <WebsiteSwitcher
+          isSwitcherOpen
+          links={[
+            {
+              href: 'https://www.ibm.com/design/language/',
+              linkText: 'IBM Design Language',
+            },
+            {
+              href: 'https://www.ibm.com/standards/web/',
+              linkText: 'IBM Digital Design',
+            },
+            { href: 'https://www.ibm.com/design/', linkText: 'IBM Design' },
+          ]}
+        />
+      </>
+    ),
+    {
+      info: {
+        text: 'Website Header with Switcher',
       },
     }
   );

--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -30,14 +30,19 @@ class Layout extends React.Component {
     isLeftNavOpen: false,
     isLeftNavFinal: false,
     isSwitcherOpen: false,
-    isSwitcherFinal: false
+    isSwitcherFinal: false,
   };
 
   componentDidMount() {
     this.checkWidth();
   }
 
-  onToggleBtnClick = (clickedPanel, finalClickedPanel, closePanel, finalClosePanel) => {
+  onToggleBtnClick = (
+    clickedPanel,
+    finalClickedPanel,
+    closePanel,
+    finalClosePanel
+  ) => {
     if (this.state[clickedPanel]) {
       this.setState({
         [clickedPanel]: false,
@@ -59,7 +64,6 @@ class Layout extends React.Component {
         });
       }, 5);
     }
-
   };
 
   handleClose = evt => {
@@ -161,12 +165,19 @@ class Layout extends React.Component {
               ]}>
               <html lang="en" />
             </Helmet>
-            <Header aria-label="Header">
+            <Header aria-label="Header" className="bx--header--website">
               <SkipToContent />
               <HeaderMenuButton
                 className="bx--header__action--menu"
                 aria-label="Open menu"
-                onClick={() => this.onToggleBtnClick('isLeftNavOpen', 'isLeftNavFinal', 'isSwitcherOpen', 'isSwitcherFinal')}
+                onClick={() =>
+                  this.onToggleBtnClick(
+                    'isLeftNavOpen',
+                    'isLeftNavFinal',
+                    'isSwitcherOpen',
+                    'isSwitcherFinal'
+                  )
+                }
                 isActive={isOpen}
               />
               {isInternal ? (
@@ -184,21 +195,32 @@ class Layout extends React.Component {
                 <HeaderGlobalAction
                   className="bx--header__action--switcher"
                   aria-label="Switch"
-                  onClick={() => this.onToggleBtnClick('isSwitcherOpen', 'isSwitcherFinal', 'isLeftNavOpen', 'isLeftNavFinal')}
-                >
+                  onClick={() =>
+                    this.onToggleBtnClick(
+                      'isSwitcherOpen',
+                      'isSwitcherFinal',
+                      'isLeftNavOpen',
+                      'isLeftNavFinal'
+                    )
+                  }>
                   {this.state.isSwitcherOpen ? <Close20 /> : <AppSwitcher20 />}
                 </HeaderGlobalAction>
               </HeaderGlobalBar>
-              
             </Header>
 
             <WebsiteSwitcher
               isSwitcherFinal={this.state.isSwitcherFinal}
               isSwitcherOpen={this.state.isSwitcherOpen}
               links={[
-                { href: 'https://www.ibm.com/design/language/', linkText: 'IBM Design Language' },
-                { href: 'https://www.ibm.com/standards/web/', linkText: 'IBM Digital Design' },
-                { href: 'https://www.ibm.com/design/', linkText: 'IBM Design' }
+                {
+                  href: 'https://www.ibm.com/design/language/',
+                  linkText: 'IBM Design Language',
+                },
+                {
+                  href: 'https://www.ibm.com/standards/web/',
+                  linkText: 'IBM Digital Design',
+                },
+                { href: 'https://www.ibm.com/design/', linkText: 'IBM Design' },
               ]}
             />
 


### PR DESCRIPTION
Noticed a couple stylinng issue when trying to ad switcher to the ibm/design website.

- Added header-website class to header so correct background color is applied to header
- Added left border (gray80) to switcher
- Fixed typo in class name
- Updated website storybook examples

## testing
check header, switcher and nav in storybook and in website and make sure styles are correct