### PR TITLE
docs(tutorial): add note on speeding up deploys

### DIFF
--- a/src/content/tutorial/react-step-5/react-step-5.mdx
+++ b/src/content/tutorial/react-step-5/react-step-5.mdx
@@ -165,6 +165,8 @@ After telling Cloud Foundry what to include, we can also specify what to ignore.
 node_modules/.cache
 ```
 
+You can speed up deploys by decreasing the files uploaded through cloud foundry. To accomplish this, ignore any folder not required by the production application on IBM Cloud. For example, in the case of serving static files, you can ignore `node_modules/` and `src/` because the only folder being served is `build/`.
+
 ## Deploy app
 
 Login to IBM Cloud with:


### PR DESCRIPTION
As mentioned by Matt Rosno in the Tutorial 5 live broadcast, you can ignore the entire `node_modules/` in `.cfignore` instead of just the `node_modules/.cache`.

By ignoring the `node_modules/` folder, the size of uploaded files can be reduced dramatically (from `60+M` to less than `1M`).

#### Changelog

**New**

- Add note on ignoring more folders in the `.cfignore`
