### PR TITLE
Added V9 link to FAQ

### DIFF
--- a/src/content/help/faq/faq.md
+++ b/src/content/help/faq/faq.md
@@ -72,4 +72,4 @@ First, refer to the [Carbon accessibility guidelines](/guidelines/accessibility)
 ### I haven't updated to the latest version of Carbon yet, but I still need the old documentation. Is there a place I can find it?
 
 Every version of Carbon that is still supported is hosted at its own domain. You can find the old sites version here:
-**[V6](http://v6.carbondesignsystem.com/)**, **[V7](http://v7.carbondesignsystem.com/)**, and **[V8](http://v8.carbondesignsystem.com/)**.
+**[V6](http://v6.carbondesignsystem.com/)**, **[V7](http://v7.carbondesignsystem.com/)**, **[V8](http://v8.carbondesignsystem.com/)**, and **[V9](http://v9.carbondesignsystem.com/).**


### PR DESCRIPTION
added v9 to the end of this paragraph https://next.carbondesignsystem.com/help/faq#i-haven%E2%80%99t-updated-to-the-latest-version-of-carbon-yet,-but-i-still-need-the-old-documentation.-is-there-a-place-i-can-find-it?