### PR TITLE
fix(style tabs): added inline code styles

### DIFF
--- a/src/content/components/accordion/style.mdx
+++ b/src/content/components/accordion/style.mdx
@@ -7,19 +7,19 @@ tabs: ['Code', 'Usage', 'Style']
 
 | Class                         | Property   | Color token      |
 | ----------------------------- | ---------- | ---------------- |
-| `.bx--accordion__title`       | color      | $text-01       |
-| `.bx--accordion__content`     | color      | $text-01       |
-| `.bx--accordion__arrow`       | fill       | $icon-01       |
-| `.bx--accordion__item`        | border-top | $ui-03         |
+| `.bx--accordion__title`       | color      | `$text-01`       |
+| `.bx--accordion__content`     | color      | `$text-01`       |
+| `.bx--accordion__arrow`       | fill       | `$icon-01 `      |
+| `.bx--accordion__item`        | border-top | `$ui-03`         |
 
 ## Typography
 
 All accordion labels are set in sentence case and should not exceed three words. Set body text appropriately based on content.
 
-| Class                     | Font-size (px/rem) | Font-weight  | Type token     |
-| ------------------------- | ------------------ | ------------ | -------------- |
-| `.bx--accordion__title`   | 14 / 0.875         | Normal / 400 | $body-long-01|
-| `.bx--accordion__content` | 14 / 0.875         | Normal / 400 | $body-long-01|
+| Class                     | Font-size (px/rem) | Font-weight  | Type token      |
+| ------------------------- | ------------------ | ------------ | --------------- |
+| `.bx--accordion__title`   | 14 / 0.875         | Regular / 400 | `$body-long-01`|
+| `.bx--accordion__content` | 14 / 0.875         | Regular / 400 | `$body-long-01`|
 
 ## Structure
 
@@ -30,12 +30,12 @@ There is no limit to the height of an open row, however, follow the other paddin
 | `.bx--accordion__heading`      | height                     | 32 / 2     | –             |
 | `.bx--accordion__item`         | border-top                 | 1          | –             |
 | `.bx--accordion__arrow`        | size                       | 16 / 1     | –             |
-| `.bx--accordion__arrow`        | padding-right              | 16 / 1     | $spacing-05 |
-| `.bx--accordion__title`        | margin-left                | 16 / 1     | $spacing-05 |
+| `.bx--accordion__arrow`        | padding-right              | 16 / 1     | `$spacing-05` |
+| `.bx--accordion__title`        | margin-left                | 16 / 1     | `$spacing-05` |
 | `.bx--accordion__content`      | padding-right              | 25%        | –             |
-| `.bx--accordion__content`      | padding-top                | 8 / 0.5    | $spacing-03 |
-| `.bx--accordion__content`      | padding-left               | 16 / 1     | $spacing-05 |
-| `.bx--accordion__item--active` | padding-bottom             | 24 / 1.5   | $spacing-06 |
+| `.bx--accordion__content`      | padding-top                | 8 / 0.5    | `$spacing-03` |
+| `.bx--accordion__content`      | padding-left               | 16 / 1     | `$spacing-05` |
+| `.bx--accordion__item--active` | padding-bottom             | 24 / 1.5   | `$spacing-06` |
 
 <ImageComponent caption="Structure and spacing measurements for accordion | px / rem" fixed="default">
 

--- a/src/content/components/breadcrumb/style.mdx
+++ b/src/content/components/breadcrumb/style.mdx
@@ -7,17 +7,17 @@ tabs: ['Code', 'Usage', 'Style']
 
 | Class                         | Property | Color token          |
 | ----------------------------- | -------- | -------------------- |
-| `.bx--link`                   | color    | $link-01     |
-| `.bx--link:hover`             | color    | $hover-primary-text |
-| `.bx--breadcrumb-item::after` | color    | $text-01            |
+| `.bx--link`                   | color    | `$link-01`           |
+| `.bx--link:hover`             | color    | `$hover-primary-text`|
+| `.bx--breadcrumb-item::after` | color    | `$text-01`           |
 
 ## Typography
 
 When a user hovers overs a breadcrumb, the breadcrumb title should be underlined.
 
-| Class       | Font-size (px/rem) | Font-weight   | Type token      |
-| ----------- | ------------------ | ------------- | --------------- |
-| `.bx--link` | 14 / 0.875         | Regular / 400 | $body-short-01 |
+| Class       | Font-size (px/rem) | Font-weight   | Type token       |
+| ----------- | ------------------ | ------------- | ---------------- |
+| `.bx--link` | 14 / 0.875         | Regular / 400 | `$body-short-01` |
 
 <ImageComponent fixed="default" caption="Breadcrumb typography treatment example">
 
