### PR TITLE
fix[known issues]: H2 too long

### DIFF
--- a/src/content/updates/release-information/known-issues.mdx
+++ b/src/content/updates/release-information/known-issues.mdx
@@ -3,7 +3,7 @@ title: Known issues
 tabs: ['Highlights', "Changelog", 'Known issues']
 ---
 
-## Carbon v10 identified bugs and issues
+## Known bugs and issues
 
 Here are the most significant issues and problems that we are aware of in the Carbon v10 release. The Carbon team will be working to resolve these.
 


### PR DESCRIPTION
Mike asked to shorten H2 from Carbon v10 Identified bugs and issues to Known bugs and issues; H2s are meant to be short and concise.

Closes #
https://github.com/carbon-design-system/carbon-website/issues/1468

