### PR TITLE
[content] Sentence casing and wording fix on homepage resource section

### DIFF
--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -23,9 +23,9 @@ import ClickableTile from '../../src/components/ClickableTile';
 
 </FeatureTile>
 
-### Other Resources
+### Other resources
 
-The Component Libraries give developers a collection of re-usable components they can use for building websites and user interfaces. See a [complete list of resources.](/resources)
+The component libraries give developers a collection of reusable components for building websites and user interfaces. See a [complete list of resources.](/resources)
 
 <Row className="tile--resource--no-margin tile--group">
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>


### PR DESCRIPTION
* Titles should be in sentence casing
* Re-usable isn't a word. Changed to reusable.
* Direct language. Developers "can use"