### PR TITLE
chore: Fix iconography library URL, resolves #1434

### DIFF
--- a/src/content/guidelines/iconography/usage.mdx
+++ b/src/content/guidelines/iconography/usage.mdx
@@ -155,7 +155,7 @@ To use SVG sprite files, they **must** be distributed through a web server and w
 
 `path_to_static-assets` is the path to your static assets where `carbon-icons.svg` is located.
 
-`icon_name` is the icon name, which will display the corresponding icon. Refer to the [iconography library]("/guidelines/iconography") page for a full list of icon names.
+`icon_name` is the icon name, which will display the corresponding icon. Refer to the [iconography library](/guidelines/iconography) page for a full list of icon names.
 
 ### CSS
 


### PR DESCRIPTION
Closes #1434

Fixes URL for Iconography Library link.

#### Changelog

**Changed**

- Removed parenthesis on link which resulted in 404 Not Found when clicked.
