### PR TITLE
Fix contribution link on home page and footer

### DIFF
--- a/packages/addons-website/src/components/WebsiteFooter/WebsiteFooter-story.js
+++ b/packages/addons-website/src/components/WebsiteFooter/WebsiteFooter-story.js
@@ -8,7 +8,7 @@ storiesOf('Website Footer', module).add(
     <WebsiteFooter
       logoOffset={true}
       linksCol1={[
-        { href: '/contributing/designers/governance', linkText: 'Contribute' },
+        { href: '/contributing/governance', linkText: 'Contribute' },
         { href: 'https://www.ibm.com/privacy', linkText: 'Privacy' },
         { href: 'https://www.ibm.com/legal', linkText: 'Terms of Use' },
         { href: 'https://www.ibm.com', linkText: 'IBM.com' },

--- a/packages/addons-website/src/components/WebsiteFooter/WebsiteFooter-story.js
+++ b/packages/addons-website/src/components/WebsiteFooter/WebsiteFooter-story.js
@@ -8,7 +8,7 @@ storiesOf('Website Footer', module).add(
     <WebsiteFooter
       logoOffset={true}
       linksCol1={[
-        { href: '/contributing/designers', linkText: 'Contribute' },
+        { href: '/contributing/designers/governance', linkText: 'Contribute' },
         { href: 'https://www.ibm.com/privacy', linkText: 'Privacy' },
         { href: 'https://www.ibm.com/legal', linkText: 'Terms of Use' },
         { href: 'https://www.ibm.com', linkText: 'IBM.com' },

--- a/src/components/Homepage/Homepage.js
+++ b/src/components/Homepage/Homepage.js
@@ -83,7 +83,7 @@ export class HomepageFooter extends React.Component {
                   interested in contributing, check out our contributing
                   guidelines to get started.
                 </h2>
-                <Link to="/contributing" alt="Start contributing">
+                <Link to="/contributing/governance" alt="Start contributing">
                   Start contributing
                   <ArrowRight24 aria-label="Start Contributing" />
                 </Link>


### PR DESCRIPTION
The "start contributing" link on the home page was going to a 404.

The link to contribute in the footer was only going to Designer contribution.

I pointed these both to contribution/governance which gives an overview and starting point about our contribution process.