### PR TITLE
fix(docs) experimental/ui-shell/usage header fix

### DIFF
--- a/src/content/experimental/ui-shell/usage.mdx
+++ b/src/content/experimental/ui-shell/usage.mdx
@@ -16,7 +16,7 @@ tabs: ['Code', 'Usage']
 
 The UI Shell is the top level in a product's UI. The Shell consists of the primary **header** and **footer**, as well as **header panels** that are used for navigation and global UI services. The shell is further divided into 3 distinct "zones" which establish purpose and level of control.
 
-###Global zone
+### Global zone
 The global zone holds the IBM global platform switcher, which allows the user to quickly navigate between different IBM platforms. This zone cannot be altered by the platform or product owner.
 
 <ImageComponent cols="12">
@@ -25,7 +25,7 @@ The global zone holds the IBM global platform switcher, which allows the user to
 
 </ImageComponent>
 
-###Platform zone
+### Platform zone
 The platform zone contains platform-level elements, which could include functions like search, docs, support, profile, and notifications. Platform owners can also choose to include custom top-nav text links in this zone.
 
 <ImageComponent cols="12">
@@ -34,7 +34,7 @@ The platform zone contains platform-level elements, which could include function
 
 </ImageComponent>
 
-###Local zone
+### Local zone
 The local zone is controlled at the product level. It contains the product-level side nav as well as the main content area.
 
 <ImageComponent cols="12">


### PR DESCRIPTION
Closes #1199 

Markdown header declaration was being exposed due to it missing a space between the `###` and header text

![image](https://user-images.githubusercontent.com/5033303/53444181-15e93b00-39d3-11e9-9c4f-514aa76831c6.png)

