### PR TITLE
fix(tutorial): typos in doc for step 5

### DIFF
--- a/src/content/tutorial/react-step-5/react-step-5.mdx
+++ b/src/content/tutorial/react-step-5/react-step-5.mdx
@@ -73,7 +73,7 @@ Before we get started, [create an IBM Cloud account](https://cloud.ibm.com/regis
 
 ## Optimize Sass
 
-So far we've be developing in a, well, development environment where static asset optimization hasn't been a priority. If you reference `/src/index.scss`, you'll see one `@import` that is pulling in Carbon's full Sass build.
+So far we've been developing in a, well, development environment where static asset optimization hasn't been a priority. If you reference `/src/index.scss`, you'll see one `@import` that is pulling in Carbon's full Sass build.
 
 ##### src/index.scss
 
@@ -115,7 +115,7 @@ You can read more about optimizing Carbon's Sass in the [Carbon Design System pu
 
 ## Build for production
 
-Before we deploy our app, we need create an optimized production build with this command. You may need to `CTRL-C` to stop the development environment first.
+Before we deploy our app, we need to create an optimized production build with this command. You may need to `CTRL-C` to stop the development environment first.
 
 ```bash
 $ yarn build
@@ -131,7 +131,7 @@ Now that we have a production build, let's get it on the cloud. We're going to u
 
 _Note: If unfamiliar with buildpacks, the [staticfile buildpack docs](https://docs.cloudfoundry.org/buildpacks/staticfile/index.html) has good definitions and configuration documentation._
 
-With the Cloud Foundry CLI installed, next we need to create a `manifest.yml` file in the root of the project. To prevent muliple apps trying to use the `carbon-tutorial` name, replace `USERNAME` with your GitHub username below to make sure our apps are uniquely named.
+With the Cloud Foundry CLI installed, next, we need to create a `manifest.yml` file in the root of the project. To prevent multiple apps trying to use the `carbon-tutorial` name, replace `USERNAME` with your GitHub username below to make sure our apps are uniquely named.
 
 ##### manifest.yml
 


### PR DESCRIPTION
Closes #1784

Fix a couple of typos in tutorial step 5 doc.

#### Changelog

**Changed**

See #1784 with the list of typos and references to the places where they are located.