@@ -31,7 +31,7 @@ The on-click dropdown should follow the [overflow menu](/components/overflow-men
 
 | Class                  | Property    | px/rem  | Spacing token |
 | ---------------------- | ----------- | ------- | ------------- |
-| `.bx--breadcrumb-item` | margin-left | 8 / 0.5 | $spacing-03  |
+| `.bx--breadcrumb-item` | margin-left | 8 / 0.5 | `$spacing-03` |
 
 <ImageComponent fixed="default" caption="Structure and spacing measurements for breadcrumb | px / rem">
 
@@ -45,16 +45,16 @@ Truncated breadcrumbs are not currently built into the breadcrumb component. The
 
 ### Color
 
-| Class                                      | Property         | Color token |
-| ------------------------------------------ | ---------------- | ----------- |
-| `.bx--overflow-menu-options__btn`          | color            | $icon-01   |
-| `.bx--overflow-menu-options__option:hover` | background-color | $hover-row |
+| Class                                      | Property         | Color token  |
+| ------------------------------------------ | ---------------- | ------------ |
+| `.bx--overflow-menu-options__btn`          | color            | `$icon-01`   |
+| `.bx--overflow-menu-options__option:hover` | background-color | `$hover-row` |
 
 ### Typography
 
-| Class                             | Font-size (px/rem) | Font-weight   | Type token      |
-| --------------------------------- | ------------------ | ------------- | --------------- |
-| `.bx--overflow-menu-options__btn` | 14 / 0.875         | Regular / 400 | $body-short-01 |
+| Class                             | Font-size (px/rem) | Font-weight   | Type token       |
+| --------------------------------- | ------------------ | ------------- | ---------------- |
+| `.bx--overflow-menu-options__btn` | 14 / 0.875         | Regular / 400 | `$body-short-01` |
 
 ### Structure
 

--- a/src/content/components/button/style.mdx
+++ b/src/content/components/button/style.mdx
@@ -8,73 +8,73 @@ tabs: ['Code', 'Usage', 'Style']
 
 ### Primary button
 
-| Class                                                          | Property                 | Color token      |
-| -------------------------------------------------------------- | ------------------------ | ---------------- |
-| `.bx--btn--primary`                                            | text color               | $text-04        |
-| `.bx--btn__icon`                                               | svg                      | $icon-03        |
-| `.bx--btn--primary`                                            | background-color         | $interactive-01  |
-| `:hover`                                                       | background-color         | $hover-primary   |
-| `:active`                                                      | background-color         | $active-primary  |
-| `:focus`                                                       | border                   | $focus           |
-| `:disabled`                                                    | background-color         | $disabled-02        |
-| `:disabled`                                                    | text color               | $disabled-03        |
+| Class                                                          | Property                 | Color token       |
+| -------------------------------------------------------------- | ------------------------ | ----------------- |
+| `.bx--btn--primary`                                            | text color               | `$text-04`        |
+| `.bx--btn__icon`                                               | svg                      | `$icon-03 `       |
+| `.bx--btn--primary`                                            | background-color         | `$interactive-01` |
+| `:hover`                                                       | background-color         | `$hover-primary`  |
+| `:active`                                                      | background-color         | `$active-primary` |
+| `:focus`                                                       | border                   | `$focus`          |
+| `:disabled`                                                    | background-color         | `$disabled-02`    |
+| `:disabled`                                                    | text color               | `$disabled-03`    |
 
 ### Secondary button
 
-| Class                                                          | Property                 | Color token      |
-| -------------------------------------------------------------- | ------------------------ | ---------------- |
-| `.bx--btn--secondary`                                          | text color               | $text-04        |
-| `.bx--btn__icon`                                               | svg                      | $icon-03        |
-| `.bx--btn--secondary`                                          | background-color         | $interactive-02  |
-| `.bx--btn--secondary`                                          | border                   | $interactive-02  |
-| `:hover`                                                       | background-color         | $hover-secondary |
-| `:active`                                                      | background-color         | $active-secondary|
-| `:focus`                                                       | border                   | $focus           |
-| `:disabled`                                                    | background-color         | $disabled-02        |
-| `:disabled`                                                    | text color               | $disabled-03        |
+| Class                                                          | Property                 | Color token         |
+| -------------------------------------------------------------- | ------------------------ | ------------------- |
+| `.bx--btn--secondary`                                          | text color               | `$text-04`          |
+| `.bx--btn__icon`                                               | svg                      | `$icon-03`          |
+| `.bx--btn--secondary`                                          | background-color         | `$interactive-02`   |
+| `.bx--btn--secondary`                                          | border                   | `$interactive-02`   |
+| `:hover`                                                       | background-color         | `$hover-secondary`  |
+| `:active`                                                      | background-color         | `$active-secondary` |
+| `:focus`                                                       | border                   | `$focus`            |
+| `:disabled`                                                    | background-color         | `$disabled-02`      |
+| `:disabled`                                                    | text color               | `$disabled-03`      |
 
 ### Tertiary button
 
-| Class                                                          | Property                 | Color token      |
-| -------------------------------------------------------------- | ------------------------ | ---------------- |
-| `.bx--btn--tertiary`                                           | text color               | $interactive-03  |
-| `.bx--btn__icon`                                               | svg                      | $interactive-03  |
-| `.bx--btn--tertiary`                                           | background-color         | transparent      |
-| `.bx--btn--tertiary`                                           | border                   | $interactive-03  |
-| `:hover`                                                       | text color               | $text-04         |
-| `:hover`                                                       | svg                      | $icon-03         |
-| `:hover`                                                       | background-color         | $hover-tertiary  |
-| `:active`                                                      | background-color         | $active-tertiary |
-| `:focus`                                                       | border                   | $focus           |
-| `:disabled`                                                    | background-color         | $disabled-02     |
-| `:disabled`                                                    | text color               | $disabled-03     |
+| Class                                                          | Property                 | Color token        |
+| -------------------------------------------------------------- | ------------------------ | ------------------ |
+| `.bx--btn--tertiary`                                           | text color               | `$interactive-03`  |
+| `.bx--btn__icon`                                               | svg                      | `$interactive-03`  |
+| `.bx--btn--tertiary`                                           | background-color         | `transparent`      |
+| `.bx--btn--tertiary`                                           | border                   | `$interactive-03`  |
+| `:hover`                                                       | text color               | `$text-04`         |
+| `:hover`                                                       | svg                      | `$icon-03`         |
+| `:hover`                                                       | background-color         | `$hover-tertiary`  |
+| `:active`                                                      | background-color         | `$active-tertiary` |
+| `:focus`                                                       | border                   | `$focus`           |
+| `:disabled`                                                    | background-color         | `$disabled-02`     |
+| `:disabled`                                                    | text color               | `$disabled-03`     |
 
 ### Ghost button
 
 | Class                                                          | Property                 | Color token      |
 | -------------------------------------------------------------- | ------------------------ | ---------------- |
-| `.bx--btn--ghost`                                              | text color               | $link-01         |
-| `.bx--btn__icon`                                               | svg                      | $link-01         |
+| `.bx--btn--ghost`                                              | text color               | `$link-01`       |
+| `.bx--btn__icon`                                               | svg                      | `$link-01`       |
 | `.bx--btn--ghost`                                              | background-color         | –                |
-| `:hover`                                                       | text color               | $hover-primary-text |
-| `:hover`                                                       | svg                      | $hover-primary-text |
-| `:hover`                                                       | background-color         | $hover-ui        |
-| `:active`                                                      | background-color         | $active-ui |
-| `:focus`                                                       | border                   | $focus           |
-| `:disabled`                                                    | text color               | $disabled-03     |
+| `:hover`                                                       | text color               | `$hover-primary-text` |
+| `:hover`                                                       | svg                      | `$hover-primary-text` |
+| `:hover`                                                       | background-color         | `$hover-ui`      |
+| `:active`                                                      | background-color         | `$active-ui`     |
+| `:focus`                                                       | border                   | `$focus`         |
+| `:disabled`                                                    | text color               | `$disabled-03`   |
 
 ### Danger button
 
-| Class                                                          | Property                 | Color token      |
-| -------------------------------------------------------------- | ------------------------ | ---------------- |
-| `.bx--btn--danger--primar`                                     | text color               | $text-04         |
-| `.bx--btn__icon`                                               | svg                      | $icon-03         |
-| `.bx--btn--danger--primary`                                    | background-color         | $support-01      |
-| `:hover`                                                       | background-color         | $hover-danger    |
-| `:active`                                                      | background-color         | $active-danger   |
-| `:focus`                                                       | border                   | $focus           |
-| `:disabled`                                                    | background-color         | $disabled-02     |
-| `:disabled`                                                    | text color               | $disabled-03     |
+| Class                                                          | Property                 | Color token        |
+| -------------------------------------------------------------- | ------------------------ | ------------------ |
+| `.bx--btn--danger--primar`                                     | text color               | `$text-04`         |
+| `.bx--btn__icon`                                               | svg                      | `$icon-03`         |
+| `.bx--btn--danger--primary`                                    | background-color         | `$support-01`      |
+| `:hover`                                                       | background-color         | `$hover-danger`    |
+| `:active`                                                      | background-color         | `$active-danger`   |
+| `:focus`                                                       | border                   | `$focus`           |
+| `:disabled`                                                    | background-color         | `$disabled-02`     |
+| `:disabled`                                                    | text color               | `$disabled-03`     |
 
 
 <ImageComponent fixed="default" caption="Primary, secondary, and ghost button state examples">
@@ -95,17 +95,17 @@ Button text should be set in sentence case, with only the first word in a phrase
 
 A button cannot have any element or text within 16 pixels / 1 rem of its borders. For button groups, the primary button is positioned on the outside of the set, while the secondary button is positioned inside. For a button with a glyph, the space between the button label and the glyph must be greater than or equal to 16 pixels / 1 rem. This is to accommodate for instances where two or more buttons with glyphs appear together.
 
-| Class                            | Property                    | px / rem | Spacing token |
-| -------------------------------- | --------------------------- | -------- | ------------- |
-| `.bx--btn--primary`              | height                      | 48 / 3   | –  |
-| `.bx--btn--sm`                   | height                      | 32 / 2   | –  |
-| `.bx--btn__icon`                 | size                        | 16 x 16  | –  |
-| `.bx--btn`                       | padding-left                | 16 / 1   | $spacing-05   |
-| `.bx--btn`                       | padding-right               | 64 / 1   | –  |
-| `.bx--btn--sm`                   | padding-left                | 16 / 1   | $spacing-05   |
-| `.bx--btn--sm`                   | padding-right               | 64 / 4   | –  |
-| `.bx--btn__icon`                 | margin-left, margin-right   | 16 / 1   | $spacing-05   |
-| `.bx--btn--ghost`                | padding-left, padding-right | 16 / 2   | $spacing-05   |
+| Class                            | Property                    | px / rem | Spacing token   |
+| -------------------------------- | --------------------------- | -------- | --------------- |
+| `.bx--btn--primary`              | height                      | 48 / 3   | –               |
+| `.bx--btn--sm`                   | height                      | 32 / 2   | –               |
+| `.bx--btn__icon`                 | size                        | 16 x 16  | –               |
+| `.bx--btn`                       | padding-left                | 16 / 1   | `$spacing-05`   |
+| `.bx--btn`                       | padding-right               | 64 / 1   | –               |
+| `.bx--btn--sm`                   | padding-left                | 16 / 1   | `$spacing-05`   |
+| `.bx--btn--sm`                   | padding-right               | 64 / 4   | –               |
+| `.bx--btn__icon`                 | margin-left, margin-right   | 16 / 1   | `$spacing-05`   |
+| `.bx--btn--ghost`                | padding-left, padding-right | 16 / 2   | `$spacing-05`   |
 
 <ImageComponent fixed="default" caption="Structure measurements for small and regular primary button | px / rem">
 

--- a/src/content/components/code-snippet/style.mdx
+++ b/src/content/components/code-snippet/style.mdx
@@ -8,8 +8,8 @@ tabs: ['Code', 'Usage', 'Style']
 
 ### Single & multi-line
 
-| Class                        | Property         | Color token |
-| ---------------------------- | ---------------- | ---------- |
+| Class                        | Property         | Color token  |
+| ---------------------------- | ---------------- | ------------ |
 | `.bx--snippet`               | background       | `$field-01`  |
 | `.bx--snippet__icon`         | color            | `$icon-01`   |
 | `.bx--snippet-button:hover`  | background-color | `$hover-ui ` |
@@ -18,8 +18,8 @@ tabs: ['Code', 'Usage', 'Style']
 
 ### Inline snippet
 
-| Class                        | Property         | Color token |
-| ---------------------------- | ---------------- | ---------- |
+| Class                        | Property         | Color token  |
+| ---------------------------- | ---------------- | ----------   |
 | `.bx--snippet--inline`       | background-color | `$field-01`  |
 | `.bx--snippet--inline`       | color            | `$text-02 `  |
 | `.bx--snippet--inline:hover` | background-color | `$hover-ui`  |


### PR DESCRIPTION
Accordion, Breadcrumb, Button were missing inline code styles for the tokens.