### PR TITLE
fix: color token for inverse text

### DIFF
--- a/src/components/PageHeader/page-header.scss
+++ b/src/components/PageHeader/page-header.scss
@@ -1,6 +1,6 @@
 .page-header {
   background: $ibm-colors__black;
-  color: $inverse-02;
+  color: $inverse-01;
   width: 100%;
   display: flex;
   flex-direction: column;

--- a/src/components/PageTabs/page-tabs.scss
+++ b/src/components/PageTabs/page-tabs.scss
@@ -26,7 +26,7 @@
   @include type-style('body-short-02');
   padding: 0 $spacing-3xl 0 $spacing-md;
   text-decoration: none;
-  color: $inverse-02;
+  color: $inverse-01;
   white-space: nowrap;
   border-top: 2px solid transparent;
   height: rem(48px);


### PR DESCRIPTION
website was using incorrect inverse token
fixes this
<img width="613" alt="screen shot 2019-01-24 at 4 14 20 pm" src="https://user-images.githubusercontent.com/2753488/51712138-71e72b00-1ff3-11e9-8829-28fa49a15d49.png">
