### PR TITLE
FIX: Fixed broken link on getting started/designers

### DIFF
--- a/src/content/getting-started/designers/designers.mdx
+++ b/src/content/getting-started/designers/designers.mdx
@@ -38,7 +38,7 @@ Carbon empowers designers to rapidly build beautiful and accessible experiences.
 
   <ClickableTile
     title="Download the IBM 2x Grid template"
-    href="https://client.sketch.cloud/v1/documents/b10cdce8-6f00-40be-982e-8f3bec7b99a4/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6ImIxMGNkY2U4LTZmMDAtNDBiZS05ODJlLThmM2JlYzdiOTlhNCIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTUyNjE3Nzk2LCJpYXQiOjE1NTI2MTQxOTYsImlzcyI6Ikpva2VuIiwianRpIjoiMm01dnNvbHVyaGN1amRzamVvMDVvZnRoIiwibmJmIjoxNTUyNjE0MTk2fQ.JCwsDPUpyExiZ5GqBW1wY0_zUkuqGHKXuncYN9LvhCQ"
+    href="https://sketch.cloud/s/ngV7z"
     type="resource">
 
 ![](/images/sketch-icon.png)
@@ -53,7 +53,7 @@ Carbon empowers designers to rapidly build beautiful and accessible experiences.
 2. [**Add libraries**](#resources). Designing with Carbon requires subscribing to two libraries: The IBM Design Language kit and the Carbon kit. Click the tiles above to subscribe to each. Both libraries are required.
     - The [Carbon](sketch://add-library/cloud/JaVzz) library contains all Carbon component symbols, color swatches, text styles, and layer styles.
     - The [IBM Design Language](sketch://add-library/cloud/75VZZ) offers fonts, colors, icons, and other resources shared across all embodiments of the IBM Design Language.
-3. [**Download the grid template**](https://client.sketch.cloud/v1/documents/b10cdce8-6f00-40be-982e-8f3bec7b99a4/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6ImIxMGNkY2U4LTZmMDAtNDBiZS05ODJlLThmM2JlYzdiOTlhNCIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTUyNTk4MzEwLCJpYXQiOjE1NTI1OTQ3MTAsImlzcyI6Ikpva2VuIiwianRpIjoiMm01dXBhZXFrdjQzZWY1dTdnMDVjYjNoIiwibmJmIjoxNTUyNTk0NzEwfQ.W65i38VrMMZeKg0KvcOVsaJByBexOu1IYmKUZGJ1nug). Click on the Grid tile at the top of this page and, once downloaded, open the file in Sketch. Navigate to `File → Save as Template...`. You can now access the saved grid template at `File → New file from Template`.
+3. [**Download the grid template**](https://sketch.cloud/s/ngV7z). Click on the Grid tile at the top of this page and select `Download Document` from the right-side panel. Open the file in Sketch. Navigate to `File → Save as Template...`. You can now access the saved grid template at `File → New file from Template`.
 
 ## Getting started
 


### PR DESCRIPTION
Closes #1331

Download link was broken. Fixed link and corresponding guidance.

#### Changelog

**Changed**

- Download link was broken. Fixed link and corresponding guidance.

**Removed**

- Broken link
