### PR TITLE
fix(ColorTokenTable): hard code theme names in array to fix references

### DIFF
--- a/src/components/ColorTokenTable/ColorTokenTable.js
+++ b/src/components/ColorTokenTable/ColorTokenTable.js
@@ -9,6 +9,8 @@ import {
 import { CopyToClipboard } from 'react-copy-to-clipboard/lib/Component';
 import colorTokens from './color-tokens';
 
+const themes = ['white', 'g10', 'g90', 'g100'];
+
 export default class ColorTokenTable extends React.Component {
   static propTypes = {};
 
@@ -59,7 +61,7 @@ export default class ColorTokenTable extends React.Component {
 
   switchTheme = theme => {
     this.setState({
-      theme: theme.name,
+      theme,
     });
   };
 
@@ -75,7 +77,10 @@ export default class ColorTokenTable extends React.Component {
   };
 
   renderValue = (token, tokenInfo) => {
-    const currentTheme = this.state.theme;
+    const currentTheme =
+      typeof this.state.theme === 'string'
+        ? this.state.theme
+        : themes[this.state.theme];
     const value = tokenInfo.value;
     let bgColor = value[currentTheme].hex;
     if (bgColor.substring(bgColor.length - 3, bgColor.length) === '50%') {
@@ -149,13 +154,10 @@ export default class ColorTokenTable extends React.Component {
           <ContentSwitcher
             className={themeSwitcherClasses}
             onChange={this.switchTheme}>
-            <Switch name="white" text={this.state.mobile ? 'Wte' : 'White'} />
-            <Switch name="g10" text={this.state.mobile ? 'G10' : 'Gray 10'} />
-            <Switch name="g90" text={this.state.mobile ? 'G90' : 'Gray 90'} />
-            <Switch
-              name="g100"
-              text={this.state.mobile ? 'G100' : 'Gray 100'}
-            />
+            <Switch text={this.state.mobile ? 'Wte' : 'White'} />
+            <Switch text={this.state.mobile ? 'G10' : 'Gray 10'} />
+            <Switch text={this.state.mobile ? 'G90' : 'Gray 90'} />
+            <Switch text={this.state.mobile ? 'G100' : 'Gray 100'} />
           </ContentSwitcher>
         </div>
         <div className="bx--col-lg-7">


### PR DESCRIPTION
Closes #119

refs https://github.com/carbon-design-system/carbon/pull/3302

very quick and dirty fix for a ContentSwitcher API change. We were initially relying on the `<Switch>` component's `name` prop to access theme names (and subsequently get hex values for color tokens). Since upgrading `carbon-components-react`, we can no longer have `name` props and instead get index only

This PR hard codes our theme names in an array so that the correct theme name will be chosen when we receive the index number from `<Switch>` where we originally expected a `name` string

---

we probably want to revisit this in the near future, since this is either a case of using the underlying component incorrectly (meaning possible changes required in `<ColorTokenTable />` logic) or an overlooked use case for the now deprecated `name` prop (meaning possible changes required in upstream Carbon)