### PR TITLE
fix(copy-button): provide text to copy button

### DIFF
--- a/packages/addons-website/src/components/WebsiteCodeSnippet/WebsiteCodeSnippet.js
+++ b/packages/addons-website/src/components/WebsiteCodeSnippet/WebsiteCodeSnippet.js
@@ -41,7 +41,7 @@ export default class WebsiteCodeSnippet extends React.Component {
 
     let textToCopy;
     if (children.props.children) {
-      textToCopy = children.props.children.replace(/[$]+/g, '');
+      textToCopy = children.props.children.replace(/(\$ )+/g, '');
     }
 
     return (

--- a/packages/addons-website/src/components/WebsiteCodeSnippet/WebsiteCodeSnippet.js
+++ b/packages/addons-website/src/components/WebsiteCodeSnippet/WebsiteCodeSnippet.js
@@ -38,12 +38,20 @@ export default class WebsiteCodeSnippet extends React.Component {
   render() {
     const { children } = this.props;
     const type = this.state.multi ? 'multi' : 'single';
+
+    let textToCopy;
+    if (children.props.children) {
+      textToCopy = children.props.children.replace(/[$]+/g, '');
+    }
+
     return (
       <div className={`${prefix}--row`}>
         <div
           className={`${prefix}--col-lg-8 ${prefix}--offset-lg-4 ${prefix}--no-gutter`}>
           <div className={`${prefix}--snippet--website`}>
-            <CopyToClipboard onCopy={() => this.setState({ copied: true })}>
+            <CopyToClipboard
+              text={textToCopy}
+              onCopy={() => this.setState({ copied: true })}>
               <CodeSnippet type={type}>
                 <div ref={element => (this.codeRef = element)}>{children}</div>
               </CodeSnippet>


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/1558

Adds in the ability to actually copy the text on pages like https://www.carbondesignsystem.com/getting-started/developers/vanilla

Multi-line commands still cause problems when copied directly into the terminal. Wonder if we could possibly replace the `$` with a new line character?

#### Changelog

**Changed**

- Provided `CopyToClipboard` with a `text` prop
