### PR TITLE
fix(content-switcher): added gray bar at the top

### DIFF
--- a/src/components/ColorTokenTable/ColorTokenTable.js
+++ b/src/components/ColorTokenTable/ColorTokenTable.js
@@ -32,7 +32,8 @@ export default class ColorTokenTable extends React.Component {
 
   addScrollListener() {
     document.addEventListener('scroll', e => {
-      let stickyPoint = this.state.mobile ? 1340 : 1244;
+      console.log(window.scrollY);
+      let stickyPoint = this.state.mobile ? 436 : 450;
       if (window.scrollY >= stickyPoint) {
         this.setState({
           sticky: true,
@@ -69,10 +70,10 @@ export default class ColorTokenTable extends React.Component {
     let result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
     return result
       ? {
-        r: parseInt(result[1], 16),
-        g: parseInt(result[2], 16),
-        b: parseInt(result[3], 16),
-      }
+          r: parseInt(result[1], 16),
+          g: parseInt(result[2], 16),
+          b: parseInt(result[3], 16),
+        }
       : null;
   };
 
@@ -84,7 +85,7 @@ export default class ColorTokenTable extends React.Component {
       let hex = bgColor.substring(0, bgColor.length - 6);
       bgColor = `rgba(${this.hexToRgb(hex).r}, ${this.hexToRgb(hex).g}, ${
         this.hexToRgb(hex).b
-        }, 0.5)`;
+      }, 0.5)`;
     }
     return (
       <div className="color-token-value">

--- a/src/components/ColorTokenTable/color-token-table.scss
+++ b/src/components/ColorTokenTable/color-token-table.scss
@@ -4,10 +4,22 @@
 }
 
 .color-token-table__theme-switcher {
+  position: relative;
   width: 100%;
   height: rem(48px);
   margin-bottom: 1.75rem;
   background: $ui-02;
+}
+
+.color-token-table__theme-switcher::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: -16px;
+  left: 0;
+  width: 110%;
+  height: 64px;
+  background: $ui-01;
 }
 
 .color-token-table__theme-switcher--sticky {
@@ -34,8 +46,8 @@
   }
 }
 
-.page-h3--sticky {
-  margin-top: 100px;
+h3.page-h3--sticky {
+  margin-top: 100px !important;
 }
 
 .color-token-table__theme-switcher


### PR DESCRIPTION
Closes #757 

Added gray bar to the top of the content switcher so you can't see the table below it when scrolling.

