### PR TITLE
fix(spacing): Adjusted spacing across the website

### DIFF
--- a/src/components/ClickableTile/clickable-tile.scss
+++ b/src/components/ClickableTile/clickable-tile.scss
@@ -98,6 +98,8 @@ p.tile__author {
 // Tile Resource
 
 .tile--resource {
+  margin-bottom: rem(24px);
+
   // full bleed for tiles on mobile
   @include breakpoint('sm') {
     width: 100%;
@@ -106,6 +108,7 @@ p.tile__author {
   @include breakpoint('md') {
     width: calc(50% - 1px);
     margin: 0;
+    margin-bottom: rem(24px);
   }
 }
 

--- a/src/components/ColorTokenTable/color-token-table.scss
+++ b/src/components/ColorTokenTable/color-token-table.scss
@@ -6,7 +6,7 @@
 .color-token-table__theme-switcher {
   width: 100%;
   height: rem(48px);
-  margin-bottom: $spacing-xl;
+  margin-bottom: 1.75rem;
   background: $ui-02;
 }
 

--- a/src/components/ComponentExample/component-example.scss
+++ b/src/components/ComponentExample/component-example.scss
@@ -3,7 +3,7 @@
   max-width: 100%;
   display: block;
   color: $ibm-colors__white;
-  margin-bottom: 6rem;
+  margin-bottom: rem(24px);
 
   p {
     margin: 0;
@@ -19,7 +19,7 @@
   min-height: rem(200px);
   position: relative;
   padding: 2rem 2rem 2.5rem;
-  margin: 1.5rem 0 0;
+  margin: 0;
   background-color: $ui-02;
   color: $text-01;
   border: 1rem solid $ui-02;

--- a/src/components/DoDontExample/do-dont-example.scss
+++ b/src/components/DoDontExample/do-dont-example.scss
@@ -9,8 +9,6 @@
 
 // Example
 .example {
-  margin-bottom: rem(36px);
-
   @include breakpoint('sm') {
     width: 100%;
   }
@@ -128,6 +126,7 @@ p.example__description {
   @include font-smoothing;
   margin: 0;
   padding: 0;
+  padding-bottom: rem(24px);
 }
 
 .example.example--full-width {

--- a/src/components/DoDontExample/do-dont-example.scss
+++ b/src/components/DoDontExample/do-dont-example.scss
@@ -9,6 +9,8 @@
 
 // Example
 .example {
+  margin-bottom: rem(24px);
+
   @include breakpoint('sm') {
     width: 100%;
   }
@@ -118,7 +120,7 @@ p.example__text {
 .example__title {
   @include type-style('body-short-01');
   margin: 0;
-  padding: 0;
+  padding: 0 !important;
 }
 
 p.example__description {

--- a/src/components/DoDontExample/do-dont-example.scss
+++ b/src/components/DoDontExample/do-dont-example.scss
@@ -117,10 +117,10 @@ p.example__text {
   padding: 8px 0 0 0;
 }
 
-.example__title {
+p.example__title {
   @include type-style('body-short-01');
   margin: 0;
-  padding: 0 !important;
+  padding: 0;
 }
 
 p.example__description {

--- a/src/components/GlossaryList/glossary-list.scss
+++ b/src/components/GlossaryList/glossary-list.scss
@@ -13,7 +13,7 @@
 
   h2 {
     margin-top: 4rem !important;
-    padding-bottom: 2rem !important;
+    padding-bottom: 0 !important;
   }
 
   .glossary-entry__desc {
@@ -22,10 +22,14 @@
 
   .glossary-entry__word {
     padding-bottom: 1.5rem;
+
+    &:last-of-type {
+      padding-bottom: 0;
+    }
   }
 
   .glossary-entry__word-heading {
-    padding-top: 1rem;
+    padding-top: rem(24px);
     padding-bottom: 0.5rem;
     @include type-style('heading-03');
   }
@@ -34,10 +38,11 @@
     @include type-style('body-short-02');
     color: $text-02;
     margin-top: 0.25rem;
+    padding-bottom: 0;
   }
 
   .glossary-entry__list {
-    margin-bottom: 5rem;
+    margin-bottom: 3rem;
   }
 }
 

--- a/src/components/IconCard/icon-card.scss
+++ b/src/components/IconCard/icon-card.scss
@@ -2,10 +2,11 @@
   display: flex;
   flex-flow: row wrap;
   width: 100%;
+  padding-bottom: rem(24px);
 }
 
 .icon-search {
-  margin-bottom: rem(48px);
+  margin-bottom: rem(32px);
 }
 
 .icon {

--- a/src/components/IconLibrary/IconLibrary.js
+++ b/src/components/IconLibrary/IconLibrary.js
@@ -109,7 +109,7 @@ export default class IconLibrary extends React.Component {
         small
         className="icon-search"
         onChange={this.handleOnChange}
-        placeHolderText="Search by descriptors like “edit, pencil, or draw"
+        placeHolderText="Search by descriptors like “edit, pencil, or draw”"
         aria-label="Icon library search"
         value={this.state.searchValue}
         labelText="Icon library search"

--- a/src/components/PageTable/page-table.scss
+++ b/src/components/PageTable/page-table.scss
@@ -74,6 +74,7 @@
  {
   width: calc(100% + 2rem);
   margin-left: -1rem;
+<<<<<<< HEAD
 
   @include breakpoint('md') {
     max-width: 75%;
@@ -82,4 +83,7 @@
   @include breakpoint('lg') {
     max-width: 50%;
   }
+=======
+  margin-top: rem(16px);
+>>>>>>> fix(spacing): finished up spacing work
 }

--- a/src/components/PageTable/page-table.scss
+++ b/src/components/PageTable/page-table.scss
@@ -70,11 +70,10 @@
   }
 }
 
-.component-docs table,
- {
+.component-docs table {
   width: calc(100% + 2rem);
   margin-left: -1rem;
-<<<<<<< HEAD
+  margin-top: rem(16px);
 
   @include breakpoint('md') {
     max-width: 75%;
@@ -83,7 +82,4 @@
   @include breakpoint('lg') {
     max-width: 50%;
   }
-=======
-  margin-top: rem(16px);
->>>>>>> fix(spacing): finished up spacing work
 }

--- a/src/components/TypeWeight/type-weight.scss
+++ b/src/components/TypeWeight/type-weight.scss
@@ -1,6 +1,7 @@
 .type-weight {
   background: $ibm-colors__white;
   padding: $spacing-md;
+  margin-bottom: rem(24px);
 
   p {
     font-size: rem(48px);

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -33,7 +33,7 @@
   //@include type-style('expressive-heading-04', true);
   position: relative;
   color: $text-01;
-  margin-top: rem(56px);
+  margin-top: rem(48px);
   margin-bottom: $spacing-lg;
   position: relative;
 }
@@ -60,7 +60,7 @@
   @include type-style('heading-02');
   color: $text-01;
   margin-top: rem(8px);
-  margin-bottom: rem(16px);
+  margin-bottom: 0;
   position: relative;
 }
 
@@ -122,6 +122,14 @@
   }
 }
 
+.page-h2:before {
+  padding-bottom: rem(56px);
+}
+
+.page-h4:before {
+  margin-top: -2rem;
+}
+
 //----------------------------
 // ul / ol
 //----------------------------
@@ -146,10 +154,24 @@
   }
 }
 
+.page-ul > li span,
+.page-ol > li span {
+  margin-top: 1rem;
+}
+
 .page-ol > li {
   font-weight: 400;
   padding-left: 0.25rem;
   list-style-type: decimal;
+}
+
+.page-ol > li:last-child p {
+  padding-bottom: 0;
+}
+
+.page-ul .page-ul {
+  margin-top: -1.25rem;
+  margin-bottom: 0;
 }
 
 // The following is a css hack because remark is nesting

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -157,20 +157,20 @@
 .page-ul,
 .page-ol {
   @include typescale('epsilon');
-  margin: 0 0 $spacing-lg $spacing-lg;
-  line-height: 1.75;
+  margin: rem(24px) 0 $spacing-lg $spacing-lg;
+  line-height: 1.5;
   position: relative;
 }
 
 .page-ul > li {
   font-weight: 400;
-  padding-left: 0.25rem;
+  padding-left: 0;
   list-style-type: none;
 
   &:before {
     content: '\2013';
     position: absolute;
-    left: -1rem;
+    left: -1.4rem;
   }
 }
 

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -63,6 +63,9 @@
   margin-top: 1.125rem;
 }
 
+.page-h3#what’s-included {
+  margin-bottom: rem(24px);
+}
 //----------------------------
 // h4
 //----------------------------
@@ -157,7 +160,7 @@
 .page-ul,
 .page-ol {
   @include typescale('epsilon');
-  margin: rem(24px) 0 $spacing-lg $spacing-lg;
+  margin: 0 0 rem(24px) $spacing-lg;
   line-height: 1.5;
   position: relative;
 }

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -38,6 +38,10 @@
   position: relative;
 }
 
+.page-h2#articles:before {
+  padding-bottom: rem(80px);
+}
+
 //----------------------------
 // h3
 //----------------------------
@@ -49,6 +53,14 @@
   margin-top: rem(24px);
   margin-bottom: $spacing-md;
   position: relative;
+}
+
+.component-docs h3 {
+  margin-top: rem(48px);
+}
+
+.page-h3#sizing {
+  margin-top: 1.125rem;
 }
 
 //----------------------------
@@ -64,6 +76,10 @@
   position: relative;
 }
 
+.component-docs h4 {
+  margin-top: rem(48px);
+}
+
 // Targets heading elements when they are the first element on a page to remove top margin
 .page-content > div > .ibm--row:first-child {
   .page-h4,
@@ -73,6 +89,10 @@
   .page-h2,
   .component-docs h2 {
     margin-top: 0;
+  }
+
+  .page-h2:before {
+    padding-bottom: 3rem;
   }
 }
 
@@ -208,6 +228,10 @@
   margin-top: 0;
 }
 
