### PR TITLE
[content] Experimental overview page refresh

### DIFF
--- a/src/content/components/button/usage.mdx
+++ b/src/content/components/button/usage.mdx
@@ -5,7 +5,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 <AnchorLinks>
 
-- [General guidance ](#general-guidance)
+- [General guidance](#general-guidance)
 - [Variations](#variations)
 - [Labels](#labels) 
 - [Icon usage](#icon-usage)

--- a/src/content/experimental/about/overview.mdx
+++ b/src/content/experimental/about/overview.mdx
@@ -1,22 +1,43 @@
 ---
-title: About
+title: About experimental
 tabs: ['Overview', 'Usage']
 ---
 
-## We want your feedback
+### "Experimental" means "we're looking at it". Carbon is a collaborative and distributed effort. If you like what you see, the Carbon team wants your help.
 
-Experimental components, designs, and other resources are presented for testing and feedback. They are not intended for production use. The Carbon team is continually updating components, and introducing new design and development guidelines into the Carbon Design System.
+<AnchorLinks>
 
-We want to provide early-access to our changes, so that designers and developers can test, work with, and provide feedback. These resources are provided in the "experimental" section of the site.
+- [How this works](#how-this-works)
+- [What you need to know](#what-are-experimental-resources)
+- [We want your help](#we-want-your-help)
 
-## What are "experimental" resources?
+</AnchorLinks>
 
-Experimental components, designs, patterns, and other resources are work that is still under development.
+## How this works
 
-They are not intended for production use, and are subject to change but are in a state where it can be productive for designers and developers to start to work with them. They may have some non-functional pieces, or be lacking in documentation. _There is no guarantee of support_.
+Carbon is always getting better. This happens through continual feature and usability upgrades to our elements and core components. It also happens through exploration and experimentation. The Carbon team will surface this exploration here. 
 
-These resources are also the future path of the Carbon Design System. As they are refined and improved, they may become core resources.
+Expect these components, patterns, and tools to change over time. If you choose to use experimental resources, you can help move them closer to production by contributing feedback, code, and design.
 
-## How can I help?
+Some of these resources will become core parts of the Carbon Design System.
 
-Your feedback is critical for the success of the Carbon Design System, and for experimental components to improve and "graduate" to being production ready. Please open a GitHub issue from the footer of any page on the Carbon Design System website to let the team know what you think. Or, if you see a problem, fix it and submit a pull request. We make sure that we acknowledge all contributors to the Carbon Design System.
+
+## What you need to know
+
+Experimental components, designs, and other resources are presented for testing and feedback. They are not intended for production use.
+
+We know major releases can mean major work for designers and developers. We use experimental projects to surface future resources and get them into the hands of teams who will use them. 
+
+They may have some non-functional pieces, or be lacking in documentation. _There is no guarantee of support_.
+
+## We want your help
+
+The Carbon team is continually updating components and introducing new design and development guidelines.  
+
+We want to provide early-access to our work. Designers and developers can test, work with, and provide feedback for experimental projects.
+
+### How can I help?
+
+Your feedback is critical for every aspect of Carbon Design System development process. Input and contributions help experimental components improve and "graduate" to production release. 
+
+Please open a GitHub issue from the footer of any page on the Carbon website to let the team know what you think. If you see a problem, fix it! Help us build the web's best design system.

--- a/src/content/experimental/about/overview.mdx
+++ b/src/content/experimental/about/overview.mdx
@@ -28,7 +28,7 @@ Experimental components, designs, and other resources are presented for testing 
 
 We know major releases can mean major work for designers and developers. We use experimental projects to surface future resources and get them into the hands of teams who will use them. 
 
-They may have some non-functional pieces, or be lacking in documentation. _There is no guarantee of support_.
+They may have some non-functional pieces, or be lacking in documentation. **There is no guarantee of support**.
 
 ## We want your help
 

--- a/src/content/experimental/about/usage.mdx
+++ b/src/content/experimental/about/usage.mdx
@@ -1,5 +1,5 @@
 ---
-title: About
+title: About experimental 
 tabs: ['Overview', 'Usage']
 ---
 
@@ -10,7 +10,7 @@ Carbon uses `feature-flags` to toggle new features on and off. We currently have
 - **Experimental Components** use `components-x`
 - **UI Shell** uses `ui-shell`.
 
-To turn on either of the feature flags include the **feature-flag** variable into your SCSS file before importing `carbon-components`, then set `components-x` and/or `ui-shell` to `true`.
+To turn on either of the feature flags, include the **feature-flag** variable into your SCSS file before importing `carbon-components`, then set `components-x` and/or `ui-shell` to `true`.
 
 ```scss
 $feature-flags: (
@@ -20,10 +20,4 @@ $feature-flags: (
 @import 'carbon-components/src/globals/scss/styles';
 ```
 
-_Note: You must be using Sass and not the compiled CSS file in order to take advantage of the code using feature flags._
-
-## Disclaimer
-
-Experimental components, designs, patterns, and other resources are work that is still under development.
-
-They are not intended for production use, and are subject to change but are in a state where it can be productive for designers and developers to start to work with them. They may have some non-functional pieces, or be lacking in documentation. _There is no guarantee of support_.
+*Note: You must be using Sass to take advantage of code using feature flags. The Sass feature flags determine which CSS is compiled.*


### PR DESCRIPTION
## Refreshed content on Experimental component page.

* Mostly a copy pass for voice/tone. 
* Removed unnecessary content and redundant content on Usage page.