### PR TITLE
fix: sending resource tile to correct location

### DIFF
--- a/src/content/index.mdx
+++ b/src/content/index.mdx
@@ -31,8 +31,8 @@ The component libraries give developers a collection of reusable components for 
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
   <ClickableTile
     dark="true"
-    title="Carbon Design Kit"
-    href="https://sketch.cloud/s/JaVzz"
+    title="Sketch libraries"
+    href="/resources#sketch-libraries"
     type="resource">
 
 ![](resources/images/sketch-icon.png)


### PR DESCRIPTION
Sketch library resource tile on homepage was sending users to White theme. Now directs to Themes location on Resources page.