### PR TITLE
Component page intro reformat

### DIFF
--- a/src/content/components/accordion/usage.md
+++ b/src/content/components/accordion/usage.md
@@ -3,7 +3,7 @@ title: Accordion
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
 The accordion component delivers large amounts of content in a small space through progressive disclosure. That is, the user gets key details about the underlying content and can choose to expand that content within the constraints of the accordion. Accordions work especially well on mobile interfaces or whenever vertical space is at a premium.
 

--- a/src/content/components/breadcrumb/code.md
+++ b/src/content/components/breadcrumb/code.md
@@ -3,7 +3,6 @@ title: Breadcrumb
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Breadcrumb** enables users to quickly see their location within a path of navigation and move up to a parent level if desired.
 
 <component 
     name="Breadcrumb"

--- a/src/content/components/breadcrumb/usage.md
+++ b/src/content/components/breadcrumb/usage.md
@@ -3,7 +3,8 @@ title: Breadcrumb
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Intro
+## General guidance
+
 
 The _breadcrumb_ component (aka, breadcrumb trail) is a secondary navigation pattern that shows heirarchy among content or traces a user's path. Breadcrumbs enable users to move quickly up to a parent level or previous step. All links in a breadcrumb should be clickable.
 
@@ -17,13 +18,15 @@ Breadcrumbs' space-efficient design and high utility make them an easy choice fo
 
 </image-component>
 
-## Types of breadcrumbs
+## Variations
 
-### Location-based
+| Breadcrumb type   | Purpose                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Location-based_      | These illustrate the site's heirarchy and show the user where they are within that heirarchy.                                                                                                |
+| _Path-based_  | These show the actual steps the user took to get to the current page, rather than reflecting the site's information architecture. Path-based breadcrumbs are always dynamically generated.
+ |
 
-These illustrate the site's heirarchy and show the user where they are within that heirarchy.
 
-### Path-based
 
-These show the actual steps the user took to get to the current page, rather than reflecting the site's information architecture. Path-based breadcrumbs are always dynamically generated.
+
 

--- a/src/content/components/button/code.md
+++ b/src/content/components/button/code.md
@@ -3,7 +3,6 @@ title: Button
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Buttons** express what action will occur when the user clicks or touches it. Buttons are used to initialize an action, either in the background or foreground of an experience.
 
 <component 
     name="Primary Button"

--- a/src/content/components/button/usage.md
+++ b/src/content/components/button/usage.md
@@ -3,24 +3,36 @@ title: Button
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#variations">Variations</a></li>
+    <li><a data-scroll href="#labels">Labels</a></li>
+    <li><a data-scroll href="#icon-usage">Icon usage</a></li>
+    <li><a data-scroll href="#danger-button-usage">Danger button usage</a></li>
+</ul>
+</anchor-links>
+
+## General guidance
+
+_Buttons_ express what action will occur when the user clicks or touches it. Buttons are used to initialize an action, either in the background or foreground of an experience.
 
 Buttons are used primarily on action items. Some examples include **Add**, **Save**, **Delete**, and **Sign up**. Each page can have one or two **primary** buttons. Any remaining calls-to-action should be represented as secondary buttons.
 
 Do not use buttons as navigational elements. Instead, use [links](/components/link) when the desired action is to take the user to a new page.
 
-## Usage
+## Variations
 
 | Button type      | Purpose                                                                                                                                                                                                                                                                                                                                                                           |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Primary          | For the principal call to action on the page.                                                                                                                                                                                                                                                                                                                                     |
-| Secondary        | For secondary actions on each page.                                                                                                                                                                                                                                                                                                                                               |
-| Button with icon | When words are not enough, icons can be used in buttons to better communicate what the button does. Icons are always paired with text.                                                                                                                                                                                                                                            |
-| Disabled button  | Use when the user cannot proceed until an input is collected.                                                                                                                                                                                                                                                                                                                     |
-| Set of buttons   | When an action required by the user has more than one option, always use a a negative action button (secondary) paired with a positive action button (primary) in that order. Negative action buttons will be on the left; positive action buttons on the right. When these two types of buttons are paired in the correct order, they will automatically space themselves apart. |
+| _Primary_          | For the principal call to action on the page.                                                                                                                                                                                                                                                                                                                                     |
+| _Secondary_        | For secondary actions on each page.                                                                                                                                                                                                                                                                                                                                               |
+| _Button with icon_ | When words are not enough, icons can be used in buttons to better communicate what the button does. Icons are always paired with text.                                                                                                                                                                                                                                            |
+| _Disabled button_  | Use when the user cannot proceed until an input is collected.                                                                                                                                                                                                                                                                                                                     |
+| _Set of buttons_   | When an action required by the user has more than one option, always use a a negative action button (secondary) paired with a positive action button (primary) in that order. Negative action buttons will be on the left; positive action buttons on the right. When these two types of buttons are paired in the correct order, they will automatically space themselves apart. |
 | Small button     | Use when there is not enough vertical space for a regular sized button.                                                                                                                                                                                                                                                                                                           |
-| Ghost button     | When an action does not require primary dominance on the page.                                                                                                                                                                                                                                                                                                                    |
-| Danger button    | When an action has potentially destructive effects on the user's data (delete, remove, etc).                                                                                                                                                                                                                                                                                      |
+| _Ghost button_     | When an action does not require primary dominance on the page.                                                                                                                                                                                                                                                                                                                    |
+| _Danger button_    | When an action has potentially destructive effects on the user's data (delete, remove, etc).                                                                                                                                                                                                                                                                                      |
 
 ## Labels
 

--- a/src/content/components/checkbox/code.md
+++ b/src/content/components/checkbox/code.md
@@ -3,7 +3,6 @@ title: Checkbox
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Checkboxes** are used for a list of options where the user may select multiple options, including all or none.
 
 <component 
     name="Checkbox"

--- a/src/content/components/checkbox/usage.md
+++ b/src/content/components/checkbox/usage.md
@@ -3,37 +3,27 @@ title: Checkbox
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Checkboxes** are used for a list of options where the user may select multiple options, including all or none.
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#related-components">Related components</a></li>
+    <li><a data-scroll href="#content">Content</a></li>
+    <li><a data-scroll href="#tables">Tables</a></li>
+</ul>
+</anchor-links>
 
