### PR TITLE
fix(images): fix images on mobile in safari

### DIFF
--- a/src/components/ImageComponent/image-component.scss
+++ b/src/components/ImageComponent/image-component.scss
@@ -46,9 +46,17 @@
 
   img.gatsby-resp-image-image {
     max-width: 736px;
-    width: 736px !important;
+    width: 100%;
     height: auto !important;
     position: relative !important;
+
+    @include breakpoint('sm') {
+      min-width: 368px !important;
+    }
+
+    @include breakpoint('md') {
+      width: 736px !important;
+    }
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/983

Adjusts image widths on mobile

cc @marijohannessen 