### PR TITLE
[Icon page] Usage tab image fix

### DIFF
--- a/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
+++ b/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
@@ -7,8 +7,10 @@
         <rect id="Rectangle-3" x="0" y="0" width="352" height="352"></rect>
         <g id="Group-5" transform="translate(56.000000, 56.000000)">
             <g id="Group">
-                <g id="Group-Copy" transform="translate(74.621849, 74.621849)">
-                    <rect id="Rectangle" fill="#FFFFFF" x="0" y="0" width="101.848739" height="101.848739"></rect>
+                <rect id="Rectangle" stroke="#97C1FF" fill="#EDF4FF" x="0.5" y="0.5" width="239" height="239"></rect>
+                <rect id="Rectangle-Copy-26" stroke="#97C1FF" fill="#FFFFFF" x="68" y="68" width="104" height="104"></rect>
+                <g id="Group-2" transform="translate(69.000000, 69.000000)">
+                    <rect id="Rectangle" x="-4.97379915e-14" y="6.39488462e-14" width="101.848739" height="101.848739"></rect>
                     <g id="menu" transform="translate(12.731092, 19.096639)" fill="#000000" fill-rule="nonzero">
                         <rect id="Rectangle" x="0" y="57.289916" width="76.3865546" height="6.36554622"></rect>
                         <rect id="Rectangle" x="0" y="19.0966387" width="76.3865546" height="6.36554622"></rect>
@@ -16,8 +18,6 @@
                         <rect id="Rectangle" x="0" y="0" width="76.3865546" height="6.36554622"></rect>
                     </g>
                 </g>
-                <path d="M0.5,0.5 L0.5,239.5 L239.5,239.5 L239.5,0.5 L0.5,0.5 Z M73.1,73.1 L176.5,73.1 L176.5,176.5 L73.1,176.5 L73.1,73.1 Z" id="Combined-Shape" stroke="#97C1FF" fill="#EDF4FF"></path>
-                <rect id="Rectangle" stroke="#97C1FF" x="0.5" y="0.5" width="239" height="239"></rect>
             </g>
         </g>
     </g>

--- a/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
+++ b/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="352px" height="352px" viewBox="0 0 352 352" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
-    <title>iconography_usage_Padding-6</title>
+    <title>iconography_usage_Padding-6 Copy 2</title>
     <desc>Created with Sketch.</desc>
-    <g id="Padding-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="Padding-6-Copy-2" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <rect id="Rectangle-3" x="0" y="0" width="352" height="352"></rect>
         <g id="Group-5" transform="translate(56.000000, 56.000000)">
             <g id="Group">
                 <g id="Group-Copy" transform="translate(74.621849, 74.621849)">
-                    <rect id="Rectangle" x="0" y="0" width="101.848739" height="101.848739"></rect>
+                    <rect id="Rectangle" fill="#FFFFFF" x="0" y="0" width="101.848739" height="101.848739"></rect>
                     <g id="menu" transform="translate(12.731092, 19.096639)" fill="#000000" fill-rule="nonzero">
                         <rect id="Rectangle" x="0" y="57.289916" width="76.3865546" height="6.36554622"></rect>
                         <rect id="Rectangle" x="0" y="19.0966387" width="76.3865546" height="6.36554622"></rect>
@@ -16,62 +16,8 @@
                         <rect id="Rectangle" x="0" y="0" width="76.3865546" height="6.36554622"></rect>
                     </g>
                 </g>
