### PR TITLE
fix: use camel case for stylized names

### DIFF
--- a/src/components/LeftNav/LeftNav.js
+++ b/src/components/LeftNav/LeftNav.js
@@ -83,7 +83,7 @@ export default class LeftNav extends React.Component {
                     to="/resources#github"
                     className="bx--side-nav--website-link"
                     element={Link}>
-                    Github Repos
+                    GitHub Repos
                   </SideNavLink>
                 </SideNavItems>
               </SideNav>

--- a/src/content/getting-started/developers/vanilla.md
+++ b/src/content/getting-started/developers/vanilla.md
@@ -43,7 +43,7 @@ $ yarn add carbon-components
     <li><a href="#cdn">CDN</a></li>
     <li><a href="#codepen">CodePen</a></li>
     <li><a href="#scss">SCSS</a></li>
-    <li><a href="#javascript">Javascript</a></li>
+    <li><a href="#javascript">JavaScript</a></li>
     <li><a href="#polyfills-for-older-browsers">Polyfills for older browsers</a></li>
     
 </ul>

--- a/src/content/guidelines/color/overview.md
+++ b/src/content/guidelines/color/overview.md
@@ -19,7 +19,7 @@ tabs: ['Overview', 'Usage']
     href="https://github.com/IBM/carbon-elements/tree/master/packages/colors"
     type="resource"
     >
-    <img src="images/sketch-icon.png" alt="Github"  />
+    <img src="images/sketch-icon.png" alt="GitHub"  />
 </clickable-tile>
 </grid-wrapper>
 

--- a/src/content/updates/migrating-to-carbon-x/migrating-to-carbon-x.md
+++ b/src/content/updates/migrating-to-carbon-x/migrating-to-carbon-x.md
@@ -34,7 +34,7 @@ Carbon X, aka v10, is currently in Alpha release. Please use this opportunity to
 
 The Beta release of Carbon X will arrive with a completely revised Sketch design kit, updated for the new IBM Design Language (f.k.a. "Duo"). All components in the kit have been reskinned, and colors, icons, typrography, UI shell, and grid elements will also reflect the new IBM Design Language.
 
-Internal IBM users will now be able to auto-sync the design kit with Box Drive, allowing users to update the Sketch library automatically. The manual download method will also still be available via the [Github repository](https://github.com/IBM/carbon-design-kit).
+Internal IBM users will now be able to auto-sync the design kit with Box Drive, allowing users to update the Sketch library automatically. The manual download method will also still be available via the [GitHub repository](https://github.com/IBM/carbon-design-kit).
 
 The Digital Design group has published a detailed guide on [setting up auto-sync for the design kit using Box Drive](https://www.ibm.com/standards/web/design-kit/).
 


### PR DESCRIPTION
Closes #949

Replace capitalized names with camel case names for trademarked names e.g. GitHub, JavaScript