### PR TITLE
Update react-step-1.mdx

### DIFF
--- a/src/content/tutorial/react-step-1/react-step-1.mdx
+++ b/src/content/tutorial/react-step-1/react-step-1.mdx
@@ -274,11 +274,11 @@ import {
 const TutorialHeader = () => (
   <Header aria-label="Carbon Tutorial">
     <SkipToContent />
-    <HeaderName href="/" prefix="IBM">
+    <HeaderName to="/" prefix="IBM">
       Carbon Tutorial
     </HeaderName>
     <HeaderNavigation aria-label="Carbon Tutorial">
-      <HeaderMenuItem href="/repos">Repositories</HeaderMenuItem>
+      <HeaderMenuItem to="/repos">Repositories</HeaderMenuItem>
     </HeaderNavigation>
     <HeaderGlobalBar />
   </Header>


### PR DESCRIPTION
Changing the `href` to `to` isn't explicitly called out in later steps during routing. Might as well have the learner use the correct syntax from the beginning. The alternative is to call it out more explicitly during the routing steps.

I think PR #1677 fixes the issue better.

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