-                <path d="M0,0 L240,0 L240,240 L0,240 L0,0 Z M73.6,73.6 L73.6,176 L176,176 L176,73.6 L73.6,73.6 Z" id="Combined-Shape" fill="#C3DAFF"></path>
-                <rect id="Rectangle" stroke="#DCDCDC" style="mix-blend-mode: multiply;" x="0.5" y="0.5" width="239" height="239"></rect>
-                <g id="Group-3" fill="#DCDCDC">
-                    <g id="Group-4">
-                        <rect id="Rectangle" style="mix-blend-mode: multiply;" x="0" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy" style="mix-blend-mode: multiply;" x="10.3913043" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-2" style="mix-blend-mode: multiply;" x="20.7826087" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-3" style="mix-blend-mode: multiply;" x="31.173913" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-27" style="mix-blend-mode: multiply;" x="41.5652174" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-28" style="mix-blend-mode: multiply;" x="51.9565217" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-29" style="mix-blend-mode: multiply;" x="62.3478261" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-30" style="mix-blend-mode: multiply;" x="72.7391304" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-31" style="mix-blend-mode: multiply;" x="83.1304348" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-32" style="mix-blend-mode: multiply;" x="93.5217391" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-33" style="mix-blend-mode: multiply;" x="103.913043" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-34" style="mix-blend-mode: multiply;" x="114.304348" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-35" style="mix-blend-mode: multiply;" x="124.695652" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-36" style="mix-blend-mode: multiply;" x="135.086957" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-37" style="mix-blend-mode: multiply;" x="145.478261" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-38" style="mix-blend-mode: multiply;" x="155.869565" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-39" style="mix-blend-mode: multiply;" x="166.26087" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-40" style="mix-blend-mode: multiply;" x="176.652174" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-41" style="mix-blend-mode: multiply;" x="187.043478" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-42" style="mix-blend-mode: multiply;" x="197.434783" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-43" style="mix-blend-mode: multiply;" x="207.826087" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-44" style="mix-blend-mode: multiply;" x="218.217391" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-45" style="mix-blend-mode: multiply;" x="228.608696" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-46" style="mix-blend-mode: multiply;" x="239" y="0" width="1" height="240"></rect>
-                    </g>
-                    <g id="Group-2" transform="translate(120.000000, 120.000000) rotate(90.000000) translate(-120.000000, -120.000000) translate(-0.000000, -0.000000)">
-                        <rect id="Rectangle" style="mix-blend-mode: multiply;" x="0" y="0" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy" style="mix-blend-mode: multiply;" x="10.3913043" y="4.20811312e-18" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-2" style="mix-blend-mode: multiply;" x="20.7826087" y="8.41622625e-18" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-3" style="mix-blend-mode: multiply;" x="31.173913" y="1.26243394e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-27" style="mix-blend-mode: multiply;" x="41.5652174" y="1.68324525e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-28" style="mix-blend-mode: multiply;" x="51.9565217" y="2.10405656e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-29" style="mix-blend-mode: multiply;" x="62.3478261" y="2.52486787e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-30" style="mix-blend-mode: multiply;" x="72.7391304" y="2.94567919e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-31" style="mix-blend-mode: multiply;" x="83.1304348" y="3.3664905e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-32" style="mix-blend-mode: multiply;" x="93.5217391" y="3.78730181e-17" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-33" style="mix-blend-mode: multiply;" x="103.913043" y="2.84637906e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-34" style="mix-blend-mode: multiply;" x="114.304348" y="2.84679987e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-35" style="mix-blend-mode: multiply;" x="124.695652" y="2.84722068e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-36" style="mix-blend-mode: multiply;" x="135.086957" y="2.84764149e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-37" style="mix-blend-mode: multiply;" x="145.478261" y="2.8480623e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-38" style="mix-blend-mode: multiply;" x="155.869565" y="2.84848311e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-39" style="mix-blend-mode: multiply;" x="166.26087" y="2.84890392e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-40" style="mix-blend-mode: multiply;" x="176.652174" y="2.84932474e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-41" style="mix-blend-mode: multiply;" x="187.043478" y="2.84974555e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-42" style="mix-blend-mode: multiply;" x="197.434783" y="2.85016636e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-43" style="mix-blend-mode: multiply;" x="207.826087" y="2.85058717e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-44" style="mix-blend-mode: multiply;" x="218.217391" y="2.85100798e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-45" style="mix-blend-mode: multiply;" x="228.608696" y="2.85142879e-14" width="1" height="240"></rect>
-                        <rect id="Rectangle-Copy-46" style="mix-blend-mode: multiply;" x="239" y="-7.11155059e-14" width="1" height="240"></rect>
-                    </g>
-                </g>
+                <path d="M0.5,0.5 L0.5,239.5 L239.5,239.5 L239.5,0.5 L0.5,0.5 Z M73.1,73.1 L176.5,73.1 L176.5,176.5 L73.1,176.5 L73.1,73.1 Z" id="Combined-Shape" stroke="#97C1FF" fill="#EDF4FF"></path>
+                <rect id="Rectangle" stroke="#97C1FF" x="0.5" y="0.5" width="239" height="239"></rect>
             </g>
         </g>
     </g>

