### PR TITLE
Fix link to Sketch library on Chatbot Overview Page

### DIFF
--- a/src/content/experimental/chatbot/overview.mdx
+++ b/src/content/experimental/chatbot/overview.mdx
@@ -90,7 +90,7 @@ While conversational interfaces may contain many different kinds of components, 
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
   <ClickableTile
     title="Chatbot Sketch library"
-    href="https://ibm.box.com/s/blx6a2z2qnp5dtmi7xz0zfj22dkac1k2"
+    href="https://ibm.box.com/s/7vauj3l8o88wukv6p80lddwhjlonoipd"
     type="resource">
 
 ![](/images/sketch-icon.png)


### PR DESCRIPTION
I noticed the link to the Sketch library on the Chatbot Overview page seems to be broken 😞: https://www.carbondesignsystem.com/experimental/chatbot/overview . The file wasn't locked and it looks like the permissions were changed somehow or some files were rearranged). This PR uses a new link on the Overview page. To ensure it doesn't become unlinked again, I've locked the file using Box's locking feature, the same way we lock our design files in WH.

#### Changelog

**Changed**

- Reconnects Chatbot Sketch Library file