### PR TITLE
chore: add netlify link to footer

### DIFF
--- a/src/components/Layouts/index.js
+++ b/src/components/Layouts/index.js
@@ -411,6 +411,10 @@ class Layout extends React.Component {
                     href: 'https://twitter.com/_carbondesign',
                     linkText: 'Twitter',
                   },
+                  {
+                    href: 'https://www.netlify.com',
+                    linkText: 'Netlify',
+                  },
                 ]}>
                 <p>
                   Have questions? Email us or open


### PR DESCRIPTION
Closes #1576 

Adds link to Netlify to our footer, we are required to link to them per terms of our OSS plan. We don't have to have it in the footer, we could also just have a link on the homepage if someone had a better idea, but we need to get the link up asap. 

https://www.netlify.com/legal/open-source-policy/
> In exchange for this free service, we request that you place a link to our service on your main page. We have premade badges for your convenience, or you may create your own link.
