### PR TITLE
fix(alert-banner): remove wrapping anchor from tab order v9

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -146,7 +146,7 @@ class Layout extends React.Component {
               <p className="website-alert__text">
                 See what's coming soon with Carbon V10-beta.
               </p>
-              <a href="https://next.carbondesignsystem.com">
+              <a href="https://next.carbondesignsystem.com" tabIndex="-1">
                 <button
                   class="bx--btn bx--btn--secondary bx--btn--sm"
                   type="button">


### PR DESCRIPTION
Tabbing through the alert banner the user can give focus to the button's parent anchor tag (which has no focus styling) and then the button. This fix removes the wrapping anchor on the banner's alert button from the tab order.

### Testing

Tab through the alert banner. The first focusable element should be the the button navigating the user to the v9 docs site.