### PR TITLE
fix: font size and spacing tweaks

### DIFF
--- a/src/components/ComponentReact/ComponentReact.js
+++ b/src/components/ComponentReact/ComponentReact.js
@@ -98,7 +98,7 @@ class ComponentReactExample extends Component {
         <div className="ibm--row">
           <div className="ibm--col-lg-12 ibm--offset-lg-4">
             <h2 className="page-h2">{name}</h2>
-            <p className="component-example__heading-label">
+            <p className="component-example__heading-label page-p">
               This component is currently only available in{' '}
               <a
                 href="https://github.com/ibm/carbon-components-react"

--- a/src/components/GlossaryList/GlossaryList.js
+++ b/src/components/GlossaryList/GlossaryList.js
@@ -38,11 +38,11 @@ class Glossary extends Component {
               <div id={wordId} key={word} className="glossary-entry__word">
                 <h4 className="page-h4 glossary-entry__word-heading">{word}</h4>
                 <p
-                  className="glossary-entry__desc"
+                  className="glossary-entry__desc page-p"
                   dangerouslySetInnerHTML={{ __html: desc }}
                 />
                 <p
-                  className="glossary-entry__subtext"
+                  className="glossary-entry__subtext page-p"
                   dangerouslySetInnerHTML={{ __html: subtext }}
                 />
               </div>

--- a/src/components/GlossaryList/glossary-list.scss
+++ b/src/components/GlossaryList/glossary-list.scss
@@ -6,14 +6,9 @@
   text-transform: lowercase;
 }
 
-.glossary-entry__desc {
-  padding-bottom: 0;
-}
-
 .glossary-entry__subtext {
   @include carbon--type-style('body-short-02');
   color: $text-02;
   font-style: italic;
   margin-top: 0.25rem;
-  padding-bottom: 0;
 }

--- a/src/components/markdown/markdown.scss
+++ b/src/components/markdown/markdown.scss
@@ -163,7 +163,7 @@
 
 .page-ul,
 .page-ol {
-  @include typescale('epsilon');
+  @include carbon--type-style('body-long-02');
   margin: 0 0 rem(24px) $spacing-lg;
   line-height: 1.5;
   position: relative;

--- a/src/data/components.json
+++ b/src/data/components.json
@@ -196,45 +196,6 @@
       }
     },
     {
-      "component": "Combo box",
-      "vanilla": {
-        "stable": false,
-        "experimental": false,
-        "new": false,
-        "updated": false,
-        "deprectated": false,
-        "underConstruction": false,
-        "notAvailable": true
-      },
-      "react": {
-        "stable": false,
-        "experimental": false,
-        "new": false,
-        "updated": false,
-        "deprectated": false,
-        "underConstruction": true,
-        "notAvailable": false
-      },
-      "angular": {
-        "stable": false,
-        "experimental": true,
-        "new": false,
-        "updated": false,
-        "deprectated": false,
-        "underConstruction": false,
-        "notAvailable": false
-      },
-      "vue": {
-        "stable": false,
-        "experimental": true,
-        "new": false,
-        "updated": false,
-        "deprectated": false,
-        "underConstruction": false,
-        "notAvailable": false
-      }
-    },
-    {
       "component": "Content switcher",
       "vanilla": {
         "stable": true,

--- a/src/styles/_page.scss
+++ b/src/styles/_page.scss
@@ -128,6 +128,10 @@ em {
   .bx--image-component > img {
     margin-bottom: 0;
   }
+
+  .bx--image-component__caption {
+    margin-bottom: 1.5rem;
+  }
 }
 
 .bx--platform-header {


### PR DESCRIPTION
Addresses @shixiedesign comments here https://github.com/carbon-design-system/carbon-website/pull/1369 

also fixes caption spacing @jeanservaas 

Hey Alison, not sure if you need visual review on this, but I noticed a few things. Could be future PR's fixes of course: 
- [x] Combo box should not be showing as a component on component overview. Because it's actually put together with Dropdown, considered a Dropdown variant.
![image](https://user-images.githubusercontent.com/15144993/55107488-738aa900-509f-11e9-9cf3-30ca5487b99e.png)
- [x] Some type sizes became small. Should be regular body copy:
Lists are affected:
Eg. https://deploy-preview-1369--carbon-website.netlify.com/components/checkbox/usage
![image](https://user-images.githubusercontent.com/15144993/55107605-b64c8100-509f-11e9-8f57-98e7a6671044.png)
Eg https://deploy-preview-1369--carbon-website.netlify.com/components/structured-list/usage
![image](https://user-images.githubusercontent.com/15144993/55107785-24914380-50a0-11e9-9e48-95e3e0626cb2.png)
Paragraph on https://deploy-preview-1369--carbon-website.netlify.com/components/dropdown/code
![image](https://user-images.githubusercontent.com/15144993/55107689-ee53c400-509f-11e9-96a1-043ca138b7e8.png)
- [x] Content / glossary page lost spacing, and some type became small (left preview, right Next site)
![image](https://user-images.githubusercontent.com/15144993/55107971-8ce02500-50a0-11e9-8e1e-f017da5bc4ab.png)
