### PR TITLE
fix(alert-banner): remove wrapping anchor from tab order

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -189,6 +189,7 @@ class Layout extends React.Component {
               </p>
               <a
                 className="website-alert__button"
+                tabIndex="-1"
                 href=" https://www.carbondesignsystem.com">
                 <button class="bx--btn bx--btn--secondary" type="button">
                   <span>Go to v9</span>


### PR DESCRIPTION
Tabbing through the alert banner the user can give focus to the button's parent anchor tag (which has no focus styling) and then the button. This fix removes the wrapping anchor on the banner's alert button from the tab order.

### Testing
Tab through the alert banner. The first focusable element should be the the button navigating the user to the v9 docs site.