### PR TITLE
fix: Deleted duplicate paragraph in Tooltip

### DIFF
--- a/src/content/components/tooltip/usage.mdx
+++ b/src/content/components/tooltip/usage.mdx
@@ -28,8 +28,6 @@ The primary purpose of a definition tooltip is to provide additional help or def
 
 #### Interactive Tooltip
 
-The primary purpose of a definition tooltip is to provide additional help or define an item or term. Therefore, they should contain read-only text that is kept to a minimum. The use of interactive elements, such as buttons or links, is discouraged. Definition tooltips appear on `hover` and `focus`.
-
 Interactive tooltips can contain text and other interactive elements such as a button or a link. They appear when the user clicks on an info icon and are persistent until intentionally dismissed by clicking outside of the tooltip.
 
 <ImageComponent cols="8"  caption="Example of an interactive tooltip.">


### PR DESCRIPTION
<img width="944" alt="Screen Shot 2019-04-15 at 3 01 14 PM" src="https://user-images.githubusercontent.com/19270502/56161564-6f132b00-5f8f-11e9-9f34-596d31f34a29.png">
