### PR TITLE
fix: update iconography page resource links

### DIFF
--- a/src/content/guidelines/iconography/contribute.mdx
+++ b/src/content/guidelines/iconography/contribute.mdx
@@ -82,4 +82,4 @@ To be considered production-ready, all icon submissions must be delivered in SVG
 
 Would your icon be useful for other products? If so, please consider contributing to the design system.
 
-To submit, open a pull request with your icon in the [carbon-icons](https://github.com/carbon-design-system/carbon-elements/tree/master/packages/icons) repository.
+To submit, open a pull request with your icon in the [carbon-icons](https://github.com/carbon-design-system/carbon/tree/master/packages/icons) repository.

--- a/src/content/guidelines/iconography/usage.mdx
+++ b/src/content/guidelines/iconography/usage.mdx
@@ -12,7 +12,7 @@ tabs: ['Usage', 'Library', 'Contribute']
 <Column offsetLg="4" colLg="4" colMd="4" noGutterSm>
   <ClickableTile
     title="Elements package: Icons"
-    href="https://github.com/IBM/carbon-elements/tree/master/packages/icons"
+    href="https://github.com/carbon-design-system/carbon/tree/master/packages/icons"
     type="resource">
 
 ![](images/github-icon.png)
@@ -22,7 +22,7 @@ tabs: ['Usage', 'Library', 'Contribute']
 <Column colLg="4" colMd="4"  noGutterSm>
   <ClickableTile
     title="Elements package: Icons-React"
-    href="https://github.com/IBM/carbon-elements/tree/master/packages/icons-react"
+    href="https://github.com/carbon-design-system/carbon/tree/master/packages/icons-react"
     type="resource">
 
 ![](images/github-icon.png)
@@ -37,7 +37,7 @@ tabs: ['Usage', 'Library', 'Contribute']
 
 ![](images/sketch-icon.png)
 
- </ClickableTile> 
+ </ClickableTile>
 </Column>
 </Row>
 


### PR DESCRIPTION
Closes #1825

This PR updates broken iconography page resource links to our monorepo packages