### PR TITLE
[docs] Sentence casing on Resources page

### DIFF
--- a/src/content/resources/resources.mdx
+++ b/src/content/resources/resources.mdx
@@ -2,7 +2,7 @@
 title: Resources
 ---
 
-## GitHub Repos
+## GitHub repos
 
 <Row className="tile--resource--no-margin tile--group">
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
@@ -11,7 +11,7 @@ title: Resources
     href="https://github.com/ibm/carbon-design-kit"
     type="resource">
 
-![](images/sketch-icon.png)
+![](images/github-icon.png)
 
   </ClickableTile>
 </Column>
@@ -72,7 +72,7 @@ title: Resources
 </Column>
 <Column colLg="4" colMd="4"  noGutterSm>
   <ClickableTile
-    title="Theming Sandbox"
+    title="Theming sandbox"
     href="http://themes.carbondesignsystem.com/"
     type="resource">
 
@@ -82,7 +82,7 @@ title: Resources
 </Column>
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
   <ClickableTile
-    title="Color Contrast Checker"
+    title="Color contrast checker"
     href="https://marijohannessen.github.io/color-contrast-checker/"
     type="resource">
 
@@ -92,7 +92,7 @@ title: Resources
 </Column>
 <Column colLg="4" colMd="4"  noGutterSm>
   <ClickableTile
-    title="Carbon Boilerplate"
+    title="Carbon boilerplate"
     href="https://github.com/carbon-design-system/carbon-boilerplate"
     type="resource">
 
@@ -123,7 +123,7 @@ title: Resources
 </Column>
 </Row>
 
-## Additional Resources
+## Additional resources
 
 ### IBM Plex
 
@@ -131,7 +131,7 @@ IBM uses the font [Plex](https://github.com/IBM/plex) across products for brand 
 
 ### IBM Design Language
 
-Carbon uses the [IBM Design Language](https://www.ibm.com/design/language/) as our guiding principle. These core values remind us to design for an outcome and to be authentically thoughtful.
+Carbon uses the [IBM Design Language](https://www.ibm.com/design/language/) as its guiding principle.
 
 ## Featured
 


### PR DESCRIPTION
### Changes

* The headers on the Resources page were in title casing. 
* I removed the sentence "These core values remind us to design for an outcome and to be authentically thoughtful." from below IBM Design Language.