### PR TITLE
Fix(site):Change button in top banner to short

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -233,7 +233,7 @@ class Layout extends React.Component {
                 className="website-alert__button"
                 tabIndex="-1"
                 href=" https://www.carbondesignsystem.com">
-                <button class="bx--btn bx--btn--secondary" type="button">
+                <button class="bx--btn bx--btn--secondary bx--btn--sm" type="button">
                   <span>Go to v9</span>
                   <ArrowRight20 />
                 </button>


### PR DESCRIPTION
The top banner was using the primary button which is taller than the banner and caused the text to be off center. This PR changes the button back to the short secondary. 

Left: Expected. Right: Current


![Screen Shot 2019-03-21 at 8 49 22 AM](https://user-images.githubusercontent.com/19270502/54756458-437e6a00-4bb6-11e9-92c4-69382da68060.png)
