### PR TITLE
fix(infrastructure): add polyfills to globalscope

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -19,6 +19,7 @@ module.exports = {
           default: require.resolve('./src/components/Layouts/index.js'),
         },
         globalScope: `
+        import '${__dirname}/src/polyfills';
         import { AnchorLinks } from '@carbon/addons-website';
         import { ImageComponent } from '@carbon/addons-website';
         import ClickableTile from '${__dirname}/src/components/ClickableTile';


### PR DESCRIPTION
Reference #1292 

Adds polyfills to MDX globalscope. Does **NOT** fix sidebar issues in IE11, however it does fix some issues with MDX pages in IE11 (ex: "Resources" page). 

I do not believe sidebar issues are related to the MDX implementation

#### Changelog

**New**

- polyfills in mdx globalScope