--- a/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
+++ b/src/content/guidelines/iconography/images/iconography-usage-padding-6.svg
@@ -1,88 +1,78 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg width="352px" height="352px" viewBox="0 0 352 352" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 52.4 (67378) - http://www.bohemiancoding.com/sketch -->
-    <title>Iconography_usage_Padding-6</title>
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>iconography_usage_Padding-6</title>
     <desc>Created with Sketch.</desc>
-    <defs>
-        <path d="M0,0 L71.8666667,0 L71.8666667,5.98888889 L0,5.98888889 L0,0 Z M0,53.9 L71.8666667,53.9 L71.8666667,59.8888889 L0,59.8888889 L0,53.9 Z M0,26.95 L71.8666667,26.95 L71.8666667,32.9388889 L0,32.9388889 L0,26.95 Z" id="path-1"></path>
-    </defs>
     <g id="Padding-6" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
         <rect id="Rectangle-3" x="0" y="0" width="352" height="352"></rect>
-        <g id="Group-6" transform="translate(65.000000, 56.000000)">
-            <g id="Group-11">
-                <rect id="Rectangle-3-Copy" fill="#F3F3F3" x="1.22051282" y="1.22051282" width="234.338462" height="234.338462"></rect>
-                <g id="Grid-01" stroke="#DCDCDC" stroke-linecap="square" stroke-width="1.22222222">
-                    <g id="Vertical-lines" transform="translate(0.250327, 1.971494)">
-                        <path d="M0.500653818,0 L0.500653818,234.227438" id="Line"></path>
-                        <path d="M10.285617,0 L10.285617,234.227438" id="Line-Copy-2"></path>
-                        <path d="M20.0705801,0 L20.0705801,234.227438" id="Line-Copy-4"></path>
-                        <path d="M29.8555432,0 L29.8555432,234.227438" id="Line-Copy-6"></path>
-                        <path d="M39.6405064,0 L39.6405064,234.227438" id="Line-Copy-8"></path>
-                        <path d="M49.4254695,0 L49.4254695,234.227438" id="Line-Copy-10"></path>
-                        <path d="M59.2104327,0 L59.2104327,234.227438" id="Line-Copy-26"></path>
-                        <path d="M68.9953958,0 L68.9953958,234.227438" id="Line-Copy-28"></path>
-                        <path d="M78.7803589,0 L78.7803589,234.227438" id="Line-Copy-30"></path>
-                        <path d="M88.5653221,0 L88.5653221,234.227438" id="Line-Copy-32"></path>
-                        <path d="M98.3502852,0 L98.3502852,234.227438" id="Line-Copy-34"></path>
-                        <path d="M108.135248,0 L108.135248,234.227438" id="Line-Copy-36"></path>
-                        <path d="M117.920211,0 L117.920211,234.227438" id="Line-Copy-38"></path>
-                        <path d="M127.705175,0 L127.705175,234.227438" id="Line-Copy-40"></path>
-                        <path d="M137.490138,0 L137.490138,234.227438" id="Line-Copy-42"></path>
-                        <path d="M147.275101,0 L147.275101,234.227438" id="Line-Copy-44"></path>
-                        <path d="M157.060064,0 L157.060064,234.227438" id="Line-Copy-46"></path>
-                        <path d="M166.845027,0 L166.845027,234.227438" id="Line-Copy-48"></path>
-                        <path d="M176.62999,0 L176.62999,234.227438" id="Line-Copy-50"></path>
-                        <path d="M186.414953,0 L186.414953,234.227438" id="Line-Copy-52"></path>
-                        <path d="M196.199917,0 L196.199917,234.227438" id="Line-Copy-54"></path>
-                        <path d="M205.98488,0 L205.98488,234.227438" id="Line-Copy-56"></path>
-                        <path d="M215.769843,0 L215.769843,234.227438" id="Line-Copy-58"></path>
-                        <path d="M225.554806,0 L225.554806,234.227438" id="Line-Copy-60"></path>
-                        <path d="M235.339769,0 L235.339769,234.227438" id="Line-Copy-62"></path>
-                    </g>
-                    <g id="Horiz-lines" transform="translate(118.640070, 119.140724) rotate(90.000000) translate(-118.640070, -119.140724) translate(0.250327, 1.971494)">
-                        <path d="M0.500653818,0 L0.500653818,234.227438" id="Line"></path>
-                        <path d="M10.285617,0 L10.285617,234.227438" id="Line-Copy-2"></path>
-                        <path d="M20.0705801,0 L20.0705801,234.227438" id="Line-Copy-4"></path>
-                        <path d="M29.8555432,0 L29.8555432,234.227438" id="Line-Copy-6"></path>
-                        <path d="M39.6405064,0 L39.6405064,234.227438" id="Line-Copy-8"></path>
-                        <path d="M49.4254695,0 L49.4254695,234.227438" id="Line-Copy-10"></path>
-                        <path d="M59.2104327,0 L59.2104327,234.227438" id="Line-Copy-26"></path>
-                        <path d="M68.9953958,0 L68.9953958,234.227438" id="Line-Copy-28"></path>
-                        <path d="M78.7803589,0 L78.7803589,234.227438" id="Line-Copy-30"></path>
-                        <path d="M88.5653221,0 L88.5653221,234.227438" id="Line-Copy-32"></path>
-                        <path d="M98.3502852,0 L98.3502852,234.227438" id="Line-Copy-34"></path>
-                        <path d="M108.135248,0 L108.135248,234.227438" id="Line-Copy-36"></path>
-                        <path d="M117.920211,0 L117.920211,234.227438" id="Line-Copy-38"></path>
-                        <path d="M127.705175,0 L127.705175,234.227438" id="Line-Copy-40"></path>
-                        <path d="M137.490138,0 L137.490138,234.227438" id="Line-Copy-42"></path>
-                        <path d="M147.275101,0 L147.275101,234.227438" id="Line-Copy-44"></path>
-                        <path d="M157.060064,0 L157.060064,234.227438" id="Line-Copy-46"></path>
-                        <path d="M166.845027,0 L166.845027,234.227438" id="Line-Copy-48"></path>
-                        <path d="M176.62999,0 L176.62999,234.227438" id="Line-Copy-50"></path>
-                        <path d="M186.414953,0 L186.414953,234.227438" id="Line-Copy-52"></path>
-                        <path d="M196.199917,0 L196.199917,234.227438" id="Line-Copy-54"></path>
-                        <path d="M205.98488,0 L205.98488,234.227438" id="Line-Copy-56"></path>
-                        <path d="M215.769843,0 L215.769843,234.227438" id="Line-Copy-58"></path>
-                        <path d="M225.554806,0 L225.554806,234.227438" id="Line-Copy-60"></path>
-                        <path d="M235.339769,0 L235.339769,234.227438" id="Line-Copy-62"></path>
+        <g id="Group-5" transform="translate(56.000000, 56.000000)">
+            <g id="Group">
+                <g id="Group-Copy" transform="translate(74.621849, 74.621849)">
+                    <rect id="Rectangle" x="0" y="0" width="101.848739" height="101.848739"></rect>
+                    <g id="menu" transform="translate(12.731092, 19.096639)" fill="#000000" fill-rule="nonzero">
+                        <rect id="Rectangle" x="0" y="57.289916" width="76.3865546" height="6.36554622"></rect>
+                        <rect id="Rectangle" x="0" y="19.0966387" width="76.3865546" height="6.36554622"></rect>
+                        <rect id="Rectangle" x="0" y="38.1932773" width="76.3865546" height="6.36554622"></rect>
+                        <rect id="Rectangle" x="0" y="0" width="76.3865546" height="6.36554622"></rect>
                     </g>
                 </g>
