### PR TITLE
Update _website-switcher.scss

### DIFF
--- a/packages/addons-website/scss/components/_website-switcher.scss
+++ b/packages/addons-website/scss/components/_website-switcher.scss
@@ -15,7 +15,6 @@
   background-color: $carbon--gray-100;
   height: 100%;
   z-index: 1000;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   transform: translate(16rem);
   will-change: transform;
   transition: transform 0.11s cubic-bezier(0.2, 0, 1, 0.9);
@@ -30,6 +29,7 @@
 
 .#{$prefix}--website-switcher--expanded {
   transform: translate(0);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .#{$prefix}--website-switcher-list__item:nth-child(1),


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/6

Switcher should only show shadow when expanded