### PR TITLE
fix(add-on): update font weights for header name

### DIFF
--- a/packages/addons-website/scss/components/_website-header.scss
+++ b/packages/addons-website/scss/components/_website-header.scss
@@ -21,10 +21,12 @@
 
 a.#{$prefix}--header__name {
   @include type-style('body-short-02');
+  font-weight: 600;
 }
 
 .#{$prefix}--header__name--prefix {
   @include type-style('heading-02');
+  font-weight: 400;
 }
 
 .#{$prefix}--header__action--menu {

--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -185,9 +185,11 @@ class Layout extends React.Component {
                   Product Design System
                 </HeaderName>
               ) : (
-                <HeaderName prefix="" to="/" element={Link}>
-                  Carbon Design System
-                </HeaderName>
+                <HeaderName
+                  prefix="Carbon Design System"
+                  to="/"
+                  element={Link}
+                />
               )}
 
               <HeaderGlobalBar>


### PR DESCRIPTION
Closes https://github.com/IBM-Design/design-website/issues/68

"— Weights should be reversed. IBM=Regular, Design=Bold"

Reverses font weights for title prefix. This doesn't change anything on the Carbon website, just the add-on.