-                <g id="icon/navigation/menu/16" transform="translate(69.569231, 69.569231)">
-                    <g id="menu" stroke-width="1" fill-rule="evenodd" transform="translate(11.977778, 17.966667)">
-                        <mask id="mask-2" fill="white">
-                            <use xlink:href="#path-1"></use>
-                        </mask>
-                        <use id="Mask" fill="#000000" fill-rule="nonzero" xlink:href="#path-1"></use>
-                        <g id="color/gray/gray-100" mask="url(#mask-2)" fill="#171717">
-                            <g transform="translate(-11.977778, -17.966667)" id="gray-100">
-                                <rect x="0" y="0" width="239.455782" height="239.455782"></rect>
-                            </g>
-                        </g>
+                <path d="M0,0 L240,0 L240,240 L0,240 L0,0 Z M73.6,73.6 L73.6,176 L176,176 L176,73.6 L73.6,73.6 Z" id="Combined-Shape" fill="#C3DAFF"></path>
+                <rect id="Rectangle" stroke="#DCDCDC" style="mix-blend-mode: multiply;" x="0.5" y="0.5" width="239" height="239"></rect>
+                <g id="Group-3" fill="#DCDCDC">
+                    <g id="Group-4">
+                        <rect id="Rectangle" style="mix-blend-mode: multiply;" x="0" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy" style="mix-blend-mode: multiply;" x="10.3913043" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-2" style="mix-blend-mode: multiply;" x="20.7826087" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-3" style="mix-blend-mode: multiply;" x="31.173913" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-27" style="mix-blend-mode: multiply;" x="41.5652174" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-28" style="mix-blend-mode: multiply;" x="51.9565217" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-29" style="mix-blend-mode: multiply;" x="62.3478261" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-30" style="mix-blend-mode: multiply;" x="72.7391304" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-31" style="mix-blend-mode: multiply;" x="83.1304348" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-32" style="mix-blend-mode: multiply;" x="93.5217391" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-33" style="mix-blend-mode: multiply;" x="103.913043" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-34" style="mix-blend-mode: multiply;" x="114.304348" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-35" style="mix-blend-mode: multiply;" x="124.695652" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-36" style="mix-blend-mode: multiply;" x="135.086957" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-37" style="mix-blend-mode: multiply;" x="145.478261" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-38" style="mix-blend-mode: multiply;" x="155.869565" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-39" style="mix-blend-mode: multiply;" x="166.26087" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-40" style="mix-blend-mode: multiply;" x="176.652174" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-41" style="mix-blend-mode: multiply;" x="187.043478" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-42" style="mix-blend-mode: multiply;" x="197.434783" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-43" style="mix-blend-mode: multiply;" x="207.826087" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-44" style="mix-blend-mode: multiply;" x="218.217391" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-45" style="mix-blend-mode: multiply;" x="228.608696" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-46" style="mix-blend-mode: multiply;" x="239" y="0" width="1" height="240"></rect>
                     </g>
