### PR TITLE
docs(tutorial): Fix typos in tutorial

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -80,7 +80,7 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue. H
    $ git commit -a -m "chore: Update header with newest designs, resolves #123"
    ```
 
-   **Note:** the optional commit -a command line option will automatically "add" and "rm" edited files. See [Close a commit via commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) and [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages) for more details on commit messages.
+   **Note:** the optional commit -a command line option will automatically "add" and "rm" edited files. See [Closing issues using keywords](https://help.github.com/en/articles/closing-issues-using-keywords) and [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages) for more details on commit messages.
 
 7. Once ready for feedback from other contributors and maintainers, **push your commits to your fork** (be sure to run `yarn ci-check` before pushing, to make sure your code passes linting and unit tests):
 

--- a/src/content/tutorial/react-step-1/react-step-1.mdx
+++ b/src/content/tutorial/react-step-1/react-step-1.mdx
@@ -287,7 +287,7 @@ const TutorialHeader = () => (
 export default TutorialHeader;
 ```
 
-_Note: you can find a description of the different components used UI Shell in our [carbon-componets-react](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UIShell) package._
+_Note: you can find a description of the different components used UI Shell in our [carbon-components-react](https://github.com/carbon-design-system/carbon/tree/master/packages/react/src/components/UIShell) package._
 
 _Note: When creating navigation headers, it's important to have a_ `Skip to content` _link so keyboard users can skip the navigation items and go straight to the main content._
 

--- a/src/content/tutorial/react-step-2/react-step-2.mdx
+++ b/src/content/tutorial/react-step-2/react-step-2.mdx
@@ -481,7 +481,7 @@ For our second row, we need to fix the tabs vertical positioning to match the de
 }
 ```
 
-We also need to adust our vertical spacing and type treatment. Like before, it's a matter of using spacing and type tokens like so:
+We also need to adjust our vertical spacing and type treatment. Like before, it's a matter of using spacing and type tokens like so:
 
 <ImageComponent cols="8" caption="Row 2 vertical spacing">
 

--- a/src/content/tutorial/react-step-3/react-step-3.mdx
+++ b/src/content/tutorial/react-step-3/react-step-3.mdx
@@ -313,7 +313,7 @@ The page will look the same as we're still rendering our static example rows, bu
 
 ## Populate data table
 
-Now that we have that data, let's populate the data table. Replace `console.log(organization);` with the following that destructures the `organization` object. Once we have the respositories, we can call our `getRowItems()` helper to build the data table rows.
+Now that we have that data, let's populate the data table. Replace `console.log(organization);` with the following that destructures the `organization` object. Once we have the repositories, we can call our `getRowItems()` helper to build the data table rows.
 
 ##### src/content/RepoPage/RepoPage.js
 
@@ -333,7 +333,7 @@ Revisiting `RepoTable.js`, we are already passing in our row objects along with 
 
 One common hurdle with the data table is how to access data that might not correspond with a table column but is needed to compute the value of a cell that does. The data table component processes and controls only the row properties which corresponds to headers (columns). Because of this, the `rows` object you get access to in the render prop function is _different_ than the one you passed in to the `rows` prop.
 
-We need to modify one apsect of the data table because if you expand a row, it says `Row description`. We want to update that with the repository description coming from the GitHub API. This is an example of where we need a simple look-up function to find the data we care about - data that does not directly correspond to a column.
+We need to modify one aspect of the data table because if you expand a row, it says `Row description`. We want to update that with the repository description coming from the GitHub API. This is an example of where we need a simple look-up function to find the data we care about - data that does not directly correspond to a column.
 
 To do so, in `RepoTable.js`, add this look-up function as the first lines inside the `RepoTable`. This should go immediately before the component's `return()`.
 

--- a/src/content/tutorial/react-step-4/react-step-4.mdx
+++ b/src/content/tutorial/react-step-4/react-step-4.mdx
@@ -21,7 +21,7 @@ internal: false
 
 Carbon provides a solid foundation for building web applications through its color palette, layout, spacing, type, as well as common building blocks in the form of components. So far, we've only used Carbon components to build out two pages.
 
-Next, we're going to use Carbon assets to build application-specific componets. We'll do so by including accessibility and responsive considerations all throughout.
+Next, we're going to use Carbon assets to build application-specific components. We'll do so by including accessibility and responsive considerations all throughout.
 
 A [preview](https://react-step-5--carbon-tutorial.netlify.com) of what you'll build (see bottom of page):
 


### PR DESCRIPTION
There are a number of typos in the Carbon React tutorial. This PR fixes them.