### PR TITLE
Fix: Removed extra spaces in image component wrapper

### DIFF
--- a/src/content/your-product-on-ibm-cloud/widget-guidelines/style.mdx
+++ b/src/content/your-product-on-ibm-cloud/widget-guidelines/style.mdx
@@ -38,7 +38,7 @@ internal: true
 Each widget has a <b>title bar</b> and a <b>content section</b>. The title bar is standard for all widgets, but the content section varies depending on the widget type. 
 
 <ImageComponent fixed="default">
-  
+
 ![Widget Terminology](images/widget_terminology.png)
 
 </ImageComponent>
@@ -58,7 +58,7 @@ Provides the user with a quick action. This element is optional and can incorpor
 The widget padding should be 1.5rem (24px) for the top, left, right, and bottom of the content area. All widgets should have the same padding, regardless of size. 
 
 <ImageComponent fixed="default">
-  
+
 ![Small Widget Normal State](images/normal_state_small.png)
 
 </ImageComponent>

--- a/src/content/your-product-on-ibm-cloud/widget-guidelines/usage.mdx
+++ b/src/content/your-product-on-ibm-cloud/widget-guidelines/usage.mdx
@@ -30,7 +30,7 @@ Dashboard widgets have <b>two possible sizes</b>, small and large. The height fo
 <br />
 
 <ImageComponent fixed="default">
-  
+
 ![Widget Dimensions](images/widget_dimensions.png)
 
 </ImageComponent>


### PR DESCRIPTION
There were extra spaces in the image component wrapper that might have been causing the images to be broken. 