### PR TITLE
fix: typo

### DIFF
--- a/src/content/resources/resources.mdx
+++ b/src/content/resources/resources.mdx
@@ -313,7 +313,7 @@ Carbon uses the [IBM Design Language](https://www.ibm.com/design/language/) as i
 
   </ClickableTile>
 </Column>
-<Column offsetLg="4" colLg="4" colMd="4" noGutterMdLeft>>
+<Column offsetLg="4" colLg="4" colMd="4" noGutterMdLeft>
   <ClickableTile
     type="article"
     title="Hacktoberfest with Carbon"


### PR DESCRIPTION
removes extra `>` tag on the Resources page