### PR TITLE
Fixed CLA anchor link

### DIFF
--- a/src/content/contributing/governance/governance.mdx
+++ b/src/content/contributing/governance/governance.mdx
@@ -9,7 +9,7 @@ title: Governance
 - [Teams](#teams)
 - [Decision-making](#decision-making)
 - [Contribution process](#contribution-process)
-- [CLAs](#clas)
+- [CLAs](#contributor-license-agreement)
 - [Support](#support)
 
 </AnchorLinks>


### PR DESCRIPTION
The CLA anchor link was broken. Changed to point to #contributor-license-agreement