### PR TITLE
Revert typography

### DIFF
--- a/src/content/guidelines/typography/overview.mdx
+++ b/src/content/guidelines/typography/overview.mdx
@@ -1,7 +1,7 @@
 ---
 label: When used properly, typography can help create clear hierarchies, organize information, and guide users through the product or experience.
 title: Typography
-tabs: ['Overview', 'Productive', 'Expressive']
+tabs: ['Overview', 'Productive']
 ---
 
 import TypeScaleTable from '../../../../src/components/TypeScaleTable';

--- a/src/content/guidelines/typography/productive.mdx
+++ b/src/content/guidelines/typography/productive.mdx
@@ -1,10 +1,11 @@
 ---
 label: When used properly, typography can help create clear hierarchies, organize information, and guide users through the product or experience.
 title: Typography
-tabs: ['Overview', 'Productive', 'Expressive']
+tabs: ['Overview', 'Productive']
 ---
 
 import TypesetStyle from '@carbon/addons-website/src/components/TypesetStyle';
+import TypeSpec from '../../../../src/components/TypeSpec';
 
 ## IBM Productive type set
 
@@ -16,6 +17,113 @@ Even though IBM Plex contains a wide range of scales, it’s important to use cu
 
 <br />
 
+
+<TypeSpec token="code-01" description="This is for inline code snippets and smaller code elements.">
+Type: IBM Plex Mono<br/>
+Size: 12px / .75rem<br/>
+Line height: 16px / 1rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: .32px
+</TypeSpec>
+<TypeSpec token="code-02" description="This is for large code snippets and larger code elements.">
+Type: IBM Plex Mono<br/>
+Size: 14px / .875rem<br/>
+Line height: 20px / 1.25rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: .32px
+</TypeSpec>
+<TypeSpec token="label-01" description="This is for field labels in components and error messages.">
+Type: IBM Plex Sans<br/>
+Size: 12px / .75rem<br/>
+Line height: 16px / 1rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: .32px
+</TypeSpec>
+<TypeSpec token="helper-text-01" description="This is for explanatory helper text that appears below a field title within a component.">
+Type: IBM Plex Sans<br/>
+Size: 12px / .75rem<br/>
+Line height: 16px / 1rem <br/>
+Weight: 400 / Italic<br/>
+Letter-spacing: .32px
+</TypeSpec>
+
+#### Body
+
+<br />
+
+<TypeSpec token="body-short-01" description="This is for short paragraphs with no more than four lines and is commonly used in components.">
+Type: IBM Plex Sans<br/>
+Size: 14px / .875rem<br/>
+Line height: 18px / 1.125rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: .16px
+</TypeSpec>
+<TypeSpec token="body-long-01" description="This is commonly used in both the expressive and the productive type theme layouts for long paragraphs with more than four lines. It is a good size for comfortable, long-form reading. We also use this for longer body copy in components such as accordion or structured list. Always left-align this type; never center it.">
+Type: IBM Plex Sans<br/>
+Size: 14px / .875rem<br/>
+Line height: 20px / 1.25rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: .16px
+</TypeSpec>
+<TypeSpec token="body-short-02" description="This is for short paragraphs with no more than four lines and is commonly used in the expressive type theme for layouts.">
+Type: IBM Plex Sans<br/>
+Size: 16px / 1rem<br/>
+Line height: 22px / 1.375rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: 0
+</TypeSpec>
+<TypeSpec token="body-long-02" description="This is commonly used in the expressive type theme layouts for long paragraphs with more than four lines. The looser line height and larger size makes for comfortable, long-form reading, in mediums that allow for more space. This type size is rarely used for body copy in components. Always left-align type; never center it.">
+Type: IBM Plex Sans<br/>
+Size: 16px / 1rem<br/>
+Line height: 24px / 1.5rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: 0
+</TypeSpec>
+
+#### Headings
+
+<br />
+
+<TypeSpec token="heading-01" description="This is for component and layout headings.">
+Type: IBM Plex Sans<br/>
+Size: 14px / .875rem<br/>
+Line height: 18px / 1.125rem <br/>
+Weight: 600 / Semi-bold<br/>
+Letter-spacing: .16px
+</TypeSpec>
+<TypeSpec token="heading-02" description="This is for component and layout headings.">
+Type: IBM Plex Sans<br/>
+Size: 16px / 1rem<br/>
+Line height: 22px / 1.375rem <br/>
+Weight: 600 / Semi-bold<br/>
+Letter-spacing: 0px
+</TypeSpec>
+<TypeSpec token="productive-heading-03" description="This is for component and layout headings.">
+Type: IBM Plex Sans<br/>
+Size: 20px / 1.25rem<br/>
+Line height: 26px / 1.625rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: 0px
+</TypeSpec>
+<TypeSpec token="productive-heading-04" description="This is for layout headings.">
+Type: IBM Plex Sans<br/>
+Size: 28px / 1.75rem<br/>
+Line height: 36px / 2.25rem <br/>
+Weight: 400 / Regular<br/>
+Letter-spacing: 0px
+</TypeSpec>
+<TypeSpec token="productive-heading-05" description="This is for layout headings.">
+Type: IBM Plex Sans<br/>
+Size: 36px / 2.25rem<br/>
+Line height: 44px / 2.75rem <br/>
+Weight: 300 / Light<br/>
+Letter-spacing: 0px
+</TypeSpec>
+
+<!--
+
 <TypesetStyle breakpointControls={false} 
               title="Productive" 
               typesets="caption,label,helperText,code,body,heading,productHeading" />
+
+              -->

--- a/src/content/guidelines/typography/productive.mdx
+++ b/src/content/guidelines/typography/productive.mdx
@@ -15,8 +15,9 @@ The Productive styles below introduce the new IBM Design Language tokens. The di
 
 Even though IBM Plex contains a wide range of scales, it’s important to use curated sets below for their specified purpose. For consistent, reliable performance across various screen sizes, do not use fluid type in components or in product UI.
 
-<br />
+_The Editorial type set tab is coming soon._
 
+<br />
 
 <TypeSpec token="code-01" description="This is for inline code snippets and smaller code elements.">
 Type: IBM Plex Mono<br/>

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -59,6 +59,10 @@ body {
     }
   }
 
+  em {
+    font-style: italic;
+  }
+
   > div > div:first-child p {
     padding-bottom: 0;
   }

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -4,6 +4,7 @@
 body {
   background: $ui-01;
   font-family: $font-family;
+  
 }
 
 .side-nav + div, //Issue #51 weird bug where sometimes on reload of the page the classnames on container div disapear
@@ -48,9 +49,9 @@ body {
   // All paragraphs on Markdown pages
   // And divs when markdown doesn't wrap text in paragraphs (when you have to use html for links to open in a new window)
   p {
-    //max-width: 38rem;
-    line-height: 1.5;
+    @include carbon--type-style('body-long-02');
     padding: 0 0 $spacing-lg;
+
 
     &:empty {
       padding: 0;

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -4,7 +4,6 @@
 body {
   background: $ui-01;
   font-family: $font-family;
-  
 }
 
 .side-nav + div, //Issue #51 weird bug where sometimes on reload of the page the classnames on container div disapear


### PR DESCRIPTION
@jeanservaas this removes the expressive page and reverts productive page for now until we can work out the last few issues w/ the component. 


_this also fixes a font size issue that got merged in late last week_