### PR TITLE
[fix] Sentence casing, removed intro italics

### DIFF
--- a/src/content/components/tooltip/usage.mdx
+++ b/src/content/components/tooltip/usage.mdx
@@ -4,7 +4,7 @@ tabs: ['Code', 'Usage','Style']
 ---
 ## General guidance
 
-_Tooltips_ provide additional information upon hover or focus. They often contain helper text that is contextual to an element.
+Tooltips provide additional information upon hover or focus. They often contain helper text that is contextual to an element.
 
 #### Icon tooltip
 
@@ -16,7 +16,7 @@ An icon tooltip is used to clarify the action or name of an interactive icon but
 
 </ImageComponent>
 
-#### Definition Tooltip
+#### Definition tooltip
 
 The primary purpose of a definition tooltip is to provide additional help or define an item or term. Therefore, they should contain read-only text that is kept to a minimum. The use of interactive elements, such as buttons or links, is discouraged. Definition tooltips appear on `hover` and `focus`.
 
@@ -26,7 +26,7 @@ The primary purpose of a definition tooltip is to provide additional help or def
 
 </ImageComponent>
 
-#### Interactive Tooltip
+#### Interactive tooltip
 
 Interactive tooltips can contain text and other interactive elements such as a button or a link. They appear when the user clicks on an info icon and are persistent until intentionally dismissed by clicking outside of the tooltip.
 


### PR DESCRIPTION
Removed intro italics because the topic of the page shouldn't need to be emphasized. 

P.S. We also aren't consistent with our emphasis styling, using bold sometimes and italics other times.
This is something we do on most of our pages, and I've been removing it as I work on pages.