### PR TITLE
Add angular storybook links to component demos

### DIFF
--- a/src/components/ComponentCode/ComponentCode.js
+++ b/src/components/ComponentCode/ComponentCode.js
@@ -12,7 +12,7 @@ export default class ComponentCode extends React.Component {
     background: PropTypes.string,
     hasLightVersion: PropTypes.bool,
     hasReactVersion: PropTypes.bool,
-    hasAngularVersion: PropTypes.bool,
+    hasAngularVersion: PropTypes.string,
     hasVueVersion: PropTypes.string,
     experimental: PropTypes.bool,
   };

--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -67,7 +67,7 @@ class ComponentExample extends Component {
     codepenSlug: PropTypes.string,
     hasLightVersion: PropTypes.string,
     hasReactVersion: PropTypes.bool,
-    hasAngularVersion: PropTypes.bool,
+    hasAngularVersion: PropTypes.string,
     hasVueVersion: PropTypes.string,
     experimental: PropTypes.bool,
   };
@@ -338,9 +338,10 @@ class ComponentExample extends Component {
                 React <Launch16 />
               </a>
             )}
-            {hasAngularVersion === true && (
+            {/* hasAngularVersion should be the query part of the storybook url */}
+            {typeof hasAngularVersion === 'string' && (
               <a
-                href={`http://angular.carbondesignsystem.com/?selectedKind=${componentNameLink}`}
+                href={`http://angular.carbondesignsystem.com/${hasAngularVersion}`}
                 target="_blank"
                 rel="noopener noreferrer">
                 Angular <Launch16 />

--- a/src/components/ComponentReact/ComponentReact.js
+++ b/src/components/ComponentReact/ComponentReact.js
@@ -27,6 +27,7 @@ class ComponentReactExample extends Component {
     name: PropTypes.string,
     component: PropTypes.string,
     variation: PropTypes.string,
+    hasAngularVersion: PropTypes.bool
   };
 
   componentDidMount() {
@@ -80,7 +81,7 @@ class ComponentReactExample extends Component {
   };
 
   render() {
-    const { name, component, variation } = this.props;
+    const { name, component, variation, hasAngularVersion } = this.props;
     const storybookMessage = {
       'MultiSelect-MultiSelect.Filterable': 'Check off Filterable in KNOBS tab',
       'MultiSelect-MultiSelect.Inline': 'Select inline in UI type in KNOBS tab',
@@ -93,6 +94,35 @@ class ComponentReactExample extends Component {
     const componentLink = `http://react.carbondesignsystem.com/?selectedKind=${component}&selectedStory=${storybookVariation ||
       'default'}`;
 
+    const getLibraryLinks = () => {
+      if (hasAngularVersion) {
+        return (
+          <>
+            <a
+              href="https://github.com/ibm/carbon-components-react"
+              target="_blank">
+              our React
+            </a>
+            {' '}and{' '}
+            <a
+              href="https://github.com/ibm/carbon-components-angular"
+              target="_blank">
+              Angular libraries
+            </a>
+          </>
+        );
+      }
+
+      return (
+        <a
+          href="https://github.com/ibm/carbon-components-react"
+          target="_blank">
+          our React library
+        </a>
+      )
+
+    };
+
     return (
       <>
         <div className="ibm--row">
@@ -100,11 +130,7 @@ class ComponentReactExample extends Component {
             <h2 className="page-h2">{name}</h2>
             <p className="component-example__heading-label page-p">
               This component is currently only available in{' '}
-              <a
-                href="https://github.com/ibm/carbon-components-react"
-                target="_blank">
-                our React library
-              </a>
+              {getLibraryLinks()}
               .
             </p>
           </div>

--- a/src/content/components/accordion/code.mdx
+++ b/src/content/components/accordion/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="accordion"
     hasReactVersion
     hasVueVersion="accordion--default"
+    hasAngularVersion="?path=/story/accordion--basic"
     codepen="WWrNvp"
     >
 </ComponentCode>

--- a/src/content/components/breadcrumb/code.mdx
+++ b/src/content/components/breadcrumb/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="breadcrumb"
     hasReactVersion
     hasVueVersion="breadcrumb--default"
+    hasAngularVersion="?path=//story/breadcrumb--basic"
     codepen="yreLJv"
     >
 </ComponentCode>
@@ -17,6 +18,7 @@ tabs: ['Code', 'Usage', 'Style']
     component="breadcrumb"
     variation="breadcrumb--current-page"
     hasReactVersion
+    hasAngularVersion="?path=/story/breadcrumb--model"
     codepen="LvGYxK"
     >
 </ComponentCode>

--- a/src/content/components/button/code.mdx
+++ b/src/content/components/button/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--primary"
     hasReactVersion
     hasVueVersion="button--primary"
+    hasAngularVersion="?path=/story/button--basic"
     codepen="xeZxLe"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--secondary"
     hasReactVersion
     hasVueVersion="button--secondary"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=secondary&knob-Size of the buttons=normal"
     codepen="OGMJxW"
     >
 </ComponentCode>
@@ -27,6 +29,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--tertiary"
     hasReactVersion
     hasVueVersion="button--tertiary"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=tertiary&knob-Size of the buttons=normal"
     codepen="VNewrL"
     >
 </ComponentCode>
@@ -36,6 +39,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--ghost"
     hasReactVersion
     hasVueVersion="button--ghost"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=ghost&knob-Size of the buttons=normal"
     codepen="MRKWZz"
     >
 </ComponentCode>
@@ -45,6 +49,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--danger"
     hasReactVersion
     hasVueVersion="button--danger"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=danger&knob-Size of the buttons=normal"
     codepen="wZMvNP"
     >
 </ComponentCode>
@@ -54,6 +59,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--primary--small"
     hasReactVersion
     hasVueVersion="button--primary&knob-small=true"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=primary&knob-Size of the buttons=sm"
     codepen="oObNVb"
     >
 </ComponentCode>
@@ -63,6 +69,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--secondary--small"
     hasReactVersion
     hasVueVersion="button--secondary&knob-small=true"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=secondary&knob-Size of the buttons=sm"
     codepen="ROrNbp"
     >
 </ComponentCode>
@@ -72,6 +79,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--tertiary--small"
     hasReactVersion
     hasVueVersion="button--tertiary&knob-small=true"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=tertiary&knob-Size of the buttons=sm"
     codepen="ZZQYGN"
     >
 </ComponentCode>
@@ -81,6 +89,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--ghost--small"
     hasReactVersion
     hasVueVersion="button--ghost&knob-small=true"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=ghost&knob-Size of the buttons=sm"
     codepen="eoJmpw"
     >
 </ComponentCode>
@@ -90,6 +99,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="button--danger--small"
     hasReactVersion
     hasVueVersion="button--danger&knob-small=true"
+    hasAngularVersion="?path=/story/button--basic&knob-Button kind=danger&knob-Size of the buttons=sm"
     codepen="KYVwXY"
     >
 </ComponentCode>
@@ -98,6 +108,7 @@ tabs: ['Code', 'Usage', 'Style']
     component="button"
     variation="button--set"
     hasReactVersion
+    hasAngularVersion="?path=/story/button--basic"
     codepen="pBgvdX"
     >
 </ComponentCode>

--- a/src/content/components/checkbox/code.mdx
+++ b/src/content/components/checkbox/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="checkbox"
     hasReactVersion
     hasVueVersion="checkbox--default"
+    hasAngularVersion="?path=/story/checkbox--basic"
     codepen="NmxPEm"
     >
 </ComponentCode>

--- a/src/content/components/code-snippet/code.mdx
+++ b/src/content/components/code-snippet/code.mdx
@@ -11,6 +11,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasReactVersion
     hasVueVersion="codesnippet--oneline"
     codepen="vMLEbR"
+    hasAngularVersion="?path=/story/codesnippet--basic"
     >
 </ComponentCode>
 <ComponentCode
@@ -20,6 +21,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasLightVersion
     hasReactVersion
     hasVueVersion="codesnippet--inline"
+    hasAngularVersion="?path=/story/codesnippet--inline"
     codepen="LvGVYe"
     >
 </ComponentCode>
@@ -29,6 +31,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="code-snippet--multi"
     hasReactVersion
     hasVueVersion="codesnippet--multiline"
+    hasAngularVersion="?path=/story/codesnippet--multi"
     codepen="ZZQGGO"
     >
 </ComponentCode>

--- a/src/content/components/content-switcher/code.mdx
+++ b/src/content/components/content-switcher/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="content-switcher"
     hasReactVersion
     hasVueVersion="contentswitcher--default"
+    hasAngularVersion="?path=/story/content-switcher--basic"
     codepen="QPybNw"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="content-switcher--disabled"
     hasReactVersion
     hasVueVersion="contentswitcher--default&knob-with%20icon=true"
+    hasAngularVersion="?path=/story/content-switcher--basic"
     codepen="OGMVxK"
     >
 </ComponentCode>

--- a/src/content/components/data-table/code.mdx
+++ b/src/content/components/data-table/code.mdx
@@ -8,6 +8,7 @@ tabs: ['Code', 'Usage', 'Style']
     component="data-table-v2"
     variation="data-table-v2"
     hasVueVersion="datatable--default"
+    hasAngularVersion="?path=/story/table--default"
     codepen="jRWbZZ"
     >
 </ComponentCode>
@@ -15,6 +16,7 @@ tabs: ['Code', 'Usage', 'Style']
     name="Expandable data table"
     component="data-table-v2"
     variation="data-table-v2--expandable"
+    hasAngularVersion="?path=/story/table--with-expansion"
     codepen="wZMKme"
     >
 </ComponentCode>
@@ -22,6 +24,7 @@ tabs: ['Code', 'Usage', 'Style']
     name="Data table with pagination"
     component="data-table-v2"
     variation="data-table-v2--with-pager"
+    hasAngularVersion="?path=/story/table--with-pagination"
     codepen="MRKaBq"
     >
 </ComponentCode>
@@ -31,6 +34,7 @@ tabs: ['Code', 'Usage', 'Style']
     name="Small data table"
     component="data-table-v2"
     variation="data-table-v2--small"
+    hasAngularVersion="?path=/story/table--default&knob-size=sm&knob-showSelectionColumn=true&knob-striped=true&knob-sortable=true&knob-Data grid keyboard interactions=
     >
 </ComponentCode>
 <ComponentCode
@@ -38,6 +42,7 @@ tabs: ['Code', 'Usage', 'Style']
     component="toolbar"
     variation="toolbar"
     hasVueVersion="toolbar--default"
+    hasAngularVersion="?path=/story/table--with-toolbar"
     >
 </ComponentCode>
 -->

--- a/src/content/components/date-picker/code.mdx
+++ b/src/content/components/date-picker/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasLightVersion
     hasReactVersion
     hasVueVersion="datepicker--simple"
+    hasAngularVersion="?path=/story/datepickerinput--simple"
     codepen="ZZQbVV"
     >
 </ComponentCode>
@@ -20,6 +21,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasLightVersion
     hasReactVersion
     hasVueVersion="datepicker--single"
+    hasAngularVersion="?path=/story/date-picker--single"
     codepen="ZZQbPw"
     >
 </ComponentCode>
@@ -30,6 +32,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasLightVersion
     hasReactVersion
     hasVueVersion="datepicker--range"
+    hasAngularVersion="?path=/story/date-picker--range"
     codepen="yreYrQ"
     >
 </ComponentCode>

--- a/src/content/components/dropdown/code.mdx
+++ b/src/content/components/dropdown/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasReactVersion
     hasLightVersion
     hasVueVersion="dropdown--default"
+    hasAngularVersion="?path=/story/dropdown--basic"
     codepen="zXrqqw"
     >
 </ComponentCode>
@@ -21,6 +22,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasReactVersion
     hasLightVersion
     hasVueVersion="dropdown--default&knob-up=true"
+    hasAngularVersion="?path=/story/dropdown--basic"
     codepen="ZZQWpB"
     >
 </ComponentCode>
@@ -30,6 +32,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="dropdown--inline"
     hasReactVersion
     hasVueVersion="dropdown--default&knob-inline=true"
+    hasAngularVersion="?path=/story/dropdown--basic"
     codepen="OGMNRY"
     >
 </ComponentCode>
@@ -37,23 +40,27 @@ tabs: ['Code', 'Usage', 'Style']
     name="Multi select"
     component="MultiSelect"
     variation="MultiSelect"
+    hasAngularVersion
     >
 </ComponentReact>
 <ComponentReact
     name="Filterable multi select"
     component="MultiSelect"
     variation="MultiSelect.Filterable"
+    hasAngularVersion
     >
 </ComponentReact>
 <ComponentReact
     name="Inline multi select"
     component="MultiSelect"
     variation="MultiSelect.Inline"
+    hasAngularVersion
     >
 </ComponentReact>
 <ComponentReact
     name="Combo box"
     component="ComboBox"
+    hasAngularVersion
     >
 </ComponentReact>
 

--- a/src/content/components/file-uploader/code.mdx
+++ b/src/content/components/file-uploader/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="file-uploader"
     hasReactVersion
     hasVueVersion="fileuploader--default"
+    hasAngularVersion="?path=/story/file-uploader--basic"
     codepen="MRyyyw"
     >
 </ComponentCode>

--- a/src/content/components/inline-loading/code.mdx
+++ b/src/content/components/inline-loading/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="inline-loading"
     hasReactVersion
     hasVueVersion="inlineloading--default"
+    hasAngularVersion="?path=/story/inline-loading--basic"
     codepen="dLMXow"
     >
 </ComponentCode>

--- a/src/content/components/link/code.mdx
+++ b/src/content/components/link/code.mdx
@@ -9,5 +9,6 @@ tabs: ['Code', 'Usage', 'Style']
   variation="link"
   hasReactVersion
   hasVueVersion="link--default"
+  hasAngularVersion="?path=/story/link--basic"
   codepen="bJpeEp"
 />

--- a/src/content/components/list/code.mdx
+++ b/src/content/components/list/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="list--ordered"
   hasReactVersion
   hasVueVersion="list--default&knob-ordered=true"
+  hasAngularVersion="?path=/story/list--basic"
   codepen="jRqrry"
 />
 
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="list"
   hasReactVersion
   hasVueVersion="list--default"
+  hasAngularVersion="?path=/story/list--basic"
   codepen="GLZqNR"
   >
 </ComponentCode>

--- a/src/content/components/loading/code.mdx
+++ b/src/content/components/loading/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="loading"
     hasReactVersion
     hasVueVersion="loading--default"
+    hasAngularVersion="?path=/story/loading--basic&knob-With overlay=true&knob-Size of the loading circle=normal"
     codepen="eoZzvV"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="loading--without-overlay"
     hasReactVersion
     hasVueVersion="loading--default&knob-overlay=false"
+    hasAngularVersion="?path=/story/loading--basic"
     codepen="ROaRgb"
     >
 </ComponentCode>
@@ -27,6 +29,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="loading--small"
     hasReactVersion
     hasVueVersion="loading--default&knob-small=true"
+    hasAngularVersion="?path=/story/loading--basic&knob-With overlay=&knob-Size of the loading circle=sm"
     codepen="dLMXRE"
     >
 </ComponentCode>

--- a/src/content/components/modal/code.mdx
+++ b/src/content/components/modal/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="modal"
   hasReactVersion
   hasVueVersion="modal--buttons"
+  hasAngularVersion="?path=/story/modal--transactional"
   codepen="QPNEOv"
 />
 <ComponentCode
@@ -17,6 +18,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="modal--nofooter"
   hasReactVersion
   hasVueVersion="modal--default"
+  hasAngularVersion="?path=/story/modal--passive"
   codepen="bJpeag"
 />
 <ComponentCode
@@ -25,6 +27,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="modal--danger"
   hasReactVersion
   hasVueVersion="modal--danger"
+  hasAngularVersion="?path=/story/modal--transactional&knob-modalType=danger&knob-modalLabel=optional label&knob-modalTitle=Delete service from application&knob-modalContent=Are you sure you want to remove the Speech to Text service from the node-test app?"
   codepen="YMqWaK"
 />
 

--- a/src/content/components/notification/code.mdx
+++ b/src/content/components/notification/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="inline-notification"
     hasReactVersion
     hasVueVersion="inlinenotification--default"
+    hasAngularVersion="?path=/story/notification--basic"
     codepen="NmNrLg"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="toast-notification"
     hasReactVersion
     hasVueVersion="toastnotification--default"
+    hasAngularVersion="?path=/story/notification--toast"
     codepen="vMGKQO"
     >
 </ComponentCode>

--- a/src/content/components/number-input/code.mdx
+++ b/src/content/components/number-input/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasReactVersion
     hasLightVersion
     hasVueVersion="numberinput--default"
+    hasAngularVersion="?path=/story/number--basic"
     codepen="zXqBMy"
     >
 </ComponentCode>

--- a/src/content/components/overflow-menu/code.mdx
+++ b/src/content/components/overflow-menu/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="overflow-menu"
     hasReactVersion
     hasVueVersion="overflowmenu--default"
+    hasAngularVersion="?path=/story/overflow-menu--basic"
     codepen="PgNGop"
     >
 </ComponentCode>

--- a/src/content/components/pagination/code.mdx
+++ b/src/content/components/pagination/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="pagination"
   hasReactVersion
   hasVueVersion="pagination--default"
+  hasAngularVersion="?path=/story/pagination--default"
   codepen="KYzgVB"
 />
 <ComponentCode

--- a/src/content/components/progress-indicator/code.mdx
+++ b/src/content/components/progress-indicator/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="progress-indicator"
     hasReactVersion
     hasVueVersion="progress--default"
+    hasAngularVersion="?path=/story/progress-indicator--basic"
     codepen="dLMppM"
     >
 </ComponentCode>
@@ -17,6 +18,7 @@ tabs: ['Code', 'Usage', 'Style']
     component="progress-indicator"
     variation="progress-indicator--vertical"
     hasReactVersion
+    hasAngularVersion="?path=/story/progress-indicator--vertical"
     codepen="QPNKpB"
     >
 </ComponentCode>

--- a/src/content/components/radio-button/code.mdx
+++ b/src/content/components/radio-button/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="radio-button"
     hasReactVersion
     hasVueVersion="radiobutton--default"
+    hasAngularVersion="?path=/story/radio--basic"
     codepen="MRyjOR"
     >
 </ComponentCode>

--- a/src/content/components/search/code.mdx
+++ b/src/content/components/search/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
   hasLightVersion
   hasReactVersion
   hasVueVersion="search--default"
+  hasAngularVersion="?path=/story/search--basic"
   codepen="dLMpqv"
 />
 <ComponentCode
@@ -19,6 +20,7 @@ tabs: ['Code', 'Usage', 'Style']
   hasLightVersion
   hasReactVersion
   hasVueVersion="search--default&knob-small=true"
+  hasAngularVersion="?path=/story/search--basic&knob-size=sm&knob-theme=dark&knob-disabled=&knob-placeholder=Search"
   codepen="dLMpQv"
 />
 <ComponentDocs component="search" />

--- a/src/content/components/select/code.mdx
+++ b/src/content/components/select/code.mdx
@@ -11,6 +11,7 @@ tabs: ['Code', 'Usage', 'Style']
   hasLightVersion
   hasReactVersion
   hasVueVersion="select--default"
+  hasAngularVersion="?path=/story/select--basic"
   codepen="oOxzmZ"
 />
 <ComponentCode
@@ -37,6 +38,7 @@ tabs: ['Code', 'Usage', 'Style']
   variation="select--inline"
   hasReactVersion
   hasVueVersion="select--default&knob-inline=true"
+  hasAngularVersion="?path=/story/select--basic&knob-Theme=dark&knob-Display=inline"
   codepen="qwZaer"
 />
 <ComponentCode

--- a/src/content/components/slider/code.mdx
+++ b/src/content/components/slider/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
     hasReactVersion
     hasLightVersion
     hasVueVersion="slider--default"
+    hasAngularVersion="?path=/story/slider--basic"
     codepen="zXqozN"
     >
 </ComponentCode>
@@ -19,6 +20,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="slider--disabled"
     hasReactVersion
     hasVueVersion="slider--default&knob-disabled=true"
+    hasAngularVersion="?path=/story/slider--basic&knob-disabled=true"
     codepen="qwZqPV"
     >
 </ComponentCode>

--- a/src/content/components/structured-list/code.mdx
+++ b/src/content/components/structured-list/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="structured-list"
     hasReactVersion
     hasVueVersion="structuredlist--default"
+    hasAngularVersion="?path=/story/structured-list--basic"
     codepen="oOxYoE"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="structured-list--selection"
     hasReactVersion
     hasVueVersion="structuredlist--selectable-with-vmodel"
+    hasAngularVersion="?path=/story/structured-list--with-selection"
     codepen="NmNbyK"
     >
 </ComponentCode>

--- a/src/content/components/tabs/code.mdx
+++ b/src/content/components/tabs/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="tabs"
     hasReactVersion
     hasVueVersion="tabs--default"
+    hasAngularVersion="?path=/story/tabs--basic"
     codepen="zXqoaz"
     >
 </ComponentCode>

--- a/src/content/components/tag/code.mdx
+++ b/src/content/components/tag/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="tag"
     hasReactVersion
     hasVueVersion="tag--default"
+    hasAngularVersion="?path=/story/tag--basic"
     codepen="zXqoLz"
     >
 </ComponentCode>

--- a/src/content/components/text-input/code.mdx
+++ b/src/content/components/text-input/code.mdx
@@ -10,6 +10,7 @@ tabs: ['Code', 'Usage', 'Style']
   hasLightVersion
   hasReactVersion
   hasVueVersion="textinput--default"
+  hasAngularVersion="?path=/story/input--input"
   codepen="EJKNOw"
 />
 
@@ -20,6 +21,7 @@ tabs: ['Code', 'Usage', 'Style']
   hasLightVersion
   hasReactVersion
   hasVueVersion="textarea--default"
+  hasAngularVersion="?path=/story/input--textarea"
   codepen="JVXbQv"
 />
 

--- a/src/content/components/tile/code.mdx
+++ b/src/content/components/tile/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="tile"
     hasReactVersion
     hasVueVersion="tile--default"
+    hasAngularVersion="?path=/story/tiles--basic"
     codepen="qwZRWy"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="tile--clickable"
      hasReactVersion
     hasVueVersion="tile--clickable"
+    hasAngularVersion="?path=/story/tiles--clickable"
     codepen="yrOgyM"
     >
 </ComponentCode>

--- a/src/content/components/toggle/code.mdx
+++ b/src/content/components/toggle/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="toggle"
     hasReactVersion
     hasVueVersion="toggle--default"
+    hasAngularVersion="?path=/story/toggle--basic"
     codepen="QPNddd"
     >
 </ComponentCode>
@@ -18,6 +19,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="toggle--small"
     hasReactVersion
     hasVueVersion="toggle--default&knob-small=true"
+    hasAngularVersion="?path=/story/toggle--basic&knob-disabled=&knob-checked=&knob-size=sm"
     codepen="XQdppE"
     >
 </ComponentCode>

--- a/src/content/components/tooltip/code.mdx
+++ b/src/content/components/tooltip/code.mdx
@@ -9,6 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
     variation="tooltip"
     hasReactVersion
     hasVueVersion="tooltip--default-interactive-tootlip"
+    hasAngularVersion="?path=/story/tooltip--basic"
     codepen="OGNWpy"
     >
 </ComponentCode>

--- a/src/content/experimental/ui-shell/code.mdx
+++ b/src/content/experimental/ui-shell/code.mdx
@@ -9,4 +9,5 @@ tabs: ['Usage', 'Code']
   variation="ui-shell--side-nav-fixed"
   experimental
   hasReactVersion
+  hasAngularVersion="?path=/story/ui-shell--together"
 />


### PR DESCRIPTION
- change hasAngularVersion to take a string
- add hasAngularVersion to ComponentReact
- add getLibraryLinks to ComponentReact
  - text can totally change, but it better represents components that are available in React _and_ Angular 
- add angular links to component demos