### PR TITLE
a11y note about label & placeholder, minor text revisions

### DIFF
--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -12,7 +12,7 @@ Search enables users to specify a word or a phrase to find relevant pieces of co
 | Search type    | Purpose                                                                                                                                                                                              |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Large search | This should be used at a global level when the user is searching content within a page view.                                                                                                        |
-| _Small search_ | Choose small when there are space constraints in your design. It can also be component specific. For example, small search can be used to filter data within a [data table](/components/data-table). |
+| Small search | Choose small when there are space constraints in your design. It can also be component-specific. For example, small search can be used to filter data within a [data table](/components/data-table). |
 
 ## Format
 

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -26,7 +26,7 @@ Search enables users to specify a word or a phrase to find relevant pieces of co
 
 Set the user's context for the search with helpful placeholder text within the search field (search documents), that pertains to the page or section the search box is in. Search in the global header should just say search.
 
-Accessibility note: If the search component's label and placeholder text differ, voiceover on macOS will read both.
+Accessibility note: If the search component's label and placeholder text differ, VoiceOver on macOS will read both.
 
 ### Search results
 

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -26,7 +26,7 @@ Search enables users to specify a word or a phrase to find relevant pieces of co
 
 Set the user's context for the search with helpful placeholder text within the search field (search documents), that pertains to the page or section the search box is in. Search in the global header should just say search.
 
-Accessibility note: If the search component's label and placeholder text differ, VoiceOver on Mac OSX will read both.
+Accessibility note: If the search component's label and placeholder text differ, voiceover on macOS will read both.
 
 ### Search results
 

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -24,7 +24,7 @@ Search enables users to specify a word or a phrase to find relevant pieces of co
 
 ### Search fields
 
-Set users' context for the search with helpful placeholder text within the search field (search documents), that pertains to the page or section the search box is in. Search in the global header should just say search.
+Set the user's context for the search with helpful placeholder text within the search field (search documents), that pertains to the page or section the search box is in. Search in the global header should just say search.
 
 Accessibility note: If the search component's label and placeholder text differ, VoiceOver on Mac OSX will read both.
 

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -11,7 +11,7 @@ Search enables users to specify a word or a phrase to find relevant pieces of co
 
 | Search type    | Purpose                                                                                                                                                                                              |
 | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _Large search_ | This should be used at a global level, when the user is searching content within a page view.                                                                                                        |
+| Large search | This should be used at a global level when the user is searching content within a page view.                                                                                                        |
 | _Small search_ | Choose small when there are space constraints in your design. It can also be component specific. For example, small search can be used to filter data within a [data table](/components/data-table). |
 
 ## Format

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -5,7 +5,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 ## General guidance
 
-_Search_ enables users to specify a word or a phrase to find particular relevant pieces of content without the use of navigation. Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
+Search enables users to specify a word or a phrase to find relevant pieces of content without the use of navigation. Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
 
 ## Variations
 

--- a/src/content/components/search/usage.mdx
+++ b/src/content/components/search/usage.mdx
@@ -1,21 +1,18 @@
 ---
 title: Search
-tabs: ['Code', 'Usage','Style']
+tabs: ['Code', 'Usage', 'Style']
 ---
+
 ## General guidance
 
 _Search_ enables users to specify a word or a phrase to find particular relevant pieces of content without the use of navigation. Search can be used as the primary means of discovering content, or as a filter to aid the user in finding content.
 
-
-
-
 ## Variations
 
-| Search type   | Purpose                                                                                                                                                     |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _Large search_      | This should be used at a global level, when the user is searching content within a page view.                                                                                             |
-| _Small search_  | Choose small when there are space constraints in your design. It can also be component specific. For example, small search can be used to filter data within a [data table](/components/data-table). |
-
+| Search type    | Purpose                                                                                                                                                                                              |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Large search_ | This should be used at a global level, when the user is searching content within a page view.                                                                                                        |
+| _Small search_ | Choose small when there are space constraints in your design. It can also be component specific. For example, small search can be used to filter data within a [data table](/components/data-table). |
 
 ## Format
 
@@ -28,6 +25,8 @@ _Search_ enables users to specify a word or a phrase to find particular relevant
 ### Search fields
 
 Set users' context for the search with helpful placeholder text within the search field (search documents), that pertains to the page or section the search box is in. Search in the global header should just say search.
+
+Accessibility note: If the search component's label and placeholder text differ, VoiceOver on Mac OSX will read both.
 
 ### Search results
 


### PR DESCRIPTION
ref https://github.com/carbon-design-system/carbon/pull/3394

**changes**
- add accessibility note to the Search usage page about how VoiceOver on Mac treats differing label + screen reader text