### PR TITLE
Weird contradictory guidance on link>style, and a tweak to What's New

### DIFF
--- a/src/content/components/link/style.mdx
+++ b/src/content/components/link/style.mdx
@@ -27,7 +27,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 ## Typography
 
-Link text should be set in set in sentence case with the first letter of each word capitalized. Links should not exceed three words.
+Links should not exceed three words.
 
 | Property    | Font-size (px/rem) | Font-weight   | Text style       |
 | ----------- | ------------------ | ------------- | ---------------- |

--- a/src/content/updates/whats-new/whats-new.mdx
+++ b/src/content/updates/whats-new/whats-new.mdx
@@ -4,9 +4,9 @@ title: What’s new
 
 ## February 2019
 
-The Carbon X launch is just around the corner, and we've officially entered Beta! That means the core team has been hard at work ensuring the new system is ready to ship. We've got tons of improvements headed your way, including implementation of the new IBM Design Language and an all-new website.
+The Carbon X launch is just around the corner, and we've officially entered Beta! That means the core team has been hard at work ensuring the new system is ready to ship. We have tons of improvements headed your way, including implementation of the new IBM Design Language and an all-new website.
 
-We expect X to launch mid-March, so keep your eyes peeled. If you're interested in getting started as soon as possible, we're always looking for beta testers to help us squash bugs and improve the Carbon Design System.
+We expect X to launch mid-March, so keep your eyes peeled. If you're interested in getting started before our public launch, we're always looking for beta testers to help us squash bugs and improve the Carbon Design System.
 
 
 ## **Archive**


### PR DESCRIPTION
There was weird contradictory guidance on Components>Link>Style page which I removed. Also a small tweak on the "What's new" page.

#### Changelog

**Changed**

- Wording tweak on What's new page.

**Removed**

- Unnecessary contradictory guidance on link page.
