### PR TITLE
fix(typography): update typography page

### DIFF
--- a/packages/addons-website/scss/components/_website-sticky-container.scss
+++ b/packages/addons-website/scss/components/_website-sticky-container.scss
@@ -9,12 +9,12 @@
   transition-timing-function: $carbon--standard-easing;
 }
 
-.#{$prefix}--sticky-container-visible {
+.website-header-hidden .#{$prefix}--sticky-container-visible {
   top: 3rem;
+}
 
-  &.#{$prefix}--sticky-container-banner {
-    top: 5.5rem;
-  }
+.#{$prefix}--sticky-container-visible {
+  top: 6rem;
 }
 
 .#{$prefix}--sticky-container-hidden {

--- a/packages/addons-website/src/components/TypesetExample/TypesetExample.js
+++ b/packages/addons-website/src/components/TypesetExample/TypesetExample.js
@@ -167,7 +167,9 @@ const TypesetExample = props => {
                     <br />
                   )}
                   <div className={`${prefix}--typeset-example-code-style`}>
-                    <CodeSnippet type="inline">${type.name}</CodeSnippet>
+                    <CodeSnippet type="inline">
+                      ${type.name.split(' ')[0]}
+                    </CodeSnippet>
                   </div>
                 </span>
               </div>

--- a/packages/addons-website/src/components/TypesetStyle/TypesetStyle.js
+++ b/packages/addons-website/src/components/TypesetStyle/TypesetStyle.js
@@ -154,7 +154,44 @@ const typeScale = {
       'letter-spacing': '0',
     },
   },
-
+  'productive-heading-06': {
+    sm: {
+      step: 9,
+      font: 'IBM Plex Sans',
+      'font-weight': '400',
+      'font-size': 2.625,
+      'line-height': 3.125,
+      'letter-spacing': '0',
+    },
+  },
+  'productive-heading-07': {
+    sm: {
+      step: 10,
+      font: 'IBM Plex Sans',
+      'font-weight': '300',
+      'font-size': 3.375,
+      'line-height': 4,
+      'letter-spacing': '0',
+    },
+  },
+  'expressive-heading-03': {
+    sm: {
+      step: 7,
+      font: 'IBM Plex Sans',
+      'font-weight': '400',
+      'font-size': 1.25,
+      'line-height': 1.625,
+      'letter-spacing': '0',
+    },
+    max: {
+      step: 13,
+      font: 'IBM Plex Sans',
+      'font-weight': '400',
+      'font-size': 1.5,
+      'line-height': 1.625,
+      'letter-spacing': '0',
+    },
+  },
   'expressive-heading-04': {
     sm: {
       step: 7,
@@ -640,12 +677,12 @@ const typeSets = {
     {
       description: 'This is for component and layout headings.',
       key: 'heading-01',
-      name: 'heading-01',
+      name: 'productive-heading-01',
     },
     {
       description: 'This is for component and layout headings.',
       key: 'heading-02',
-      name: 'heading-02',
+      name: 'productive-heading-02',
     },
     {
       description: 'This is for component and layout headings.',
@@ -662,20 +699,33 @@ const typeSets = {
       key: 'productive-heading-05',
       name: 'productive-heading-05',
     },
+    {
+      description: 'This is for layout headings.',
+      key: 'productive-heading-06',
+      name: 'productive-heading-06',
+    },
+    {
+      description: 'This is for layout headings.',
+      key: 'productive-heading-07',
+      name: 'productive-heading-07',
+    },
   ],
-  fixedHeading: [
+  headings: [
     {
       description: 'This is for component and layout headings.',
       key: 'heading-01',
-      name: 'heading-01',
+      name: 'expressive-heading-01 (fixed)',
     },
     {
       description: 'This is for component and layout headings.',
       key: 'heading-02',
-      name: 'heading-02',
+      name: 'expressive-heading-02 (fixed)',
     },
-  ],
-  fluidHeadings: [
+    {
+      description: 'This is for component and layout headings.',
+      key: 'expressive-heading-03',
+      name: 'expressive-heading-03',
+    },
     {
       description: 'Heading style',
       key: 'expressive-heading-04',
@@ -687,7 +737,7 @@ const typeSets = {
       name: 'expressive-heading-05',
     },
   ],
-  FluidParagraphsAndQuotes: [
+  paragraphsAndQuotes: [
     {
       description: 'Paragraph',
       key: 'expressive-paragraph-01',
@@ -696,34 +746,34 @@ const typeSets = {
     {
       description: '“Quote.”',
       key: 'quotation-01',
-      name: 'quotation-01',
+      name: 'expressive-quotation-01',
     },
     {
       description: '“Quote.”',
       key: 'quotation-02',
-      name: 'quotation-02',
+      name: 'expressive-quotation-02',
     },
   ],
-  fluidDisplay: [
+  display: [
     {
       description: 'Display',
       key: 'display-01',
-      name: 'display-01',
+      name: 'expressive-display-01',
     },
     {
       description: 'Display',
       key: 'display-02',
-      name: 'display-02',
+      name: 'expressive-display-02',
     },
     {
       description: 'Display',
       key: 'display-03',
-      name: 'display-03',
+      name: 'expressive-display-03',
     },
     {
       description: 'Display',
       key: 'display-04',
-      name: 'display-04',
+      name: 'expressive-display-04',
     },
   ],
 };

--- a/packages/addons-website/src/components/TypesetStyle/TypesetStyle.js
+++ b/packages/addons-website/src/components/TypesetStyle/TypesetStyle.js
@@ -954,7 +954,10 @@ class TypesetStyle extends React.Component {
             .map((typeset, i) => (
               <>
                 <h4 className="page-h4">
-                  {typeset.replace(/([a-z])([A-Z])/g, '$1 $2').toLowerCase()}
+                  {typeset
+                    .replace(/fixed/g, '')
+                    .replace(/([a-z])([A-Z])/g, '$1 $2')
+                    .toLowerCase()}
                 </h4>
                 <TypesetExample
                   key={i}

--- a/src/content/guidelines/typography/expressive.mdx
+++ b/src/content/guidelines/typography/expressive.mdx
@@ -23,5 +23,5 @@ Fluid type is applied to large headline and display type styles. We set up fixed
 
 <TypesetStyle
   breakpointControls={true}
-  typesets="fluidHeadings,FluidParagraphsAndQuotes,fluidDisplay"
+  typesets="headings,paragraphsAndQuotes,display"
 />

--- a/src/content/guidelines/typography/overview.mdx
+++ b/src/content/guidelines/typography/overview.mdx
@@ -58,7 +58,7 @@ import TypeWeight from '../../../../src/components/TypeWeight';
 
 ![](images/sandbox-icon.png)
 
- </ClickableTile> 
+ </ClickableTile>
 </Column>
 </Row>
 


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/1583

Long overdue updates to Typography tokens 

#### Changelog

**New**
- `expressive-heading-03` now exists
- `productive-heading-06`and `productive-heading-07` were added

**Changed**
- `heading-01` and `heading-02` are now `productive-heading-01` and `productive-heading-02`, respectively
- All fluid tokens now being with `$expressive-`

**Removed**
- `Fluid` in front of each `h4` on the Expressive tab
