### PR TITLE
Fix wrong link for Vue environment variables

### DIFF
--- a/src/pages/tutorial/vue/step-3.mdx
+++ b/src/pages/tutorial/vue/step-3.mdx
@@ -102,7 +102,7 @@ When you get to the scope/permissions step, you can leave them all unchecked. We
 
 Once you have your token, we need to put it in a place where create-vue-app can use it. When your application is being built and developed, create-vue-app will parse environmental variables in any file that starts with `.env` and make them available under `process.env.MY_VARIABLE`.
 
-One caveat is that we need to start our variables with `VUE_APP_`. You can read more about environmental variables in [create-vue-app's guide](https://facebook.github.io/create-vue-app/docs/adding-custom-environment-variables).
+One caveat is that we need to start our variables with `VUE_APP_`. You can read more about environmental variables in [create-vue-app's guide](https://cli.vuejs.org/guide/mode-and-env.html#environment-variables).
 
 _Note: If you already have a valid GitHub Personal Access Token, you can use that token here._
 


### PR DESCRIPTION
In the step 3 of the Vue tutorial:

The existing link https://facebook.github.io/create-vue-app/docs/adding-custom-environment-variables would redirect to the page https://opensource.facebook.com/