+.page-content > div:first-child > .anchor-links:first-child .page-ul {
+  margin-bottom: 0;
+}
+
 .anchor-links {
   .page-ul {
     width: auto;
@@ -246,7 +270,8 @@
 
       &:before {
         content: '\21B3'; //"↳"
-        font-family: 'IBM Plex Sans', 'ibm-plex-sans', 'Helvetica Neue', Arial, sans-serif;
+        font-family: 'IBM Plex Sans', 'ibm-plex-sans', 'Helvetica Neue', Arial,
+          sans-serif;
         color: $ibm-colors__gray-90;
         transition: color $transition--base;
         padding-right: rem(16px);
@@ -257,7 +282,7 @@
 }
 
 .anchor-links--small .page-ul {
-  margin-top: 2.25rem;
+  margin-top: rem(56px);
 }
 
 .anchor-links--small a,
@@ -322,4 +347,20 @@ iframe.embedVideoIframe {
 //----------------------------
 hr {
   display: none;
+}
+
+//----------------------------
+// Tiles
+//----------------------------
+
+.page-content > div > .tile--resource {
+  margin-bottom: 0;
+}
+
+//----------------------------
+// Table
+//----------------------------
+
+.component-docs p + table {
+  margin-top: 0;
 }

--- a/src/content/contributing/designers/designers.md
+++ b/src/content/contributing/designers/designers.md
@@ -16,11 +16,11 @@ Carbon has three different levels of contribution. Click on the contribution lev
 
 If you are not sure which model your contribution fits into, open an issue in one our repos and we will figure out which model it falls into.
 
-**Not sure where to open an issue?**
+#### Not sure where to open an issue?
 
 All contribution proposals should be opened in the [carbon-contribution repo](https://github.com/carbon-design-system/carbon-contribution). This includes light, medium, and heavy contributions (all components, icons, guideline updates, etc.).
 
-**Not sure how to submit an issue?**
+#### Not sure how to submit an issue?
 
 It's not so bad, we promise! You can read a [tutorial](https://help.github.com/articles/creating-an-issue/) on GitHub to get familiar with best practices.
 

--- a/src/content/experimental/ui-shell/code.md
+++ b/src/content/experimental/ui-shell/code.md
@@ -3,8 +3,6 @@ title: UI Shell
 tabs: ['Code', 'Usage']
 ---
 
-<hr/>
-
 <component 
     name="Experimental UI Shell"
     component="ui-shell"

--- a/src/content/getting-started/developers/angular.md
+++ b/src/content/getting-started/developers/angular.md
@@ -29,10 +29,6 @@ $ npm start
 
 **Note:** This isn't the only way to bootstrap a `carbon-components-angular` application, but the combination of `@angular/cli` and the `carbon-components` scss is our recommended setup.
 
-<a target="_blank" href="https://codesandbox.io/s/0129r494ql">
-  <img style="width: 200px" alt="Edit on CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
-</a>
-
 ### Using our starter app
 
 <img style="width: 100%" alt="carbon-angular-starter screenshot" src="images/carbon-angular-starter.png" />

--- a/src/content/getting-started/developers/other-frameworks.md
+++ b/src/content/getting-started/developers/other-frameworks.md
@@ -7,11 +7,11 @@ The Carbon Design System supports vanilla JS, React and Angular as core parts of
 
 ## Development options
 
-**Using just the styles**
+#### Using just the styles
 
 Developers wanting to build in different ways follow the instructions for the [Vanilla](/getting-started/developers/vanilla) library to access the styles and build out their own components.
 
-**Wrapping a component with a JavaScript framework of your choice**
+#### Wrapping a component with a JavaScript framework of your choice
 
 Many JavaScript frameworks have a mechanism to dynamically create/destroy DOM elements, for example, upon change in array.
 This often makes it unclear when the DOM element to instantiate a Carbon component is available, which often depends on the JavaScript framework you use.

--- a/src/content/getting-started/developers/react.md
+++ b/src/content/getting-started/developers/react.md
@@ -29,10 +29,6 @@ $ yarn add carbon-components-react carbon-components carbon-icons
 
 If you just want to try out `carbon-components-react`, you can also use [CodeSandbox](https://codesandbox.io).
 
-<a target="_blank" href="https://codesandbox.io/s/x2mjypo6pp">
-  <img style="width: 200px" alt="Edit on CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg" />
-</a>
-
 ## Development
 
 Please refer to the [Contribution Guidelines](https://github.com/carbon-design-system/carbon-components-react/blob/master/.github/CONTRIBUTING.md) before starting any work.

--- a/src/content/guidelines/content/guidance.md
+++ b/src/content/guidelines/content/guidance.md
@@ -17,7 +17,7 @@ For specific capitalization rules for different element or component types, see 
 Use sentence-style capitalization in text and for all text elements in the UI, except for table/grid column headers, headings for groups of toggles, and product names. Sentence style capitalizes only the first word of each sentence and proper nouns
 (such as names).
 
-**Examples:**
+#### Examples:
 
 - Cloud Foundry apps
 - Business models
@@ -28,7 +28,7 @@ Use sentence-style capitalization in text and for all text elements in the UI, e
 
 Only use headline-style capitalization for table/grid column headers and product names. Headline style capitalizes words based on parts of speech.
 
-**Capitalize the initial letter of the following words:**
+#### Capitalize the initial letter of the following words:
 
 - All nouns, pronouns, adjectives, verbs, adverbs, and subordinating conjunctions such as:
   - After
@@ -46,7 +46,7 @@ Only use headline-style capitalization for table/grid column headers and product
   - Whether
   - While
 
-**Do not capitalize the initial letter of the following words:**
+#### Do not capitalize the initial letter of the following words:
 
 - articles, except as the first word
 - coordinating conjunctions

--- a/src/content/guidelines/iconography/usage.md
+++ b/src/content/guidelines/iconography/usage.md
@@ -61,7 +61,7 @@ When used next to text, icons should be center-aligned.
 
 ### Using SVG sprite (recommended)
 
-**Requirements:**
+#### Requirements:
 
 - Install `carbon-icons`
 

--- a/src/content/patterns/common-actions/common-actions.md
+++ b/src/content/patterns/common-actions/common-actions.md
@@ -29,7 +29,6 @@ title: Common Actions
 **Usage:** Use a _secondary button_ or a _link_.
 
 ![Example of cancel in a modal](images/common-action-1.svg)
-
 _"Cancel" action as a button._
 
 ### Clear

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -55,6 +55,18 @@ body {
     }
   }
 
+  > div > div:first-child p {
+    padding-bottom: 0;
+  }
+
+  > div > div:nth-child(2) h2:before {
+    padding-bottom: rem(80px);
+  }
+
+  > div > div:nth-child(2) h3 {
+    margin-top: rem(48px);
+  }
+
   // All links on Markdown pages but not inside component examples
   & > div > * > a,
   .page-table td a,
@@ -85,6 +97,14 @@ body {
     background: $ui-03;
     border: 0px transparent;
   }
+
+  img {
+    margin-bottom: rem(24px);
+  }
+
+  img + img {
+    margin-bottom: 0;
+  }
 }
 
 .bx--platform-header {
@@ -106,7 +126,7 @@ body {
 .gatsby-resp-image-wrapper {
   background: $ui-02;
   margin-left: 0 !important;
-  margin-bottom: 4rem;
+  margin-bottom: rem(24px);
 
   @include breakpoint('lg') {
     margin-left: calc(25% + 0.5rem) !important;
@@ -118,7 +138,7 @@ body {
 .page-content > div > img[src*='svg'],
 .page-content > div > img[src*='gif'] {
   background: $ui-02;
-  margin-bottom: 4rem;
+  // margin-bottom: 4rem;
 
   @include breakpoint('lg') {
     margin-left: calc(25% + 0.5rem) !important;
@@ -154,7 +174,11 @@ img[src*='gif'] {
 
     &:first-child {
       padding-top: $spacing-xs;
-      margin-top: -4rem; //needed because of default image spacing
+      // margin-top: -4rem; //needed because of default image spacing
     }
   }
+}
+
+.page-content iframe {
+  margin-bottom: rem(24px);
 }

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -39,8 +39,8 @@ body {
 // Page styles
 //---------------------------------------
 .page-content {
-  padding-top: rem(64px);
-  padding-bottom: rem(64px);
+  padding-top: rem(80px);
+  padding-bottom: rem(104px);
 
   // All paragraphs on Markdown pages
   // And divs when markdown doesn't wrap text in paragraphs (when you have to use html for links to open in a new window)


### PR DESCRIPTION
Closes #739 

Did my best attempt to adjust spacing across the website. Unfortunately, this is easier said than done because of the grid and therefore not being able to target certain elements/patterns (for example when an image comes after an H2 etc). 

**A couple of things:**

- I did not do any spacing adjustments on images and captions as this will be addressed with the new image component.
- Was unable to adjust the spacing on the iframes on the Layout page as they are using padding to be displayed, so unsure how to approach this
- I guessed a lot for the spacing on the Glossary page, would love to have some input here @shixiedesign @jeanservaas 
- There are some hacky CSS in here now because of certain outliers, are we okay with this @alisonjoseph ? 

Also, I did one page at a time and I might have fixed something on one page that affected another page, so will need to double check all the pages to make sure it looks okay.
