### PR TITLE
feat: add link to load special characters from google fonts

### DIFF
--- a/src/html.js
+++ b/src/html.js
@@ -29,6 +29,8 @@ export default class HTML extends React.Component {
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
           />
+          {/* Stylesheet for special characters (↳) */}
+          <link href="https://fonts.googleapis.com/css?family=IBM+Plex+Mono|IBM+Plex+Sans|IBM+Plex+Sans+Condensed|IBM+Plex+Serif&text=%E2%86%B3" rel="stylesheet" />
         </body>
       </html>
     );


### PR DESCRIPTION
Closes #1321

**background:** 
- Safari no longer loads local font files other than system fonts. The google 
- fonts default stylesheet doesn't include the arrow character by default. 

**fix:** We can use the `text` beta feature of google fonts to specify the character and request that font file.

**new:** Add link to GF stylesheet with text query specifying our character. 

**note:** This feature isn't supported yet by the gatsby google fonts loading plugin. We can add encoded special characters to this link should we need more in the future.