### PR TITLE
chore(icons): update link to monorepo for icons

### DIFF
--- a/src/content/guidelines/iconography/library.mdx
+++ b/src/content/guidelines/iconography/library.mdx
@@ -11,7 +11,7 @@ import IconLibrary from '../../../../src/components/IconLibrary';
 <Column offsetLg="4" colMd="4" colLg="4" noGutterSm>
   <ClickableTile
     title="Elements package: Icons"
-    href="https://github.com/IBM/carbon-elements/tree/master/packages/icons"
+    href="https://github.com/carbon-design-system/carbon/tree/master/packages/icons"
     type="resource">
 
 ![](images/github-icon.png)


### PR DESCRIPTION
Update link for icon resource to monorepo path.

#### Changelog

**New**

**Changed**

- resource tile on `library.mdx` now uses the correct link

**Removed**
