### PR TITLE
fix: use correct capitalization for form style page

### DIFF
--- a/src/content/components/form/style.md
+++ b/src/content/components/form/style.md
@@ -25,7 +25,7 @@ Form inputs come in two different colors. The default input color is `$field-01`
 
 ## Typography
 
-Form headings and labels should be set in sentence case with the first letter of the first word capitalized. Please refer to the [Text Input](/components/text-input), [Dropdown](/components/dropdown), [Checkbox](/components/checkbox), [Radio button](/components/radio-button), [Toggle](/component/toggle), [Button](/component/button) pages for specific typography details on each component.
+Form headings and labels should be set in sentence case with the first letter of the first word capitalized. Please refer to the [text input](/components/text-input), [dropdown](/components/dropdown), [checkbox](/components/checkbox), [radio button](/components/radio-button), [toggle](/component/toggle), and [button](/component/button) pages for specific typography details on each component.
 
 | Property                       | Font-size (px/rem) | Font-weight     | Type style          |
 | ------------------------------ | ------------------ | --------------- | ------------------- |


### PR DESCRIPTION
Closes #984 

This PR avoids capitalizing references to components outside of headings and sentence openings