### PR TITLE
Update designers.mdx

### DIFF
--- a/src/content/contributing/designers/designers.mdx
+++ b/src/content/contributing/designers/designers.mdx
@@ -9,8 +9,8 @@ Welcome and thank you for contributing! The Carbon team is committed to maintain
 Carbon has three different levels of contribution. Click on the contribution level name to read more details about the workflow process for that particular level of contribution.
 
 - [Light](https://github.com/carbon-design-system/carbon-contribution/wiki/1.-Light-Contribution-Model): A small design tweak (i.e. changing a border color)
-- [Medium](https://github.com/carbon-design-system/carbon-contribution/wiki/2.-Medium-Contribution-Model): Adding to/or changing guidelines, or contributing an icon
-- [Heavy](https://github.com/carbon-design-system/carbon-contribution/wiki/3.-Heavy-Contribution-Model): Contributing a whole new component to the system
+- [Medium](https://github.com/carbon-design-system/carbon-contribution/wiki/Icon-contribution-guidelines): Adding to/or changing guidelines, or contributing an icon
+- [Heavy](https://github.com/carbon-design-system/carbon-contribution/wiki/2.-Heavy-contribution-model): Contributing a whole new component to the system
 
 ### Submitting an issue
 


### PR DESCRIPTION
Contribution links do not point to the right places.

The Wiki pages are currently named:
<img width="227" alt="Screen Shot 2019-07-06 at 6 26 52 PM" src="https://user-images.githubusercontent.com/8253577/60761696-dcc57500-a01b-11e9-8314-acbbda6f6dfd.png">

Having a consistent naming convention may benefit the user by making things easier to find:
<img width="228" alt="Screen Shot 2019-07-06 at 6 29 03 PM" src="https://user-images.githubusercontent.com/8253577/60761709-fbc40700-a01b-11e9-955f-2530a43fa743.png">

This PR points the links to the correct pages but does not address how the pages are named.
