### PR TITLE
fix(inline-loading): change Inline Loading example button to --sm variant

### DIFF
--- a/src/html/inline-loading/inline-loading.html
+++ b/src/html/inline-loading/inline-loading.html
@@ -7,11 +7,29 @@
         <circle class="bx--loading__stroke" cx="0" cy="0" r="37.5" />
       </svg>
     </div>
-    <svg data-inline-loading-finished hidden class="bx--inline-loading__checkmark-container bx--inline-loading__svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10">
-      <polyline class="bx--inline-loading__checkmark" points="0.74 3.4 3.67 6.34 9.24 0.74"></polyline>
+    <svg
+      data-inline-loading-finished
+      hidden
+      class="bx--inline-loading__checkmark-container bx--inline-loading__svg"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 10 10"
+    >
+      <polyline
+        class="bx--inline-loading__checkmark"
+        points="0.74 3.4 3.67 6.34 9.24 0.74"
+      ></polyline>
     </svg>
   </div>
-  <p data-inline-loading-text-active class="bx--inline-loading__text">Loading data...</p>
-  <p data-inline-loading-text-finished hidden class="bx--inline-loading__text">Data loaded.</p>
+  <p data-inline-loading-text-active class="bx--inline-loading__text">
+    Loading data...
+  </p>
+  <p data-inline-loading-text-finished hidden class="bx--inline-loading__text">
+    Data loaded.
+  </p>
 </div>
-  <button data-inline-loading-demo-button class="bx--btn bx--btn--primary">Toggle state</button>
+<button
+  data-inline-loading-demo-button
+  class="bx--btn bx--btn--primary bx--btn--sm"
+>
+  Toggle state
+</button>


### PR DESCRIPTION
Closes [#1906](https://github.com/IBM/carbon-components/issues/1906)

A `--sm` button was requested to make the documentation example less clunky looking.

#### Changelog

**Changed**

- added `bx--btn--sm` to the Inline Loading button component in inline-loading.html
