### PR TITLE
[docs] Changed intro H3 on Typography to be in line with Carbon voice

### DIFF
--- a/src/content/guidelines/typography/overview.mdx
+++ b/src/content/guidelines/typography/overview.mdx
@@ -1,5 +1,5 @@
 ---
-label: When used properly, typography can help create clear hierarchies, organize information, and guide users through the product or experience.
+label: Typography can help create clear hierarchies, organize information, and guide users through a product or experience.
 title: Typography
 tabs: ['Overview', 'Productive']
 ---
@@ -7,7 +7,7 @@ tabs: ['Overview', 'Productive']
 import TypeScaleTable from '../../../../src/components/TypeScaleTable';
 import TypeWeight from '../../../../src/components/TypeWeight';
 
-### With our new bespoke corporate typeface, IBM Plex™, comes a new set of guidance and best practices. Type Specs helps to set up a start point to apply typography—type scales, styles and alignment on screens.
+### Typography can help create clear hierarchies, organize information, and guide users through a product or experience.
 
 <AnchorLinks>
 


### PR DESCRIPTION
"Our new bespoke corporate typeface" is marketing speak. This page is for typography guidance, and the intro didn't match the content.