-                    <rect id="transparent-rectangle" x="0" y="0" width="95.8222222" height="95.8222222"></rect>
+                    <g id="Group-2" transform="translate(120.000000, 120.000000) rotate(90.000000) translate(-120.000000, -120.000000) translate(-0.000000, -0.000000)">
+                        <rect id="Rectangle" style="mix-blend-mode: multiply;" x="0" y="0" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy" style="mix-blend-mode: multiply;" x="10.3913043" y="4.20811312e-18" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-2" style="mix-blend-mode: multiply;" x="20.7826087" y="8.41622625e-18" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-3" style="mix-blend-mode: multiply;" x="31.173913" y="1.26243394e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-27" style="mix-blend-mode: multiply;" x="41.5652174" y="1.68324525e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-28" style="mix-blend-mode: multiply;" x="51.9565217" y="2.10405656e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-29" style="mix-blend-mode: multiply;" x="62.3478261" y="2.52486787e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-30" style="mix-blend-mode: multiply;" x="72.7391304" y="2.94567919e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-31" style="mix-blend-mode: multiply;" x="83.1304348" y="3.3664905e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-32" style="mix-blend-mode: multiply;" x="93.5217391" y="3.78730181e-17" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-33" style="mix-blend-mode: multiply;" x="103.913043" y="2.84637906e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-34" style="mix-blend-mode: multiply;" x="114.304348" y="2.84679987e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-35" style="mix-blend-mode: multiply;" x="124.695652" y="2.84722068e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-36" style="mix-blend-mode: multiply;" x="135.086957" y="2.84764149e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-37" style="mix-blend-mode: multiply;" x="145.478261" y="2.8480623e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-38" style="mix-blend-mode: multiply;" x="155.869565" y="2.84848311e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-39" style="mix-blend-mode: multiply;" x="166.26087" y="2.84890392e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-40" style="mix-blend-mode: multiply;" x="176.652174" y="2.84932474e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-41" style="mix-blend-mode: multiply;" x="187.043478" y="2.84974555e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-42" style="mix-blend-mode: multiply;" x="197.434783" y="2.85016636e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-43" style="mix-blend-mode: multiply;" x="207.826087" y="2.85058717e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-44" style="mix-blend-mode: multiply;" x="218.217391" y="2.85100798e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-45" style="mix-blend-mode: multiply;" x="228.608696" y="2.85142879e-14" width="1" height="240"></rect>
+                        <rect id="Rectangle-Copy-46" style="mix-blend-mode: multiply;" x="239" y="-7.11155059e-14" width="1" height="240"></rect>
+                    </g>
                 </g>
             </g>
