### PR TITLE
docs(developers): deprecate src in vanilla NPM package

### DIFF
--- a/src/content/getting-started/developers/vanilla.md
+++ b/src/content/getting-started/developers/vanilla.md
@@ -41,7 +41,7 @@ carbon-components/
 │   └── index.js
 ├── es
 │   └── index.js
-└── src
+└── src (Deprecated and subject to breaking changes, please use es/umd/scss instead)
 ```
 
 ### CDN


### PR DESCRIPTION
Refs [IBM/carbon-components#1890](https://github.com/IBM/carbon-components/issues/1890).

#### Changelog

**New**

- A note that `src` directory in vanilla NPM package has been deprecated. The package historically included `src` directory. This technically locks the list of Babel plugins used against our source code, which is unfortunate because we'd want to use some newer specs like [optional catch binding](https://babeljs.io/docs/en/next/babel-plugin-proposal-optional-catch-binding.html).