### PR TITLE
[docs] Added lead h3 to Contribution/Governance page. 

### DIFF
--- a/src/content/contributing/governance/governance.mdx
+++ b/src/content/contributing/governance/governance.mdx
@@ -2,9 +2,10 @@
 title: Governance
 ---
 
+### Carbon is an ecosystem of open-source projects. This design system is the result of community contributions of code, design, ideas, and guidance.
+
 <AnchorLinks>
 
-- [Open-source](#open-source)
 - [Roles and responsibilities](#roles-and-responsibilities)
 - [Teams](#teams)
 - [Decision-making](#decision-making)
@@ -13,10 +14,6 @@ title: Governance
 - [Support](#support)
 
 </AnchorLinks>
-
-## Open-source
-
-The Carbon Design System community welcomes all feedback and contributions of design, code, guidance, and ideas in order to produce the best possible experience for our users. Carbon is an ecosystem of open-source projects, and this document describes how the system is governed, how decisions are made, and how you can get involved.
 
 ## Roles and responsibilities
 


### PR DESCRIPTION
#### Changelog

I removed the "open source" section and moved it into a higher level statement as the lead h3. This also matches our page pattern.
