### PR TITLE
Fix typo under Other Resources section

### DIFF
--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -26,7 +26,7 @@ import ClickableTile from '../../src/components/ClickableTile';
 
 ### Other Resources
 
-The Component Libraries give developers a collection of re-usable React components they can use for building websites and user interfaces. See a [complete list of resources.](/resources)
+The Component Libraries give developers a collection of re-usable components they can use for building websites and user interfaces. See a [complete list of resources.](/resources)
 
 <GridWrapper col_lg="8" flex="true" bleed="true">
   <ClickableTile


### PR DESCRIPTION
The sentence pointed to having only react components, but other framework components are listed right below it.

#### Changelog

**Changed**

- re-usable React components to re-usable components