-### Checkbox States
+## General guidance
+_Checkboxes_ are used for a list of options where the user may select multiple options, including all or none.
+
+#### Checkbox states
 
 The checkbox control allows for three states: **selected**, **unselected**, and **indeterminate**. The indeterminate state comes into play when the checkbox contains a sublist of selections, some of which are selected, and some unselected.
 
-### Checkbox vs. Radio Button
-
-Whereas radio buttons represent a group of _mutually exclusive_ choices, users can select one or more checkboxes from a group. In use cases where only one selection of a group is allowed, use the radio button component instead of the checkbox.
-
-### Checkbox vs. Toggle Switch
-
-Generally, toggle switches are preferred when the resulting action will be instantaneously applied, without the need for further confirmation. Checkboxes generally represent one input in a larger flow which requires a final confirmation step.
-
-### Headings
-
-If necessary, a heading can accompany a set of checkboxes to provide further context or clarity. Use sentence case for checkbox headings. In the example below, “IBM designers” would be the heading for the set of checkboxes.
-
-### Labels
-
-Always use clear and concise labels for checkboxes. Be explicit about the results that will follow if the checkbox is selected. Labels appear to the right of checkboxes.
-
-### Click target
+#### Click target
 
 Users should be able to select the checkbox by clicking on the box directly or by clicking on its label.
 
-### Tables
-
-See the [Data Table](/components/data-table/usage) section for guidance on how to use checkboxes within a table.
-
-### Default selection
+#### Default selection
 
 The default view of a set of checkboxes is having no option selected.
 
@@ -43,12 +33,35 @@ The default view of a set of checkboxes is having no option selected.
 
 </image-component>
 
-### Related Components
 
-[Toggle](/experimental/toggle)
+## Related components
 
-[Radio Button](/experimental/radio-button)
+#### Checkbox vs. radio button
+Whereas radio buttons represent a group of _mutually exclusive_ choices, users can select one or more checkboxes from a group. In use cases where only one selection of a group is allowed, use the radio button component instead of the checkbox.
 
-[Form](/experimental/form)
+#### Checkbox vs. toggle switch
+Generally, toggle switches are preferred when the resulting action will be instantaneously applied, without the need for further confirmation. Checkboxes generally represent one input in a larger flow which requires a final confirmation step.
 
-Data Table (coming soon)
+#### References
+
+<br>
+
+- [Toggle](/experimental/toggle)
+- [Radio Button](/experimental/radio-button)
+- [Form](/experimental/form)
+- _Data Table (coming soon)_
+
+
+## Content
+
+#### Headings
+If necessary, a heading can accompany a set of checkboxes to provide further context or clarity. Use sentence case for checkbox headings. In the example below, “IBM designers” would be the heading for the set of checkboxes.
+
+#### Labels
+Always use clear and concise labels for checkboxes. Be explicit about the results that will follow if the checkbox is selected. Labels appear to the right of checkboxes.
+
+
+## Tables
+
+See the [Data Table](/components/data-table/usage) section for guidance on how to use checkboxes within a table.
+

--- a/src/content/components/code-snippet/code.md
+++ b/src/content/components/code-snippet/code.md
@@ -3,8 +3,6 @@ title: Code snippet
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Code snippets** are small blocks of reusable code that can be inserted in a code file.
-variations:
 
 <component
     name="Code Snippet"

--- a/src/content/components/code-snippet/usage.md
+++ b/src/content/components/code-snippet/usage.md
@@ -3,15 +3,20 @@ title: Code snippet
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General
+## General guidance
+
+_Code snippets_ are small blocks of reusable code that can be inserted in a code file.
+variations.
+
 
 <p>Our Code Snippets are built with basic styling. We recommend using <a href="https://github.com/chriskempson/base16" target=blank>Base16</a> for more complex syntax highlighting. Base16 provides carefully chosen syntax highlighting and a default set of sixteen colors suitable for a wide range of applications. The theme we recommend using is **Solarflare**.</p>
 
-### Overflow
+#### Overflow
 
 If there are more than nine lines of code, apply vertical scrolling to the Code Snippet.
 
 Terminal commands are often longer strings and should only appear on one line. Apply horizontal scrolling to maintain the set width of the box for those longer strings.
+
 
 ## Interaction
 

--- a/src/content/components/content-switcher/code.md
+++ b/src/content/components/content-switcher/code.md
@@ -3,7 +3,6 @@ title: Content switcher
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Content switcher** manipulates the content shown following an exclusive or “either/or” pattern.
 
 <component 
     name="Content switcher"

--- a/src/content/components/content-switcher/usage.md
+++ b/src/content/components/content-switcher/usage.md
@@ -3,19 +3,22 @@ title: Content switcher
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-The content switcher is used to toggle between two or more content sections within the same space on screen. Only one section can be shown at a time.
+_Content switcher_ manipulates the content shown following an exclusive or “either/or” pattern.
+It is used to toggle between two or more content sections within the same space on screen. Only one section can be shown at a time.
 
-### Text
+#### Text
 
 Be concise and specific. Titles have a max of two words.
 
-### Default selection
+#### Default selection
 
 Based on usage, there should be a default selection. The default selection is always the first option in a switcher.
 
-### Content switcher vs. toggle
+## Related components
+
+#### Content switcher vs. toggle
 
 The content switcher is used for large groups of content, as opposed to the [toggle](/components/toggle) which is meant for a “yes/no” or “on/off” binary decision.
 

--- a/src/content/components/data-table/code.md
+++ b/src/content/components/data-table/code.md
@@ -4,7 +4,6 @@ title: Data table
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-<page-intro>**Data tables** present raw data sets and lend meaning to the data, while maintaining that the data is readable, scannable, and easily comparable.</page-intro>
 
 <component 
     name="Data table"

--- a/src/content/components/date-picker/code.md
+++ b/src/content/components/date-picker/code.md
@@ -3,7 +3,6 @@ title: Date picker
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Date and time pickers** allow users to select a single or a range of dates and times.
 
 <component 
     name="Simple Date Picker"

--- a/src/content/components/date-picker/usage.md
+++ b/src/content/components/date-picker/usage.md
@@ -3,13 +3,29 @@ title: Date picker
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Usage
+
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#variations">Variations</a></li>
+    <li><a data-scroll href="#content">Content</a></li>
+    <li><a data-scroll href="#interaction">Interaction</a></li>
+    <li><a data-scroll href="#time-picker">Time picker</a></li>
+</ul>
+</anchor-links>
+
+## General guidance
+
+_Date and time pickers_ allow users to select a single or a range of dates and times.
+
+## Variations
 
 | Type               | Purpose                                                                                     |
 | ------------------ | ------------------------------------------------------------------------------------------- |
