### PR TITLE
fix(snippet): two different type styles

### DIFF
--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -80,13 +80,21 @@ body {
   li > code,
   td > code {
     @include reset;
-    @include type-style('code-01');
     position: relative;
     display: inline;
     padding: rem(1px) $spacing-xs;
     background: transparent;
     border-radius: 4px;
     background-color: $ibm-colors__gray-20;
+  }
+
+  td > code {
+    @include type-style('code-01');
+  }
+
+  p > code,
+  li > code {
+    @include type-style('code-02');
   }
 
   // HR dividers


### PR DESCRIPTION
Custom fixes for @jeanservaas 

Snippets that appear in text blocks are `code-02`, while snippets in tables are `code-01`