### PR TITLE
fix: Lead space update

### DIFF
--- a/docs/CONTENT.md
+++ b/docs/CONTENT.md
@@ -34,7 +34,6 @@ The top of each markdown file has required frontmatter fields to display the hea
 
 ```
 ---
-label: Optional paragraph of text at the top of a page (Used only in Guidelines pages)
 title: Page title
 tabs: ['Tab 1', 'Tab 2', 'Tab 3'']
 internal: true

--- a/src/components/Homepage/homepage.scss
+++ b/src/components/Homepage/homepage.scss
@@ -29,7 +29,7 @@
   // Match max height at lg breakpoint
   @include breakpoint('lg') {
     padding: 0;
-    height: 512px;
+    height: 560px;
   }
 }
 

--- a/src/components/PageHeader/PageHeader.js
+++ b/src/components/PageHeader/PageHeader.js
@@ -3,24 +3,8 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 
 const PageHeader = ({ children, label, title }) => {
-  let labelContent =
-    label != null ? (
-      <header className="ibm--grid page-header__label-wrapper">
-        <div className="ibm--row">
-          <div className="ibm--col-lg-6 ibm--col-md-4 ibm--offset-lg-4">
-            <p className="page-header__label">{label}</p>
-          </div>
-        </div>
-      </header>
-    ) : null;
-
-  const classNames = classnames('page-header', {
-    'page-header--md': label != null,
-  });
-
   return (
-    <div className={classNames}>
-      {labelContent}
+    <div className="page-header">
       <div className="ibm--grid">
         <div className="ibm--row">
           <div className="ibm--col-lg-12 ibm--offset-lg-4">

--- a/src/components/PageHeader/page-header.scss
+++ b/src/components/PageHeader/page-header.scss
@@ -8,10 +8,6 @@
   height: rem(240px);
 }
 
-.page-header--md {
-  height: rem(320px);
-}
-
 .ibm--grid.page-header__label-wrapper {
   padding-top: rem(24px);
   margin-bottom: auto;

--- a/src/content/components/data-table/code.mdx
+++ b/src/content/components/data-table/code.mdx
@@ -1,5 +1,4 @@
 ---
-label: Component
 title: Data table
 tabs: ['Code', 'Usage', 'Style']
 ---

--- a/src/content/components/data-table/style.mdx
+++ b/src/content/components/data-table/style.mdx
@@ -1,22 +1,21 @@
 ---
-label: Component
 title: Data table
 tabs: ['Code', 'Usage', 'Style']
 ---
 
 ## Color
 
-| Class                                                                                                                 | Property                              | SCSS       | HEX                    |
-| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ---------- | ---------------------- |
-| `.bx--data-table-v2 tbody`                                                                                            | background-color                      | $ui-01     | #ffffff                |
-| `.bx--data-table-v2--zebra tbody tr:nth-child(even)`                                                                  | background-color                      | $ui-02     | #f4f7fb                |
-| `.bx--data-table-v2 thead`                                                                                            | background-color                      | $ui-02     | #f4f7fb                |
-| `.bx--data-table-v2 tr:hover td`                                                                                      | background-color                      | $hover-row | #5596e6 at 10% opacity |
-| `tr.bx--expandable-row-v2 > td:first-of-type:before`                                                                  | background-color                      | $brand-01  | #3d70b2                |
-| `.bx--data-table-v2 th:first-of-type`   <br/> `.bx--data-table-v2 th:last-of-type`   <br/> `.bx--data-table-v2 th`        | border-top, border-right, border-left | $ui-04     | #8897a2                |
-| `.bx--data-table-v2 tr:hover td`                                                                                      | border                                | $brand-01  | #3d70b2                |
-| `.bx--responsive-table td`   <br/> `.bx--responsive-table th`   <br/> `.bx--table-sort-v2`   <br/> `--data-table-v2-header` | color                                 | $text-01   | #152935                |
-| `.bx--table-sort-v2__icon`   <br/> `.bx--table-expand-v2__svg`   <br/> `.bx--overflow-menu__icon`                         | fill                                  | ui-05      | #5a6872                |
+| Class                                                                                                                 | Property                              | SCSS        | HEX                    |
+| --------------------------------------------------------------------------------------------------------------------- | ------------------------------------- | ----------- | ---------------------- |
+| `.bx--data-table-v2 tbody`                                                                                            | background-color                      | \$ui-01     | #ffffff                |
+| `.bx--data-table-v2--zebra tbody tr:nth-child(even)`                                                                  | background-color                      | \$ui-02     | #f4f7fb                |
+| `.bx--data-table-v2 thead`                                                                                            | background-color                      | \$ui-02     | #f4f7fb                |
+| `.bx--data-table-v2 tr:hover td`                                                                                      | background-color                      | \$hover-row | #5596e6 at 10% opacity |
+| `tr.bx--expandable-row-v2 > td:first-of-type:before`                                                                  | background-color                      | \$brand-01  | #3d70b2                |
+| `.bx--data-table-v2 th:first-of-type` <br/> `.bx--data-table-v2 th:last-of-type` <br/> `.bx--data-table-v2 th`        | border-top, border-right, border-left | \$ui-04     | #8897a2                |
+| `.bx--data-table-v2 tr:hover td`                                                                                      | border                                | \$brand-01  | #3d70b2                |
+| `.bx--responsive-table td` <br/> `.bx--responsive-table th` <br/> `.bx--table-sort-v2` <br/> `--data-table-v2-header` | color                                 | \$text-01   | #152935                |
+| `.bx--table-sort-v2__icon` <br/> `.bx--table-expand-v2__svg` <br/> `.bx--overflow-menu__icon`                         | fill                                  | ui-05       | #5a6872                |
 
 ### Style options
 
@@ -30,7 +29,7 @@ If zebra striping is turned off, you must have row dividers.
 
 _Data table with various row styling_
 
-<br/>
+<br />
 
 **Background colors**
 
@@ -88,9 +87,9 @@ After the simple table structure, tables can be enhanced by adding any of the fo
 
 | Class                                                                            | Property                    | px / rem  | Spacing token |
 | -------------------------------------------------------------------------------- | --------------------------- | --------- | ------------- |
-| `.bx--data-table-v2-header`                                                      | margin-bottom               | 16 / 1    | $spacing-md   |
-| `.bx--table-sort-v2__icon`                                                       | padding                     | 2 / 0.125 | $spacing-3xs  |
-| `.bx--data-table-v2 td:first-of-type`   <br/> `.bx--data-table-v2 td:last-of-type` | padding-left, padding-right | 24 / 1.5  | $spacing-lg   |
+| `.bx--data-table-v2-header`                                                      | margin-bottom               | 16 / 1    | \$spacing-md  |
+| `.bx--table-sort-v2__icon`                                                       | padding                     | 2 / 0.125 | \$spacing-3xs |
+| `.bx--data-table-v2 td:first-of-type` <br/> `.bx--data-table-v2 td:last-of-type` | padding-left, padding-right | 24 / 1.5  | \$spacing-lg  |
 
 _Structure and spacing measurements for a basic and an enhanced data table | px / rem_
 
@@ -98,15 +97,14 @@ _Structure and spacing measurements for a basic and an enhanced data table | px 
 
 | Spacing between | Property | px/rem     | Spacing token |
 | --------------- | -------- | ---------- | ------------- |
-| Columns         | padding  | ≥ 24 / 1.5 | $spacing-lg   |
+| Columns         | padding  | ≥ 24 / 1.5 | \$spacing-lg  |
 
 ### Toolbar
 
 | Class                      | Property                  | px/rem   | Spacing token |
 | -------------------------- | ------------------------- | -------- | ------------- |
-| `.bx--toolbar-action_icon` | height                    | 16 / 1   | $spacing-md   |
-| `.bx--toolbar > div`       | margin-left, margin-right | 4 / 0.25 | $spacing-2xs  |
-| `.bx--toolbar`             | margin-top, margin-bottom | 16 / 1   | $spacing-md   |
-
+| `.bx--toolbar-action_icon` | height                    | 16 / 1   | \$spacing-md  |
+| `.bx--toolbar > div`       | margin-left, margin-right | 4 / 0.25 | \$spacing-2xs |
+| `.bx--toolbar`             | margin-top, margin-bottom | 16 / 1   | \$spacing-md  |
 
 _Structure and spacing measurements for toolbar icons | px / rem_

--- a/src/content/components/data-table/usage.mdx
+++ b/src/content/components/data-table/usage.mdx
@@ -1,5 +1,4 @@
 ---
-label: Component
 title: Data table
 tabs: ['Code', 'Usage', 'Style']
 ---

--- a/src/content/guidelines/accessibility/color.mdx
+++ b/src/content/guidelines/accessibility/color.mdx
@@ -4,11 +4,6 @@ title: Accessibility
 tabs: ['Overview', 'Color', 'Keyboard', 'Developers']
 ---
 
-import GridWrapper from '../../../../src/components/GridWrapper';
-
-import ClickableTile from '../../../../src/components/ClickableTile';
-
-
 ## Resources
 
 <GridWrapper col_lg="8" flex="true" bleed="true">

--- a/src/content/guidelines/color/overview.mdx
+++ b/src/content/guidelines/color/overview.mdx
@@ -1,8 +1,9 @@
 ---
-label: Color is a foundational element of Carbon. Careful application of color drives consistency, engagement, and focus for all user interfaces.
 title: Color
 tabs: ['Overview', 'Usage']
 ---
+
+### Color is a foundational element of Carbon. Careful application of color drives consistency, engagement, and focus for all user interfaces.
 
 ## Resources
 

--- a/src/content/updates/design-language/design-language.mdx
+++ b/src/content/updates/design-language/design-language.mdx
@@ -1,5 +1,4 @@
 ---
-label: Updates
 title: IBM Design Language
 ---
 


### PR DESCRIPTION
Closes #1189 


#### Changelog

* Change leadspace height from (Medium to Small --  320px to 240px) in Guidelines to match the rest of the site
* Remove intro sentences from the leadspace
* Change homepage leadspace to 560px to match Language 

@jeanservaas I moved the heading for the color overview page only to a h3 so you could see what it looked like. 