### PR TITLE
fix: change brand link in switcher

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -316,7 +316,7 @@ class Layout extends React.Component {
                   linkText: 'IBM Design Language',
                 },
                 {
-                  href: 'https://www.ibm.com/design/brand/',
+                  href: 'https://www.ibm.com/brand/',
                   linkText: 'IBM Brand Center',
                 },
                 {


### PR DESCRIPTION
Closes #1769 

#### Changelog

**New**

**Changed**

- changed "IBM Brand Center" in switcher to link to https://www.ibm.com/brand/

**Removed**
