### PR TITLE
fix(color): added new tokens

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -47,12 +47,12 @@ module.exports = {
       role: ['Secondary interactive color', 'Secondary button'],
       value: {
         white: {
-          name: 'Gray 100',
-          hex: '#171717',
+          name: 'Gray 80',
+          hex: '#3d3d3d',
         },
         g10: {
-          name: 'Gray 100',
-          hex: '#171717',
+          name: 'Gray 80',
+          hex: '#3d3d3d',
         },
         g90: {
           name: 'Gray 60',
@@ -327,6 +327,27 @@ module.exports = {
         g100: {
           name: 'Blue 40',
           hex: '#6ea6ff',
+        },
+      },
+    },
+    '$inverse-link': {
+      role: ['Links on $inverse-02 backgrounds'],
+      value: {
+        white: {
+          name: 'Blue 40',
+          hex: '#6ea6ff',
+        },
+        g10: {
+          name: 'Blue 40',
+          hex: '#6ea6ff',
+        },
+        g90: {
+          name: 'Blue 60',
+          hex: '#0062ff',
+        },
+        g100: {
+          name: 'Blue 60',
+          hex: '#0062ff',
         },
       },
     },
@@ -858,6 +879,27 @@ module.exports = {
         g100: {
           name: 'Gray 90 hover',
           hex: '#353535',
+        },
+      },
+    },
+    '$inverse-hover-ui': {
+      role: ['Hover for $inverse-02'],
+      value: {
+        white: {
+          name: 'Gray 80 hover',
+          hex: '#4c4c4c',
+        },
+        g10: {
+          name: 'Gray 80 hover',
+          hex: '#4c4c4c',
+        },
+        g90: {
+          name: 'Gray 10 hover',
+          hex: '#e5e5e5',
+        },
+        g100: {
+          name: 'Gray 10 hover',
+          hex: '#e5e5e5',
         },
       },
     },


### PR DESCRIPTION
Updates to guidelines/color/usage page:
- Updated `interactive-02` value in the White and Gray 10 themes to be Gray 80 [#3604](https://github.com/carbon-design-system/carbon/issues/3604)
- Added `inverse-hover-ui`[ #3570](https://github.com/carbon-design-system/carbon/issues/3570#issuecomment-516620860)
- Added `inverse-link` [#3329](https://github.com/carbon-design-system/carbon/issues/3329) 