### PR TITLE
Add-disclaimer-icons

### DIFF
--- a/src/content/guidelines/iconography/library.mdx
+++ b/src/content/guidelines/iconography/library.mdx
@@ -4,6 +4,12 @@ title: Iconography
 tabs: ['Library', 'Usage', 'Contribution']
 ---
 
+## About the icon library
+
+This library page is for visual reference only. Please do not copy icons directly from this page for production work. 
+
+For designers, the icons are accessible as a Sketch library via the [IBM Design Language kit](https://www.ibm.com/standards/web/design-kit/). For developers, the icons are available via the [Carbon icons package](https://github.com/IBM/carbon-elements/tree/master/packages).
+
 import IconLibrary from '../../../../src/components/IconLibrary';
 
 <IconLibrary />


### PR DESCRIPTION
Adds clarifying language to the top of the Icons Library page to prevent situations like this:

https://ibm-studios.slack.com/archives/GCPF37GEB/p1552319536014500