### PR TITLE
docs: moved videos from IDL

### DIFF
--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -16,6 +16,8 @@ import ColorBlock from 'components/ColorBlock';
 
 </AnchorLinks>
 
+<Video vimeoId="281513790" />
+
 ## Resources
 
 <Row className="resource-card-group">

--- a/src/pages/guidelines/layout/index.mdx
+++ b/src/pages/guidelines/layout/index.mdx
@@ -15,6 +15,8 @@ title: Layout
 
 </AnchorLinks>
 
+<Video vimeoId="281513522" />
+
 ## Resources
 
 <Row className="resource-card-group">


### PR DESCRIPTION
In an effort to reduce redundant content, the videos from the color and layout pages on the IDL site now live on the equivalent Carbon pages.

**Layout:**
IDL: https://www.ibm.com/design/language/elements/2x-grid-ui/
Carbon: https://www.carbondesignsystem.com/guidelines/layout

**Color:**
https://www.ibm.com/design/language/elements/color-ui
https://www.carbondesignsystem.com/guidelines/color/overview/