### PR TITLE
fix(tables): fixed overflow on page tables

### DIFF
--- a/src/components/PageTable/PageTable.js
+++ b/src/components/PageTable/PageTable.js
@@ -10,9 +10,16 @@ export default class PageTable extends React.Component {
   render() {
     const { children } = this.props;
 
-    let gridSize = children[1].props.children[0].props.children.length > 3 ? 'ibm--col-lg-12' : 'ibm--col-lg-8 ibm--col-md-6';
+    let gridSize =
+      children[1].props.children[0].props.children.length > 3
+        ? 'ibm--col-lg-12'
+        : 'ibm--col-lg-8 ibm--col-md-6';
 
-    const classNames = classnames(gridSize, 'ibm--offset-lg-4 ibm--col-bleed')
+    const classNames = classnames(
+      gridSize,
+      'ibm--offset-lg-4 ibm--col-bleed',
+      'page-table__container'
+    );
 
     return (
       <div className="ibm--row">

--- a/src/components/PageTable/page-table.scss
+++ b/src/components/PageTable/page-table.scss
@@ -83,3 +83,7 @@
     max-width: 50%;
   }
 }
+
+.page-table__container {
+  overflow-x: auto;
+}


### PR DESCRIPTION
Closes #948 
Closes #945 

Added a container className to the div surrounding the page tables and added `overflow-x: auto` to enable scrolling the table on smaller screens.
