### PR TITLE
fix(progress-indicator): tooltip glitch

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -114,3 +114,12 @@
 .component-example__live.component-example__live--modal .bx--modal {
   z-index: 10000;
 }
+
+//---------------------------------------
+// Progress Indicator
+//---------------------------------------
+
+.component-example__live .bx--progress .bx--tooltip {
+  margin-left: 1.375rem;
+  margin-top: 2.5rem;
+}


### PR DESCRIPTION
Closes #1845 

Tooltip was receiving override styles from:

```css

//---------------------------------------	
// Tooltip
//---------------------------------------	
.component-example__live .bx--tooltip {	
  margin-left: -1rem;	 
  margin-top: -0.5rem;	 
}	
```

Added styles to override progress indicator tooltip margin to original margin.