### PR TITLE
chore: update deploy.yml to use macos 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
 
     steps:
     - uses: actions/checkout@master
@@ -22,7 +22,7 @@ jobs:
         yarn build
     - name: Install ibmcloud cli
       run: |
-        curl -fsSL https://clis.cloud.ibm.com/install/linux | sh
+        curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
     - name: Login to ibmcloud
       env:
         API_KEY: ${{ secrets.API_KEY }}


### PR DESCRIPTION
Deploys are failing on cloud cli install. updating use mac os instead.

tested login here and it seems to be working 
https://github.com/carbon-design-system/carbon-website/pull/185