### PR TITLE
fix(ComponentExample): fix overflow menu position for FF

### DIFF
--- a/src/components/ComponentExample/ComponentExample.js
+++ b/src/components/ComponentExample/ComponentExample.js
@@ -197,7 +197,7 @@ class ComponentExample extends Component {
                           : parseInt(
                               liveContainerRef.ownerDocument.defaultView
                                 .getComputedStyle(liveContainerRef)
-                                .getPropertyValue('border-width')
+                                .getPropertyValue('border-left-width') // FF doesn't have one for `border-width`
                             );
                       const adjustLeft =
                         liveContainerLeft +


### PR DESCRIPTION
Fixes #1459.

#### Changelog

**Changed**

- Change in how to obtain border width for component example container DOM element.