### PR TITLE
fix(website): add links to component variations

### DIFF
--- a/src/components/ComponentCode/ComponentCode.js
+++ b/src/components/ComponentCode/ComponentCode.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
+import { Location } from '@reach/router';
+import { Link } from 'gatsby';
+import { Link20 } from '@carbon/icons-react';
 import ComponentExample from '../ComponentExample/ComponentExample';
 
 export default class ComponentCode extends React.Component {
@@ -41,30 +43,53 @@ export default class ComponentCode extends React.Component {
     }
 
     return (
-      <>
-        <div className="bx--row">
-          <div className="bx--col-lg-12 bx--offset-lg-4">
-            <h2 className="page-h2">{name}</h2>
-          </div>
-        </div>
+      <Location>
+        {({ location }) => {
+          const hash = name
+            .replace(/[:&?’‘“”'",.]/g, '')
+            .toLowerCase()
+            .split(' ')
+            .join('-');
+          const path = location.pathname;
 
-        <div className="component-variation bx--row">
-          <div className="bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
-            <ComponentExample
-              codepenSlug={codepen}
-              component={component}
-              variation={variation}
-              htmlFile={htmlFile}
-              hideViewFullRender={this.props.hideViewFullRender}
-              hasLightVersion={hasLightVersion}
-              hasReactVersion={hasReactVersion}
-              hasAngularVersion={hasAngularVersion}
-              hasVueVersion={hasVueVersion}
-              experimental={experimental}
-            />
-          </div>
-        </div>
-      </>
+          return (
+            <>
+              <div className="bx--row">
+                <div className="bx--col-lg-12 bx--offset-lg-4">
+                  <h2 id={hash} className="page-h2">
+                    {hash && (
+                      <Link className="anchor-link" to={`${path}#${hash}`}>
+                        <Link20
+                          className="anchor-link__icon"
+                          aria-label="Anchor Link"
+                        />
+                      </Link>
+                    )}
+                    {name}
+                  </h2>
+                </div>
+              </div>
+
+              <div className="component-variation bx--row">
+                <div className="bx--col-lg-12 bx--offset-lg-4 bx--no-gutter">
+                  <ComponentExample
+                    codepenSlug={codepen}
+                    component={component}
+                    variation={variation}
+                    htmlFile={htmlFile}
+                    hideViewFullRender={this.props.hideViewFullRender}
+                    hasLightVersion={hasLightVersion}
+                    hasReactVersion={hasReactVersion}
+                    hasAngularVersion={hasAngularVersion}
+                    hasVueVersion={hasVueVersion}
+                    experimental={experimental}
+                  />
+                </div>
+              </div>
+            </>
+          );
+        }}
+      </Location>
     );
   }
 }

--- a/src/components/ComponentDocs/ComponentDocs.js
+++ b/src/components/ComponentDocs/ComponentDocs.js
@@ -26,21 +26,18 @@ export default class ComponentDocs extends React.Component {
     return (
       <Location>
         {({ location }) => {
-          const hash = 'documentation';
           const path = location.pathname;
 
           return (
             <div className="page_md component-docs bx--row">
               <div className="bx--col-lg-12 bx--offset-lg-4">
-                <h2 id={hash} className="page-h2">
-                  {hash && (
-                    <Link className="anchor-link" to={`${path}#${hash}`}>
-                      <Link20
-                        className="anchor-link__icon"
-                        aria-label="Anchor Link"
-                      />
-                    </Link>
-                  )}
+                <h2 id="documentation" className="page-h2">
+                  <Link className="anchor-link" to={`${path}#documentation`}>
+                    <Link20
+                      className="anchor-link__icon"
+                      aria-label="Anchor Link"
+                    />
+                  </Link>
                   Documentation
                 </h2>
                 {

--- a/src/components/ComponentDocs/ComponentDocs.js
+++ b/src/components/ComponentDocs/ComponentDocs.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Location } from '@reach/router';
+import { Link } from 'gatsby';
+import { Link20 } from '@carbon/icons-react';
 
 export default class ComponentDocs extends React.Component {
   static propTypes = {
@@ -21,18 +24,37 @@ export default class ComponentDocs extends React.Component {
     }
 
     return (
-      <div className="page_md component-docs bx--row">
-        <div className="bx--col-lg-12 bx--offset-lg-4">
-          <h2 className="page-h2">Documentation</h2>
-          {
-            <div
-              dangerouslySetInnerHTML={{
-                __html: componentDocUrl,
-              }}
-            />
-          }
-        </div>
-      </div>
+      <Location>
+        {({ location }) => {
+          const hash = 'documentation';
+          const path = location.pathname;
+
+          return (
+            <div className="page_md component-docs bx--row">
+              <div className="bx--col-lg-12 bx--offset-lg-4">
+                <h2 id={hash} className="page-h2">
+                  {hash && (
+                    <Link className="anchor-link" to={`${path}#${hash}`}>
+                      <Link20
+                        className="anchor-link__icon"
+                        aria-label="Anchor Link"
+                      />
+                    </Link>
+                  )}
+                  Documentation
+                </h2>
+                {
+                  <div
+                    dangerouslySetInnerHTML={{
+                      __html: componentDocUrl,
+                    }}
+                  />
+                }
+              </div>
+            </div>
+          );
+        }}
+      </Location>
     );
   }
 }

--- a/src/components/HomepageVideo/HomepageVideo.js
+++ b/src/components/HomepageVideo/HomepageVideo.js
@@ -88,7 +88,7 @@ export default class HomepageVideo extends React.Component {
         <rect
           id="_Transparent_Rectangle_"
           data-name="&lt;Transparent Rectangle&gt;"
-          class="cls-1"
+          className="cls-1"
           width="32"
           height="32"
         />
@@ -105,7 +105,7 @@ export default class HomepageVideo extends React.Component {
         <rect
           id="_Transparent_Rectangle_"
           data-name="&lt;Transparent Rectangle&gt;"
-          class="cls-1"
+          className="cls-1"
           width="32"
           height="32"
         />

--- a/src/components/WebsiteAlert/WebsiteAlert.js
+++ b/src/components/WebsiteAlert/WebsiteAlert.js
@@ -13,7 +13,9 @@ export default class WebsiteAlert extends React.Component {
           <span /> <span>{alertDescription}</span>
         </p>
         <Link className="website-alert__button" tabIndex="-1" to={buttonTo}>
-          <button class="bx--btn bx--btn--secondary bx--btn--sm" type="button">
+          <button
+            className="bx--btn bx--btn--secondary bx--btn--sm"
+            type="button">
             <span>{buttonText}</span>
             <ArrowRight20 />
           </button>

--- a/src/content/components/date-picker/usage.mdx
+++ b/src/content/components/date-picker/usage.mdx
@@ -36,7 +36,7 @@ Both date and time pickers are accompanied by labels, and follow the same access
 
 #### Format
 
-For date pickers, use placeholder text so users input the date in the correct format. It can be formatted in a variety of ways. See the date picker code [documentation](https://github.com/ibm/carbon-components/tree/master/src/components/date-picker) for more info.
+For date pickers, use placeholder text so users input the date in the correct format. It can be formatted in a variety of ways. See the date picker code [documentation](https://github.com/carbon-design-system/carbon-components/tree/master/packages/components/src/components/date-picker) for more info.
 
 ## Interaction
 

--- a/src/content/components/date-picker/usage.mdx
+++ b/src/content/components/date-picker/usage.mdx
@@ -36,7 +36,7 @@ Both date and time pickers are accompanied by labels, and follow the same access
 
 #### Format
 
-For date pickers, use placeholder text so users input the date in the correct format. It can be formatted in a variety of ways. See the date picker code [documentation](https://github.com/carbon-design-system/carbon-components/tree/master/packages/components/src/components/date-picker) for more info.
+For date pickers, use placeholder text so users input the date in the correct format. It can be formatted in a variety of ways. See the date picker code [documentation](https://github.com/carbon-design-system/carbon-components/blob/master/packages/components/src/components/date-picker/README.md) for more info.
 
 ## Interaction
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/1461
Closes https://github.com/carbon-design-system/carbon-website/issues/1597

Turned out to be a bigger fix that the branch name implies 😅 

#### Changelog

**New**

- Component variations all now have an anchor link

**Changed**

- Fixes a 404 on a link in `DatePicker` docs
- Switched `class` to `className` in a few instances
