### PR TITLE
fix(color-page): flip overflow menu

### DIFF
--- a/src/components/ColorTokenTable/ColorTokenTable.js
+++ b/src/components/ColorTokenTable/ColorTokenTable.js
@@ -100,9 +100,9 @@ export default class ColorTokenTable extends React.Component {
                 value[currentTheme].hex === '#ffffff' && '1px solid #BEBEBE',
             }}
           />
-          <OverflowMenu floatingMenu={false}>
+          <OverflowMenu floatingMenu={false} flipped>
             <CopyToClipboard text={value[currentTheme].hex}>
-              <OverflowMenuItem itemText="Copy hex" />
+              <OverflowMenuItem primaryFocus itemText="Copy hex" />
             </CopyToClipboard>
             <CopyToClipboard text={token}>
               <OverflowMenuItem itemText="Copy token" />


### PR DESCRIPTION
When reviewing https://github.com/carbon-design-system/carbon-website/pull/1563, I noticed the overflow menu went off the edge of the screen, causing a horizontal scroll. Also, our focus styles were not being used. 

Without fix:
<img width="145" alt="Screen Shot 2019-04-29 at 12 37 50 PM" src="https://user-images.githubusercontent.com/11928039/56921902-c62efa80-6a7b-11e9-9fa8-ee2b2669a205.png">

With fix (does not have circle PR merged in):
<img width="208" alt="Screen Shot 2019-04-29 at 12 44 15 PM" src="https://user-images.githubusercontent.com/11928039/56922246-96342700-6a7c-11e9-83f2-ef07bfb53590.png">

