### PR TITLE
Fix:Update to carbon component version to 10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@mdx-js/tag": "^1.0.0-alpha.0",
     "@reach/router": "^1.2.1",
     "@vimeo/player": "^2.6.7",
-    "carbon-components": "v10.0.0",
+    "carbon-components": "v10.1.0",
     "carbon-components-react": "v7.0.0",
     "carbon-icons": "^7.0.7",
     "classnames": "^2.2.6",


### PR DESCRIPTION
The data table component examples are not the latest. @jnm2377 suggest updating to the latest version of the components would be the fix.

Current data table example
<img width="1227" alt="Screen Shot 2019-04-17 at 4 46 04 PM" src="https://user-images.githubusercontent.com/19270502/56323084-6a39ad00-6130-11e9-9853-d54745c83d39.png">
