### PR TITLE
fix(captions): adjust caption width, based on grid now

### DIFF
--- a/src/components/DoDontExample/do-dont-example.scss
+++ b/src/components/DoDontExample/do-dont-example.scss
@@ -157,14 +157,30 @@ p.example__description {
   position: relative;
 }
 
+.ibm--col-lg-12 > .example--full-width .example__caption {
+  width: 100%;
+
+  @include breakpoint('md') {
+    width: 75%;
+  }
+
+  @include breakpoint('xlg') {
+    width: 50%;
+  }
+}
+
 .example--full-width .example__caption {
   @include breakpoint('sm') {
     width: 100%;
   }
 
   @include breakpoint('md') {
-    width: calc(50% - 16px);
+    width: 75%;
   }
+
+  // @include breakpoint('xlg') {
+  //   width: 70%;
+  // }
 }
 
 .example span.gatsby-resp-image-wrapper {

--- a/src/components/DoDontExample/do-dont-example.scss
+++ b/src/components/DoDontExample/do-dont-example.scss
@@ -124,7 +124,14 @@ p.example__text {
 p.example__title {
   @include carbon--type-style('body-short-01');
   margin: 0;
-  padding: 0 25% 0 0;
+
+  @media (orientation: landscape) {
+    padding: 0 25% 0 0;
+  }
+
+  @include breakpoint('md') {
+    padding: 0 25% 0 0;
+  }
 }
 
 p.example__description {

--- a/src/components/ImageComponent/ImageComponent.js
+++ b/src/components/ImageComponent/ImageComponent.js
@@ -48,7 +48,7 @@ class ImageComponent extends Component {
           <div className={imgComponentClasses}>{children}</div>
         </div>
         {caption && (
-          <div className="ibm--col-lg-6 ibm--offset-lg-4">
+          <div className="ibm--col-lg-4 ibm--col-md-4 ibm--offset-lg-4">
             <p className="image-component__caption">{caption}</p>
           </div>
         )}

--- a/src/content/guidelines/motion/basics.mdx
+++ b/src/content/guidelines/motion/basics.mdx
@@ -234,5 +234,5 @@ We are working on making dynamic duration a build-in feature for all Carbon comp
 
 | Style      | Token                   | Value |
 | ---------- | ----------------------- | ----- |
-| Productive | \$transition--base      | 100ms |
-| Expressive | \$transition--expansion | 150ms |
+| Productive | `$transition--base`      | 100ms |
+| Expressive | `$transition--expansion` | 150ms |

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -201,17 +201,8 @@ img[src*='gif'] {
     color: $text-01;
     display: block;
 
-    @include breakpoint('lg') {
-      padding-right: 35%;
-    }
-
-    @include breakpoint('lg') {
-      padding-right: 44%;
-    }
-
     &:first-child {
       padding-top: $spacing-xs;
-      // margin-top: -4rem; //needed because of default image spacing
     }
   }
 }


### PR DESCRIPTION
Adjusts caption paddings since image captions are now contained within a grid class.  

Captions also go full-width on mobile, but not on landscape 