### PR TITLE
fix(code-snippets): removed border-radius

### DIFF
--- a/src/components/ComponentDocs/component-docs.scss
+++ b/src/components/ComponentDocs/component-docs.scss
@@ -10,4 +10,5 @@ body .component-docs pre[class*='language-'] {
   background: $ui-05;
   padding: 1rem 3rem 2rem 1.5rem !important;
   margin-bottom: 1.5rem !important;
+  border-radius: 0;
 }


### PR DESCRIPTION
Closes #823 

Set `border-radius` to 0 to prevent rounded borders on the code snippets.