### PR TITLE
fix:spacing tokens

### DIFF
--- a/src/content/guidelines/spacing/spacing.mdx
+++ b/src/content/guidelines/spacing/spacing.mdx
@@ -36,7 +36,6 @@ margin-right: $layout-05;
 padding: $spacing-04;
 padding: $layout-05 $layout-03;
 padding: $spacing-07 $spacing-04 0 $spacing-04;
-padding-left: $spacing-auto;
 ```
 
 ## Spacing scale

--- a/src/content/guidelines/spacing/spacing.mdx
+++ b/src/content/guidelines/spacing/spacing.mdx
@@ -29,13 +29,13 @@ Carbon has two spacing scales; one for general spacing within components and the
 Both the _spacing_ and the _layout_ scales can be applied to `margin` or `padding` properties. Likewise, these spacing tokens can be applied to both vertical and horizontal edges. The token takes the place of the values normally assigned to `margin` and `padding`. The following are all approved ways to syntactically apply Carbon spacing tokens:
 
 ```css
-margin: $spacing-xs;
-margin: $layout-sm $layout-2xs;
-margin: $spacing-xl 0 $spacing-sm 0;
-margin-right: $layout-lg;
-padding: $spacing-sm;
-padding: $layout-lg $layout-sm;
-padding: $spacing-xl $spacing-sm 0 $spacing-sm;
+margin: $spacing-03;
+margin: $layout-03 $layout-01;
+margin: $spacing-07 0 $spacing-04 0;
+margin-right: $layout-05;
+padding: $spacing-04;
+padding: $layout-05 $layout-03;
+padding: $spacing-07 $spacing-04 0 $spacing-04;
 padding-left: $spacing-auto;
 ```
 


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/carbon-website/issues/1300

Updated the tokens in the spacing example
## Old (broken)
![image](https://user-images.githubusercontent.com/19270502/54438209-3835c500-4704-11e9-906a-717f37a22846.png)


## New (fixed)
<img width="821" alt="Screen Shot 2019-03-15 at 9 23 31 AM" src="https://user-images.githubusercontent.com/19270502/54438220-3f5cd300-4704-11e9-84b9-7f7b52ab4ff4.png">
