### PR TITLE
feat: convert color blocks to html

### DIFF
--- a/src/content/guidelines/color/overview.mdx
+++ b/src/content/guidelines/color/overview.mdx
@@ -84,7 +84,48 @@ With this system, all Carbon users can create their own themes by assigning new 
 
 Themes serve as an organizational framework for color in Carbon, with each theme based on a specific primary background color. There are two default "light" themes and two default "dark" themes. The light themes use White and Gray 10 backgrounds, and the dark themes use Gray 100 and Gray 90 backgrounds. Default color tokens are provided for each component based on the primary background color.
 
-![Theme backgrounds](images/theme_swatches.png)
+<Row class="color-blocks">
+<Column colSm={1} colMd={1} colLg={2} offsetLg={4}>
+
+<div class="bx--aspect-ratio bx--aspect-ratio--1x1">
+  <div class="bx--aspect-ratio--object color-square color-square--white">
+    White
+  </div>
+</div>
+
+<div class="bx--caption">Light</div>
+
+</Column>
+<Column colSm={1} colMd={1} colLg={2}>
+
+<div class="bx--aspect-ratio bx--aspect-ratio--1x1">
+  <div class="bx--aspect-ratio--object color-square color-square--gray-10">
+    Gray 10
+  </div>
+</div>
+
+</Column>
+<Column colSm={1} colMd={1} colLg={2}>
+
+<div class="bx--aspect-ratio bx--aspect-ratio--1x1">
+  <div class="bx--aspect-ratio--object color-square color-square--gray-100">
+    Gray 100
+  </div>
+</div>
+
+<div class="bx--caption">Dark</div>
+
+</Column>
+<Column colSm={1} colMd={1} colLg={2}>
+
+<div class="bx--aspect-ratio bx--aspect-ratio--1x1">
+  <div class="bx--aspect-ratio--object color-square color-square--gray-90">
+    Gray 90
+  </div>
+</div>
+
+</Column>
+</Row>
 
 <br />
 

--- a/src/styles/_color-ui.scss
+++ b/src/styles/_color-ui.scss
@@ -1,0 +1,78 @@
+//---------------------------------------
+// Color UI
+//---------------------------------------
+.bx--caption {
+  @include carbon--type-style('body-short-01');
+  padding-top: $spacing-03;
+  margin-bottom: $spacing-06;
+  padding-left: $spacing-05;
+}
+
+.bx--aspect-ratio--image {
+  background: $carbon--white-0;
+}
+
+.bx--aspect-ratio--image .gatsby-resp-image-wrapper {
+  margin: 1rem !important;
+}
+
+.color-blocks {
+  @include carbon--breakpoint('sm') {
+    margin-left: 0;
+  }
+
+  @include carbon--breakpoint('md') {
+    margin-left: -1rem;
+  }
+}
+
+.color-blocks .bx--col-lg-2 {
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.color-blocks .bx--col-lg-2:nth-child(2) {
+  margin-right: 40%;
+
+  @include carbon--breakpoint('md') {
+    margin-right: 0;
+  }
+}
+
+.color-blocks .bx--col-lg-2:nth-child(3) {
+  @include carbon--breakpoint('md') {
+    margin-left: $spacing-07;
+  }
+}
+
+.color-square {
+  padding: $spacing-05;
+}
+
+.color-square--white {
+  background: $carbon--white-0;
+}
+
+.color-square--gray-10 {
+  background: $carbon--gray-10;
+  outline: 1px solid $carbon--gray-30;
+  outline-offset: -1px;
+}
+
+.color-square--gray-100 {
+  background: $carbon--gray-100;
+}
+
+.color-square--gray-90 {
+  background: $carbon--gray-90;
+}
+
+.color-square--gray-80 {
+  background: $carbon--gray-80;
+}
+
+.color-square--gray-100,
+.color-square--gray-90,
+.color-square--gray-80 {
+  color: $carbon--white-0;
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -31,6 +31,7 @@ $font-family-mono: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono',
 
 @import 'overrides';
 @import 'page';
+@import 'color-ui';
 
 //---------------------------------------
 // Add-on Components


### PR DESCRIPTION
Closes #740

Coverts color block image to html so it can scale on the grid correctly. (code was copied over from new IDL site build)

`/guidelines/color/overview/#themes`

<img width="897" alt="Screen Shot 2019-07-22 at 8 10 50 PM" src="https://user-images.githubusercontent.com/2753488/61675168-d17d7500-acbc-11e9-9614-7e1e80c3d48e.png">