-| Range Date Picker  | To select a range of dates, accompanied by a calendar widget.                               |
-| Single Date Picker | When a user needs to select one date, accompanied by a calendar widget.                     |
-| Simple Date Picker | When the date is known by the user, and they don't need a calendar to anticipate the dates. |
+| _Range Date Picker_  | To select a range of dates, accompanied by a calendar widget.                               |
+| _Single Date Picker_ | When a user needs to select one date, accompanied by a calendar widget.                     |
+| _Simple Date Picker_ | When the date is known by the user, and they don't need a calendar to anticipate the dates. |
+
 
 <image-component cols="8" caption="Types of date pickers">
 
@@ -17,32 +33,32 @@ tabs: ['Code', 'Usage', 'Style']
 
 </image-component>
 
-## General guidelines
 
-### Labels
+## Content
 
+#### Labels
 Both Date and Time Pickers are accompanied by labels, and follow the same accessibility guidelines for all [Forms](/components/form).
 
-### Format
-
+#### Format
 For Date Pickers, use placeholder text so users input the date in the correct format. It can be formatted in a variety of ways. See the Date Picker code [documentation](https://github.com/ibm/carbon-components/tree/master/src/components/date-picker) for more info.
 
 ## Interaction
 
-### Calendar widget
+#### Calendar widget
 
 It is recommended to use the Date Picker with a calendar widget when the user is browsing between a range of dates. We can aid the user in making the proper choices by providing a visual reference of dates for them to choose from. The calendar widget appears once the user has interacted with the date input field (typically on `:focus`).
 
-<image-component fixed="default" caption="Selecting dates from the range date picker>
+
+<image-component cols="8" caption="Selecting dates from the range date picker">
 
 ![example of date picker](images/date-picker-usage-animation-1.gif)
 
 </image-component>
 
-### Simple Date Picker
+#### Simple Date Picker
 
 The Simple Date Picker provides the user with a text input in which they can input month/day/year. Simple Date Pickers are typically used when the date is known by the user, such as a birthday or credit card expiration.
 
-## Time Picker
+## Time picker
 
 Time pickers provide the user with a text input in which they can input hours/minutes. Additionally, they can be accompanied by an “AM/PM” selection and a time zone selection, which is styled as an [Inline Select](/components/select).

--- a/src/content/components/dropdown/code.md
+++ b/src/content/components/dropdown/code.md
@@ -3,8 +3,7 @@ title: Dropdown
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Dropdowns** present a list of options that can be used to filter existing content.
-variations:
+
 
 <component 
     name="Dropdown"

--- a/src/content/components/dropdown/usage.md
+++ b/src/content/components/dropdown/usage.md
@@ -3,25 +3,39 @@ title: Dropdown
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Usage
+
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#variations">Variations</a></li>
+    <li><a data-scroll href="#content">Content</a></li>
+    <li><a data-scroll href="#interaction">Interaction</a></li>
+</ul>
+</anchor-links>
+
+## General guidance
+
+_Dropdowns_ present a list of options that can be used to filter existing content. They can also be used as menus. This can be seen in [Tabs](/components/tabs), when used in a smaller screen size, collapses into a dropdown.
+
+## Variations
 
 | Type                         | Purpose                                                                                                                                                                                  |
 | ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Dropdown                     | User needs to pick one option from a list.                                                                                                                                               |
-| Filter dropdown              | When a list contains more than 25 items, use filtering to help find options from the list. May only be used with dropdown or multi-select dropdown. Cannot be used with inline dropdown. |
-| Multi-select dropdown        | User needs to select multiple options from a dropdown.                                                                                                                                   |
-| Inline dropdown              | A stylized dropdown that can be formatted to appear inline with other content and allows the user to select one option.                                                                  |
-| Inline multi-select dropdown | A stylized dropdown that can be formatted to appear inline with other content and allows the user to select more than one option.                                                        |
+| _Dropdown_                     | User needs to pick one option from a list.                                                                                                                                               |
+| _Filter dropdown_              | When a list contains more than 25 items, use filtering to help find options from the list. May only be used with dropdown or multi-select dropdown. Cannot be used with inline dropdown. |
+| _Multi-select dropdown_        | User needs to select multiple options from a dropdown.                                                                                                                                   |
+| _Inline dropdown_              | A stylized dropdown that can be formatted to appear inline with other content and allows the user to select one option.                                                                  |
+| _Inline multi-select dropdown_ | A stylized dropdown that can be formatted to appear inline with other content and allows the user to select more than one option.                                                        |
 
-Dropdowns can also be used as menus. This can be seen in [Tabs](/components/tabs), when used in a smaller screen size, collapses into a dropdown.
+
 
 ## Content
 
-### Labels
+#### Labels
 
 Labels inform users what to expect in the list of dropdown options. Use clear labels for the dropdown trigger so that users understand the purpose. Keep the label short and concise by limiting it to a single line of text.
 
-### Dropdown options
+#### Dropdown options
 
 Describe the dropdown option succinctly in one line of text. Never use images or icons within a dropdown. Avoid having multiple lines of text in a dropdown, but if text wrapping is necessary, limit it to two lines and an ellipsis (...) for overflow content. We recommend presenting the options in alphabetical order.
 

--- a/src/content/components/file-uploader/code.md
+++ b/src/content/components/file-uploader/code.md
@@ -3,7 +3,6 @@ title: File uploader
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**File Uploader** allows the user to transfer a file or submit content of their own.
 
 <component 
     name="File Uploader"

--- a/src/content/components/file-uploader/usage.md
+++ b/src/content/components/file-uploader/usage.md
@@ -3,7 +3,19 @@ title: File uploader
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#interaction">Interaction</a></li>
+    <li><a data-scroll href="#upload-state">Upload state</a></li>
+    <li><a data-scroll href="#removing-files">Removing files</a></li>
+</ul>
+</anchor-links>
+
+## General guidance
+
+_File Uploader_ allows the user to transfer a file or submit content of their own.
+
 
 - A File Uploader is commonly found in forms, but they can also live as stand alone elements.
 - **Add files** is the default text that appears with the File Uploader.
@@ -16,7 +28,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 </image-component>
 
-## Basic interaction
+## Interaction
 
 1. The user may select 1 or more files to upload at a time. By default, any file type is accepted, but you can add parameters to validate a specific file type.
 2. The action of clicking **Add files** will trigger a browser-specific upload window.

--- a/src/content/components/form/code.md
+++ b/src/content/components/form/code.md
@@ -3,7 +3,6 @@ title: Form
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Forms** are used for submitting data.
 
 <component 
     name="Form"

--- a/src/content/components/form/usage.md
+++ b/src/content/components/form/usage.md
@@ -3,40 +3,21 @@ title: Form
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Effective form design
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#format">Format</a></li>
+    <li><a data-scroll href="#form-logic">Form logic</a></li>
+    <li><a data-scroll href="#validation--errors">Validation & errors</a></li>
+</ul>
+</anchor-links>
 
-All forms are comprised of 6 elements:
 
-- **Labels:** Inform users what the corresponding input fields mean.
-- **Input fields:** Enable users to provide information. Information can be entered through a variety of different input fields ranging from text fields, checkboxes, and many other types.
-- **Help text:** Provides assistance on how to fill out a field. Help text is optional.
-- **Placeholder text:** Hints at what goes into a field. Placeholder text is optional.
-- **Actions:** Allow users to submit a form.
-- **Validation:** Ensures the data submitted by the user conforms to acceptable parameters.
-
-<image-component cols="8">
-
-![effective form design](images/form-usage-1.png)
-
-</image-component>
-
-## Form logic
-
-- **Radio Buttons** are used when there is a list of two or more options that are mutually exclusive and the user must select exactly one choice. In other words, clicking a non-selected radio button will deselect whatever other button was previously selected in the list.
-- **Checkboxes** are used when there are lists of options and the user may select any number of choices, including zero, one, or several. In other words, each checkbox is independent of all other checkboxes in the list, so checking one box doesn’t uncheck the others. A stand-alone checkbox, or a toggle can be used for a single option that the user can turn on or off.
-- For fields in which a single selection is required and there are a large number of possible options, consider using a **Select** element.
-
-<image-component cols="8">
-
-![form logic](images/form-usage-4.png)
-
-</image-component>
-
-## General guidelines
+## General guidance
 
 ### Keep it short
 
-Be as concise as possible when designing forms. Think about each field and what value the data will provide. What do you gain by collecting this information?
+_Forms_ are used for submitting data so be as concise as possible when designing. Think about each field and what value the data will provide. What do you gain by collecting this information?
 
 **Begin by asking:**
 
@@ -65,6 +46,38 @@ Help text is pertinent information that assists the user in completing a field. 
 ### Placeholder text
 
 Placeholder text provides hints or examples of what to enter. Placeholder text disappears after the user begins entering data into the Input and should not contain crucial information. Use sentence-style capitalization, and in most cases, write the text as a direct statement without punctuation.
+
+## Format
+
+All forms are comprised of 6 elements:
+
+- **Labels:** Inform users what the corresponding input fields mean.
+- **Input fields:** Enable users to provide information. Information can be entered through a variety of different input fields ranging from text fields, checkboxes, and many other types.
+- **Help text:** Provides assistance on how to fill out a field. Help text is optional.
+- **Placeholder text:** Hints at what goes into a field. Placeholder text is optional.
+- **Actions:** Allow users to submit a form.
+- **Validation:** Ensures the data submitted by the user conforms to acceptable parameters.
+
+<image-component cols="8">
+
+![effective form design](images/form-usage-1.png)
+
+</image-component>
+
+
+
+## Form logic
+
+- **Radio Buttons** are used when there is a list of two or more options that are mutually exclusive and the user must select exactly one choice. In other words, clicking a non-selected radio button will deselect whatever other button was previously selected in the list.
+- **Checkboxes** are used when there are lists of options and the user may select any number of choices, including zero, one, or several. In other words, each checkbox is independent of all other checkboxes in the list, so checking one box doesn’t uncheck the others. A stand-alone checkbox, or a toggle can be used for a single option that the user can turn on or off.
+- **Select elements** are used for fields in which a single selection is required and there are a large number of possible options.
+
+<image-component cols="8">
+
+![form logic](images/form-usage-4.png)
+
+</image-component>
+
 
 ## Validation and errors
 

--- a/src/content/components/inline-loading/code.md
+++ b/src/content/components/inline-loading/code.md
@@ -3,7 +3,6 @@ title: Inline loading
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Inline Loading** spinners are used when performing actions. They help notify user's that their action is being processed.
 
 <component 
     name="Inline Loading"

--- a/src/content/components/inline-loading/usage.md
+++ b/src/content/components/inline-loading/usage.md
@@ -2,36 +2,23 @@
 title: Inline loading
 tabs: ['Code', 'Usage', 'Style']
 ---
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#format">Format</a></li>
+    <li><a data-scroll href="#states">States</a></li>
+</ul>
+</anchor-links>
 
-## General
 
+## General guidance
+
+_Inline Loading_ spinners are used when performing actions. They help notify user's that their action is being processed.
 The waiting experience is a crucial design opportunity. Although it may not be obvious what is occurring on the back-end, we can communicate clearly to reassure the user that progress is happening.
 
 It is best practice to use an Inline Loading component for any Create, Update, or Delete actions. The component provides feedback to the user about the progress of the action they took. This could be in a table, after a primary or secondary button click, or even in a modal.
 
-## States
-
-### Loading
-
-The **LOADING** state indicates that the action is still in progress.
-
-<image-component cols="8">
-
-![Example of inline loading](images/inline-loading-usage-1.png)
-
-</image-component>
-
-### Success
-
-The **SUCCESS** state indicates that the action completed successfully.
-
-<image-component cols="8">
-
-![Example of loading success](images/inline-loading-usage-2.png)
-
-</image-component>
-
-## Guidelines
+## Format
 
 - If the Inline Loading is being used to submit a form, the form fields should get disabled.
 
@@ -42,3 +29,27 @@ The **SUCCESS** state indicates that the action completed successfully.
 - If an error occurs, the Inline Loading component should be hidden and a error notification should be added or error handling within a form should appear.
 
 - The Inline Loading component should never be used to load a page or data.
+
+
+## States
+
+#### Loading
+
+The _loading_ state indicates that the action is still in progress.
+
+<image-component cols="8">
+
+![Example of inline loading](images/inline-loading-usage-1.png)
+
+</image-component>
+
+#### Success
+
+The _success_ state indicates that the action completed successfully.
+
+<image-component cols="8">
+
+![Example of loading success](images/inline-loading-usage-2.png)
+
+</image-component>
+

--- a/src/content/components/link/code.md
+++ b/src/content/components/link/code.md
@@ -3,8 +3,6 @@ title: Link
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Links** are used primarily as a navigational element. Links may also change what or how data is displayed (view more, show all). If the action taken by the user will change or manipulate data, use a button.
-
 <component 
     name="Link"
     component="link" 

--- a/src/content/components/link/usage.md
+++ b/src/content/components/link/usage.md
@@ -3,7 +3,14 @@ title: Link
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Link text
+## General guidance
+
+
+_Links_ are used primarily as a navigational element. Links may also change what or how data is displayed (view more, show all). If the action taken by the user will change or manipulate data, use a button.
+
+
+
+## Content
 
 - Use text for links rather than graphics or icons.
 - Links should be three words or less.

--- a/src/content/components/list/code.md
+++ b/src/content/components/list/code.md
@@ -3,7 +3,6 @@ title: List
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Lists** consist of related content grouped together and organized vertically.
 
 <component 
     name="Ordered List"

--- a/src/content/components/list/usage.md
+++ b/src/content/components/list/usage.md
@@ -3,22 +3,30 @@ title: List
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
+
+_Lists_ consist of related content grouped together and organized vertically.
+
+
+## Variations
 
 | List type       | Purpose                                                                            |
 | --------------- | ---------------------------------------------------------------------------------- |
 | Unordered lists | To present content of equal status or value.                                       |
 | Ordered lists   | Imply sequence and order, and are commonly used when giving a set of instructions. |
 
-### Length
+
+## Content
+
+#### Length
 
 Generally, lists should be used to present simple pieces of information. For more complex sets of data, consider using a [Data Table.](/components/data-table)
 
-### Order
+#### Order
 
 Arrange list items in a logical way. For example, if the list is about resource use, the default order might be highest resource use to lowest. Grouping items in categories into smaller, more specific lists might be more meaningful in some contexts. Alternatively, organize in alphabetical or numeric order.
 
-### Text
+#### Text
 
 Use list items that are grammatically parallel. For example, do not mix passive voice with active voice or declarative sentences (statements) with imperative sentences (direct command).
 

--- a/src/content/components/loading/code.md
+++ b/src/content/components/loading/code.md
@@ -3,7 +3,7 @@ title: Loading
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Loading** spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway.
+
 
 <component 
     name="Loading"

--- a/src/content/components/loading/usage.md
+++ b/src/content/components/loading/usage.md
@@ -3,9 +3,9 @@ title: Loading
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-The waiting experience is a crucial design opportunity. Although it may not be obvious what is occurring on the back-end, we can communicate clearly to reassure the user that progress is happening.
+_Loading_ spinners are used when retrieving data or performing slow computations, and help to notify users that loading is underway. The waiting experience is a crucial design opportunity. Although it may not be obvious what is occurring on the back-end, we can communicate clearly to reassure the user that progress is happening.
 
 It is best practice to use a loading spinner whenever the wait time is anticipated to be longer than three seconds.
 

--- a/src/content/components/modal/code.md
+++ b/src/content/components/modal/code.md
@@ -3,7 +3,6 @@ title: Modal
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Modals** communicate information via a secondary window and allow the user to maintain the context of a particular task. Use Modals sparingly because they interrupt user workflow.
 
 <component 
     name="Passive Modal"

--- a/src/content/components/modal/usage.md
+++ b/src/content/components/modal/usage.md
@@ -3,29 +3,37 @@ title: Modal
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Dismissal
+<anchor-links>
+<ul>
+    <li><a data-scroll href="#general-guidance">General guidance</a></li>
+    <li><a data-scroll href="#format">Format</a></li>
+    <li><a data-scroll href="#variations">Variations</a></li>
+    <li><a data-scroll href="#dismissal">Dismissal</a></li>
+</ul>
+</anchor-links>
 
-Modals may be dismissed in 3 ways:
 
-- Using the “x” in the upper right-hand corner of the Modal
-- Pressing the `ESC` key
-- Clicking / touching outside of the Modal area
+## General guidance
 
-## Structure
+_Modals_ communicate information via a secondary window and allow the user to maintain the context of a particular task. Use Modals sparingly because they interrupt user workflow.
 
-### Header
+## Format
+
+#### Header
 
 Include a heading within the Modal that mirrors the action or button that was clicked by the user. Headers include a close button “x” in the upper right-hand corner of the Modal.
 
-### Body
+#### Body
 
 The body content within a Modal should be as minimal as possible. Components that may be used in Modals include: Form fields, Text Area, Select, and Radio Buttons.
 
-### Footer
+#### Footer
 
 The footer area of a Modal typically contains a set of buttons. Refer to [Button](/components/button) guidelines for usage.
 
-## Usage
+
+
+## Variations
 
 ### Transactional Modal
 
@@ -56,3 +64,13 @@ Modals used in this case include input areas that the user may interact with. Th
 ![input modal](images/modal-usage-2.png)
 
 </image-component>
+
+
+## Dismissal
+
+Modals may be dismissed in 3 ways:
+
+- Using the “x” in the upper right-hand corner of the Modal
+- Pressing the `ESC` key
+- Clicking / touching outside of the Modal area
+

--- a/src/content/components/notification/code.md
+++ b/src/content/components/notification/code.md
@@ -3,7 +3,6 @@ title: Notification
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Notifications** are messages that communicate information to the user.
 
 <component 
     name="Inline Notification"

--- a/src/content/components/notification/usage.md
+++ b/src/content/components/notification/usage.md
@@ -3,30 +3,48 @@ title: Notification
 tabs: ['Code', 'Usage', 'Style']
 ---
 
+## General guidance
+
+_Notifications_ are messages that communicate information to the user.
+
+
 ## Format
 
-### Title
+#### Title
 
-All notifications have subject titles, which should be short and descriptive. Example: **“Tester-app-02 has crashed.”**
+All notifications have subject titles, which should be short and descriptive. _Example: “Tester-app-02 has crashed.”_
 
-### Message
+#### Message
 
 We recommend the body of the notification be contained within two lines. Be descriptive and include any troubleshooting actions or next steps. When possible, communicate the main message using just the title. You can include [Links](/components/link) within the notification body that redirect the user to next steps.
 
-### Dismissal
+#### Dismissal
 
 We recommend that toast notifications automatically disappear after five seconds. Inline notifications are persistent until the user dismisses them. All notifications have at least one method of dismissal (typically, it is a small “x” in the upper right hand corner).
 
-### Icons
+#### Icons
 
 Icons may provide additional clarity. Icons should be placed to the left of a title. These glyphs (16x16) can be found in the [iconography](/guidelines/iconography/library) library.
 
-## Placement
 
-### Toast notifications
+## Variations
+
+| Notification type   | Purpose                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Toast notification_      | Toasts are a non-modal, time-based window elements used to display short messages; they usually appear at the bottom of the screen and disappear after a few seconds.                                                                                               |
+| _Inline notification_  | Inline notifications show up in task flows, to notify users of the status of an action. They usually appear at the top of the primary content area. |
+
+
+### Placement
+
+#### Toast notifications
 
 Toast notifications slide in and out a page from the top-right corner. Actionable notifications do not appear on mobile screen widths.
 
-### Inline notifications
+#### Inline notifications
 
 Inline notifications appear near its related item. In [Forms](/components/form), we recommend placing the inline notification at the bottom of the form, right before the submission buttons. Depending on the context of the page, inline notifications can appear above the content as well.
+
+
+
+

--- a/src/content/components/number-input/code.md
+++ b/src/content/components/number-input/code.md
@@ -3,7 +3,6 @@ title: Number input
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Number inputs** are similar to text inputs, but contain controls used to increase or decrease an incremental value.
 
 <component 
     name="Number Input"

--- a/src/content/components/number-input/usage.md
+++ b/src/content/components/number-input/usage.md
@@ -3,7 +3,12 @@ title: Number input
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
+
+_Number inputs_ are similar to text inputs, but contain controls used to increase or decrease an incremental value.
+
+
+## Format
 
 - Do not use number inputs when large value changes are expected. They work best for making small, incremental changes that only require a few clicks.
 - Enable the user to also choose to type a number in the field.

--- a/src/content/components/overflow-menu/code.md
+++ b/src/content/components/overflow-menu/code.md
@@ -3,8 +3,6 @@ title: Overflow menu
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Overflow menu** is used when additional options are available to the user and there is a space constraint.
-
 <component 
     name="Overflow Menu"
     component="overflow-menu" 

--- a/src/content/components/overflow-menu/usage.md
+++ b/src/content/components/overflow-menu/usage.md
@@ -3,12 +3,18 @@ title: Overflow menu
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-### Text
+
+_Overflow menu_ is used when additional options are available to the user and there is a space constraint.
+
+
+## Format
+
+#### Text
 
 The text within an Overflow Menu should be direct so users can quickly decide on an action. Actions that could cause a significant change to the user's data (Delete app, Delete service, etc.) is separated by a horizontal rule and live below the primary set of actions.
 
-### Positioning
+#### Positioning
 
 Depending on where the Overflow Menu appears within the UI, the caret or arrow may be left or right aligned so the Overflow Menu is clearly visible.

--- a/src/content/components/pagination/code.md
+++ b/src/content/components/pagination/code.md
@@ -3,7 +3,6 @@ title: Pagination
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Pagination** is used for splitting up content or data into several pages, with a control for navigating to the next or previous page.
 
 <component 
     name="Pagination"

--- a/src/content/components/pagination/usage.md
+++ b/src/content/components/pagination/usage.md
@@ -3,20 +3,22 @@ title: Pagination
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Usage
+## General guidance
+
+_Pagination_ is used for splitting up content or data into several pages, with a control for navigating to the next or previous page.
 
 Generally, Pagination is used if there are more than 25 items displayed in one view. The default number displayed will vary depending on the context.
 
 ## Best practices
 
-### Identify the current page
+#### Identify the current page
 
 Clearly identify which page the user is on my displaying the current page number. By providing context into how many pages there are in total (eg. 1 of 4 pages), you can help provide clarity around the data displayed.
 
-### Provide various options for navigating
+#### Provide various options for navigating
 
-**Previous** and **next** chevrons or links are the most useful way for the user to move forward or backward through pages of data. Provide a [Inline select](/components/select) in which users can choose the page they wish to navigate to.
+_Previous_ and _next_ chevrons or links are the most useful way for the user to move forward or backward through pages of data. Provide a [Inline select](/components/select) in which users can choose the page they wish to navigate to.
 
-### Items per page
+#### Items per page
 
 Use an Inline select within the Pagination bar so the user can change the amount of data displayed per page.

--- a/src/content/components/progress-indicator/code.md
+++ b/src/content/components/progress-indicator/code.md
@@ -3,7 +3,6 @@ title: Progress indicator
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Progress Indicator** is a visual representation of a users progress through a set of steps. They guide the user through a number of steps in order to complete a specified process.
 
 <component
     name="Progress Indicator"

--- a/src/content/components/progress-indicator/usage.md
+++ b/src/content/components/progress-indicator/usage.md
@@ -3,20 +3,22 @@ title: Progress indicator
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
+
+_Progress Indicator_ is a visual representation of a users progress through a set of steps. They guide the user through a number of steps in order to complete a specified process.
 
 Use Progress Indicators to keep the user on track when completing a specific task. By dividing the end goal into smaller, sub-tasks, it increases the percentage of completeness as each task is completed.
 
 ## Best practices
 
-### Logical progression
+#### Logical progression
 
 Display the steps in order from left to right. Indicate to the user that they are performing a multi-step process, and show the direction of movement. Allow the user to return to a previous step to review their data submission.
 
-### Indicate the current step
+#### Indicate the current step
 
 Keeping the user informed of where they currently are within the process or task at hand will give them a sense of control. This helps the user to know where they are in relation to where they have been, and what sections are to follow. Clear labels should accompany the Progress Indicator to indicate what the user will accomplish within each step. Keep labels between one to two words.
 
-### Validation
+#### Validation
 
 Use validation to confirm that a previous step has been completed. If the user cannot proceed onto another step without first completing a task, use an [Inline Notification](/experimental/notification) to inform them.

--- a/src/content/components/radio-button/code.md
+++ b/src/content/components/radio-button/code.md
@@ -3,7 +3,7 @@ title: Radio button
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Radio buttons** are used when a list of two or more options are mutually exclusive, meaning the user must select only one option.
+
 
 <component 
     name="Radio Button"

--- a/src/content/components/radio-button/usage.md
+++ b/src/content/components/radio-button/usage.md
@@ -3,16 +3,20 @@ title: Radio button
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-### Headings
+_Radio buttons_ are used when a list of two or more options are mutually exclusive, meaning the user must select only one option.
+
+##Format
+
+#### Headings
 
 If necessary, a heading can accompany a set of radio buttons to provide further clarity for the user. Use sentence-style capitalization (only the first word in a phrase and any proper nouns capitalized).
 
-### Labels
+#### Labels
 
 Always use a clear and concise label for radio buttons. Be explicit about the action that will follow if the radio button is selected. Labels appear to the right of radio buttons. Use sentence-style capitalization (only the first word in a phrase and any proper nouns capitalized) and no more than three words.
 
-### Default selection
+## Default selection
 
 A set of radio buttons should default to having one option selected. Never display them without a default selection.

--- a/src/content/components/search/code.md
+++ b/src/content/components/search/code.md
@@ -3,8 +3,6 @@ title: Search
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-Search enables users to specify a word or a phrase to find particular relevant pieces of content without the use of navigation. Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
-
 <component 
     name="Small Search"
     component="search" 

--- a/src/content/components/search/usage.md
+++ b/src/content/components/search/usage.md
@@ -3,13 +3,22 @@ title: Search
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-### Search variations
+_Search_ enables users to specify a word or a phrase to find particular relevant pieces of content without the use of navigation. Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
 
-**Large Search** should be used at a global level, when the user is searching content within a page view.
 
-**Small Search** can be used when there are space constraints in your design. It can also be component specific. For example, Small Search can be used to filter data within a [Data Table](/components/data-table).
+
+
+## Variations
+
+| Search type   | Purpose                                                                                                                                                     |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Large search_      | This should be used at a global level, when the user is searching content within a page view.                                                                                             |
+| _Small search_  | Choose small when there are space constraints in your design. It can also be component specific. For example, Small Search can be used to filter data within a [Data Table](/components/data-table). |
+
+
+## Format
 
 ### Search fields
 

--- a/src/content/components/select/code.md
+++ b/src/content/components/select/code.md
@@ -3,9 +3,6 @@ title: Select
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Component variations
-**Select** is a type of input that is used in forms, where a user is submitting data and chooses one option from a list.
-
 <component 
     name="Select"
     component="select" 

--- a/src/content/components/select/usage.md
+++ b/src/content/components/select/usage.md
@@ -3,21 +3,29 @@ title: Select
 tabs: ['Code', 'Usage', 'Style']
 ---
 
+
+
+## General guidance
+_Select_ is a type of input that is used in forms, where a user is submitting data and chooses one option from a list.
+
+
+## Variations
+
 | Select type   | Purpose                                                                                                                                                     |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Default       | Typically used in forms with a variety of other components.                                                                                                 |
-| Small select  | When vertical space is a concern, or Select is being paired with larger component, such as [Cards](/add-ons/card) or [Data Tables](/components/data-table). |
-| Inline select | When multiple selects are grouped together.                                                                                                                 |
+| _Default_      | Typically used in forms with a variety of other components.                                                                                                 |
+| _Small select_  | When vertical space is a concern, or Select is being paired with larger component, such as [Cards](/add-ons/card) or [Data Tables](/components/data-table). |
+| _Inline select_ | When multiple selects are grouped together.                                                                                                                 |
 
-### Small select
+#### Small select
 
 _Small selects_ are commonly used in [data tables](/components/data-table). When using a small select for a number selection, the increments in the select should be 10, 25, 50 and 100. The maximum amount of items a user can see per page is 100.
 
-### Inline select
+#### Inline select
 
 Inline select is useful when you have multiple `select` fields within a form. Inline selects have less visual weight on a page because they are borderless.
 
-## General guidelines
+## Format
 
 ### Labels
 
@@ -40,9 +48,9 @@ One of the <a href="https://www.w3.org/TR/WCAG20-TECHS/G202.html" target=blank>W
 
 While you can make a select element easily usable by a mouse, making it usable with keyboard navigation is complex. The default `select` element should follow this process:
 
-|         | Mouse                                    | Keyboard                                            |
+| State        | Mouse                                    | Keyboard                                            |
 | ------- | ---------------------------------------- | --------------------------------------------------- |
-| :hover  | move your cursor over the select element | use the tab key to focus the select element         |
-| :focus  | click on the select element              | press enter                                         |
-| :       | move your cursor over the desired option | use the top and bottom arrow keys to pick an option |
+| _:hover_  | move your cursor over the select element | use the tab key to focus the select element         |
+| _:focus_  | click on the select element              | press enter                                         |
+| _:_       | move your cursor over the desired option | use the top and bottom arrow keys to pick an option |
 | :select | click on the desired option              | press enter                                         |

--- a/src/content/components/slider/code.md
+++ b/src/content/components/slider/code.md
@@ -3,8 +3,6 @@ title: Slider
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Sliders** provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
-
 <component 
     name="Slider"
     component="slider" 

--- a/src/content/components/slider/usage.md
+++ b/src/content/components/slider/usage.md
@@ -3,7 +3,10 @@ title: Slider
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Types of sliders
+## General guidance
+
+
+_Sliders_ provide a visual indication of adjustable content, where the user can move the handle along a horizontal track to increase or decrease the value.
 
 The _slider_ in its basic form should be accompanied by a label and a number input that doubles as a display for the slider's current value. The basic slider does **not** include discrete values, as the slider represents a percentage of 0-100. In this case it is not necessary for a user to choose a specific value, but instead generally increase or decrease an input. For example, the user increases the slider amount and the volume of the music gets louder. The more complex versions should be used for selecting a specific value within a value range.
 

--- a/src/content/components/structured-list/code.md
+++ b/src/content/components/structured-list/code.md
@@ -3,7 +3,6 @@ title: Structured list
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Structured Lists** group content that is similar or related, such as terms or definitions.
 
 <component 
     name="Structured List"

--- a/src/content/components/structured-list/usage.md
+++ b/src/content/components/structured-list/usage.md
@@ -3,6 +3,12 @@ title: Structured list
 tabs: ['Code', 'Usage', 'Style']
 ---
 
+## General guidance
+
+_Structured Lists_ group content that is similar or related, such as terms or definitions.
+
+
+
 ## Content
 
 - Row height varies based on content, and can expand to fit multiple lines.

--- a/src/content/components/tabs/code.md
+++ b/src/content/components/tabs/code.md
@@ -3,7 +3,6 @@ title: Tabs
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Tabs** are used to quickly navigate between views within the same context.
 
 <component
     name="Tabs"

--- a/src/content/components/tabs/usage.md
+++ b/src/content/components/tabs/usage.md
@@ -3,16 +3,19 @@ title: Tabs
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
+_Tabs_ are used to quickly navigate between views within the same context.
 
-### Text
+## Format
+
+#### Text
 
 Each Tab label describes its content and sets user expectations. Labels are concise and use one to two words maximum. Keep in mind that at mobile widths, the character length of a title will impact the experience. Icons are not permitted in Tab labels.
 
-### Number of tabs
+#### Number of tabs
 
 A maximum of six tabs may be displayed. This is to maintain an uncluttered UI and reduce cognitive load for users.
 
-### Order
+#### Order
 
 Tab order should be consistent across an experience. Tabs with related content should be grouped adjacent to each other.

--- a/src/content/components/tag/code.md
+++ b/src/content/components/tag/code.md
@@ -3,7 +3,6 @@ title: Tag
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Tags** are used for items that need to be labeled, categorized, or organized using keywords that describe them.
 
 <component 
     name="Tag"

--- a/src/content/components/tag/usage.md
+++ b/src/content/components/tag/usage.md
@@ -5,6 +5,9 @@ tabs: ['Code', 'Usage', 'Style']
 
 ## General guidelines
 
+_Tags_ are used for items that need to be labeled, categorized, or organized using keywords that describe them.
+
+
 Multiple or single tags can be used to categorize items.
 
 Use tags when content is mapped to multiple categories, and the user needs a way to differentiate between them.

--- a/src/content/components/text-input/code.md
+++ b/src/content/components/text-input/code.md
@@ -3,7 +3,6 @@ title: Text input
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Text inputs** enable the user to interact with and input data. Use when the application requires long-form content from the user.
 
 <component
     name="Text Input"

--- a/src/content/components/text-input/usage.md
+++ b/src/content/components/text-input/usage.md
@@ -3,14 +3,17 @@ title: Text input
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
+
+_Text inputs_ enable the user to interact with and input data. Use when the application requires long-form content from the user.
+
 
 | Type       | Purpose                                                                           |
 | ---------- | --------------------------------------------------------------------------------- |
 | Text input | When the expected user input is a single line of text, as opposed to a paragraph. |
 | Text area  | When the expected user input is more than one sentence.                           |
 
-## General guidelines
+## Format
 
 ### Labels
 

--- a/src/content/components/tile/code.md
+++ b/src/content/components/tile/code.md
@@ -3,7 +3,6 @@ title: Tile
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Tiles** are flexible containers that house a variety of content.
 
 <component 
     name="Tile"

--- a/src/content/components/tile/usage.md
+++ b/src/content/components/tile/usage.md
@@ -3,7 +3,7 @@ title: Tile
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Usage
+## General guidance
 
 Tiles are a highly flexible component for displaying a wide variety of content, including informational, getting started, how-to, next steps, and more.
 
@@ -11,7 +11,7 @@ Carbon ships a basic tile structure that responds to the grid. Tiles have no pre
 
 When using a call-to-action (CTA) within a tile, use a [secondary button](/components/button). Primary buttons should be reserved for the most important action a user can take on the page.
 
-## Types of tiles
+## Variations
 
 _All of the images below represent examples of types of content that could be presented within a tile. The styling in these examples is for illustration only; you are free to create your own layout and design within a tile._
 

--- a/src/content/components/toggle/code.md
+++ b/src/content/components/toggle/code.md
@@ -3,7 +3,6 @@ title: Toggle
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Toggle** is a control that is used to quickly switch between two possible states.
 
 <component 
     name="Toggle"

--- a/src/content/components/toggle/usage.md
+++ b/src/content/components/toggle/usage.md
@@ -3,19 +3,19 @@ title: Toggle
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## General guidelines
+## General guidance
 
-Toggles are used for binary actions that occur immediately after the user “flips” the toggle switch. They are commonly used for “on/off” switches.
+_Toggle_ is a control that is used to quickly switch between two possible states. Toggles are only used for these binary actions that occur immediately after the user “flips” the toggle switch. They are commonly used for “on/off” switches.
 
-### Heading
+#### Heading
 
 A heading may accompany a toggle to further clarify on the action the toggle will perform.
 
-### Labels
+#### Labels
 
 Use labels with a toggle so the action is clear. Labels should be three words or less and appear on the side of a toggle.
 
-### Language
+#### Language
 
 Use adjectives rather than verbs to describe labels and the state of the object affected.
 

--- a/src/content/components/tooltip/code.md
+++ b/src/content/components/tooltip/code.md
@@ -3,7 +3,7 @@ title: Tooltip
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-**Tooltips** provide additional information upon hover or focus. They often contain helper text that is contextual to an element.
+
 
 <component 
     name="Tooltip"

--- a/src/content/components/tooltip/usage.md
+++ b/src/content/components/tooltip/usage.md
@@ -3,16 +3,18 @@ title: Tooltip
 tabs: ['Code', 'Usage', 'Style']
 ---
 
-## Usage
+## General guidance
 
-### Icon tooltip
+_Tooltips_ provide additional information upon hover or focus. They often contain helper text that is contextual to an element.
+
+#### Icon tooltip
 
 An icon tooltip is used to clarify the action or name of an interactive icon button. The tooltip content should only contain one to two words. Icon tooltips appear on `hover` and `focus`.
 
-### Definition Tooltip
+#### Definition Tooltip
 
 The primary purpose of a definition tooltip is to provide additional help or define an item or term. Therefore, they should contain read-only text that is kept to a minimum. The use of interactive elements, such as buttons or links, is discouraged. Definition tooltips appear on `hover` and `focus`.
 
-### Interactive Tooltip
+#### Interactive Tooltip
 
 Interactive tooltips can contain text and other interactive elements such as a button or a link. They appear when the user clicks on an info icon and are persistent until intentionally dismissed by clicking outside of the tooltip.


### PR DESCRIPTION
Changes per discussion at design review yesterday:

- remove stray sentence from beginnings of Code tab page on all components and fold it into usage content where it belongs for now

- Make sure usage content is displayed in a consistent order and that like information has the same H2 (for instance, the first paragraph was sometimes called "General Guidelines," sometimes called "Usage," sometimes called "Best practises" etc. Did a quick audit of this, chose what appeared most frequently and applied it across components

- added anchor links where necessary 

- change a lot of H3s to H4s due to choppiness of read and extremely short content