### PR TITLE
[docs] Added requested information to Interactive tooltip usage page

### DIFF
--- a/src/content/components/tooltip/usage.mdx
+++ b/src/content/components/tooltip/usage.mdx
@@ -4,11 +4,15 @@ tabs: ['Code', 'Usage','Style']
 ---
 ## General guidance
 
-Tooltips provide additional information upon hover or focus. They often contain helper text that is contextual to an element.
+Tooltips provide additional information upon hover or focus.
 
-#### Icon tooltip
+## Variants
 
-An icon tooltip is used to clarify the action or name of an interactive icon button. The tooltip content should only contain one to two words. Icon tooltips appear on `hover` and `focus`.
+A tooltip is to provide additional, contextual information. Each variant achieves this for different design needs.
+
+### Icon tooltip
+
+An icon tooltip is used to clarify the action or name of an interactive icon button.
 
 <ImageComponent cols="8"  caption="Icon tooltip used to clarify the action or name of an interactive icon button.">
 
@@ -16,9 +20,17 @@ An icon tooltip is used to clarify the action or name of an interactive icon but
 
 </ImageComponent>
 
-#### Definition tooltip
+#### Guidance:
 
-The primary purpose of a definition tooltip is to provide additional help or define an item or term. Therefore, they should contain read-only text that is kept to a minimum. The use of interactive elements, such as buttons or links, is discouraged. Definition tooltips appear on `hover` and `focus`.
+* The tooltip content should only contain one or two words.
+
+#### Behavior:
+
+* Icon tooltips appear on `hover` and `focus`.
+
+### Definition tooltip
+
+The definition tooltip provides additional help or defines an item or term. 
 
 <ImageComponent cols="8"  caption="Definition tooltip used to define a Form label.">
 
@@ -26,12 +38,39 @@ The primary purpose of a definition tooltip is to provide additional help or def
 
 </ImageComponent>
 
-#### Interactive tooltip
+#### Guidance:
 
-Interactive tooltips can contain text and other interactive elements such as a button or a link. They appear when the user clicks on an info icon and are persistent until intentionally dismissed by clicking outside of the tooltip.
+* Should contain brief, read-only text.
+
+#### Behavior:
+
+* Definition tooltips appear on `hover` and `focus`.
+
+
+### Interactive tooltips
+
+Interactive tooltips contain text and other interactive elements like buttons or links.
 
 <ImageComponent cols="8"  caption="Example of an interactive tooltip.">
 
 ![Example image of an interactive tooltip.](images/tooltip-usage-3.png)
 
 </ImageComponent>
+
+Use interactive tooltips when users may be seeking more info than can fit in a definition tooltip.
+
+#### Guidance:
+
+* If a user may need to visit an external resource, like while using a form, include a link in your interactive tooltip.
+* Don't use without a label. Consider the context a user needs before clicking a link.
+
+#### Behavior:
+
+* Interactive tooltips appear when the user clicks on an info icon. 
+* They persistent until intentionally dismissed by clicking outside of the tooltip.
+
+
+
+
+
+


### PR DESCRIPTION
In response to https://github.com/carbon-design-system/carbon-website/issues/1492.

* Adjusted header weights and standardizing pattern to allow for expanded guidance.
* Added additional guidance for interactive tooltip.

It still looks weird with only a line of copy beneath "general guidance" but that's a pattern that persists across our usage pages. More content will follow as part of an upcoming component content push.

Opened issue for contextual images on all of our component pages (https://github.com/carbon-design-system/carbon-website/issues/1587). Currently, too many images just float in space without context.