-            <path d="M176.974359,59.8051282 L59.8051282,59.8051282 L59.8051282,176.974359 L176.974359,176.974359 L176.974359,59.8051282 Z M235.558974,59.8051282 L235.558974,176.974359 L235.558974,235.558974 L59.8051282,235.558974 L1.22051282,235.558974 L1.22051282,1.22051282 L59.8051282,1.22051282 L235.558974,1.22051282 L235.558974,59.8051282 Z" id="Combined-Shape" fill="#87B6FF" opacity="0.5"></path>
         </g>
     </g>
 </svg>

--- a/src/content/guidelines/iconography/usage.mdx
+++ b/src/content/guidelines/iconography/usage.mdx
@@ -18,7 +18,7 @@ tabs: ['Library', 'Usage', 'Contribution']
   className="tile--resource--no-margin"
   col_lg="8"
   flex="true"
-  bleed="true"> 
+  bleed="true">
   <ClickableTile
     title="Elements package: Icons"
     href="https://github.com/IBM/carbon-elements/tree/master/packages/icons"
@@ -39,7 +39,7 @@ tabs: ['Library', 'Usage', 'Contribution']
 
 
 
- </ClickableTile> 
+ </ClickableTile>
 </GridWrapper>
 
 
@@ -84,7 +84,7 @@ UI icons that appear within Carbon components are generally 16 px squares, howev
 
 All touch targets for interactive icons need to be 44 px or larger. Developers can add padding to a touch target with CSS to meet the 44 px requirement.
 
-<ImageComponent  cols="4">
+<ImageComponent  cols="4" caption="The menu button that is also a touch target may have a 20px x 20px icon centered in a 48px x 48px button.">
 
 ![touch target padding](images/iconography-usage-padding-6.svg)
 


### PR DESCRIPTION
Fixed image on https://next.carbondesignsystem.com/guidelines/iconography/usage because it's showing the old menu icon:
- Correct menu icon has 4 lines
- Cleaned up the image by dropping the grid lines to align the style better with illustrations of padding on Layout page.
- Added caption that was missing

Left new image, right current on site:

![image](https://user-images.githubusercontent.com/15144993/55129372-dc484480-50e4-11e9-9bb7-43b4c7c20304.png)




