### PR TITLE
docs: updated kit tiles

### DIFF
--- a/src/pages/get-started/design/index.mdx
+++ b/src/pages/get-started/design/index.mdx
@@ -59,13 +59,27 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
 
 #### 3. **Bring in additional colors and icons**.
 
-The full icon library and additional color collections live in the IBM Design Language library.
+The IBM Design Language Library has additional colors and themes. The Icon librares have the full set of icons seperated based on size.
 
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Get the IBM Design Language library"
-      href="sketch://add-library/cloud/75VZZ">
+      href="sketch://add-library/cloud/nwqmk">
+      <MdxIcon name="sketch" />
+    </ResourceCard>
+  </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      subTitle="Get the Icons (16px, 20px) library"
+      href="sketch://add-library/cloud/KW2yr">
+      <MdxIcon name="sketch" />
+    </ResourceCard>
+  </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      subTitle="Get the Icons (24px, 32px) library"
+      href="sketch://add-library/cloud/2bwkM">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/get-started/design/index.mdx
+++ b/src/pages/get-started/design/index.mdx
@@ -59,27 +59,13 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
 
 #### 3. **Bring in additional colors and icons**.
 
-The IBM Design Language Library has additional colors and themes. The Icon librares have the full set of icons seperated based on size.
+The full icon library and additional color collections live in the IBM Design Language library.
 
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Get the IBM Design Language library"
-      href="sketch://add-library/cloud/nwqmk">
-      <MdxIcon name="sketch" />
-    </ResourceCard>
-  </Column>
-  <Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="Get the Icons (16px, 20px) library"
-      href="sketch://add-library/cloud/KW2yr">
-      <MdxIcon name="sketch" />
-    </ResourceCard>
-  </Column>
-  <Column colMd={4} colLg={4} noGutterSm>
-    <ResourceCard
-      subTitle="Get the Icons (24px, 32px) library"
-      href="sketch://add-library/cloud/2bwkM">
+      href="sketch://add-library/cloud/75VZZ">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/guidelines/iconography/usage.mdx
+++ b/src/pages/guidelines/iconography/usage.mdx
@@ -31,7 +31,7 @@ tabs: ['Usage', 'Library', 'Contribute']
 </Column>
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
-    subTitle="Get the Icons (16px, 20px) library"
+    subTitle="Get the IBM Icons (16px, 20px) library"
     href="sketch://add-library/cloud/KW2yr"
     >
       <MdxIcon name="sketch" />
@@ -39,7 +39,7 @@ tabs: ['Usage', 'Library', 'Contribute']
 </Column>
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
-    subTitle="Get the Icons (24px, 32px) library"
+    subTitle="Get the IBM Icons (24px, 32px) library"
     href="sketch://add-library/cloud/2bwkM"
     >
       <MdxIcon name="sketch" />

--- a/src/pages/guidelines/iconography/usage.mdx
+++ b/src/pages/guidelines/iconography/usage.mdx
@@ -31,8 +31,16 @@ tabs: ['Usage', 'Library', 'Contribute']
 </Column>
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
-    subTitle="Get all icons via the IBM Design Language Kit"
-    href="sketch://add-library/cloud/75VZZ"
+    subTitle="Get the Icons (16px, 20px) library"
+    href="sketch://add-library/cloud/KW2yr"
+    >
+      <MdxIcon name="sketch" />
+ </ResourceCard> 
+</Column>
+<Column colLg={4} colMd={4}  noGutterSm>
+  <ResourceCard
+    subTitle="Get the Icons (24px, 32px) library"
+    href="sketch://add-library/cloud/2bwkM"
     >
       <MdxIcon name="sketch" />
  </ResourceCard> 

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -147,10 +147,30 @@ title: Resources
 <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language library"
-      href="sketch://add-library/cloud/75VZZ"
+      href="sketch://add-library/cloud/nwqmk"
       >
 <MdxIcon name="sketch" />
   </ResourceCard>
+</Column>
+<Column colMd={4} colLg={4} noGutterSm>
+  <ResourceCard
+    subTitle="Icons (16px, 20px) library"
+    href="sketch://add-library/cloud/KW2yr"
+    >
+
+<MdxIcon name="sketch" />
+
+</ResourceCard>
+</Column>
+<Column colMd={4} colLg={4} noGutterSm>
+  <ResourceCard
+    subTitle="Icons (24px, 32px) library"
+    href="sketch://add-library/cloud/2bwkM"
+    >
+
+<MdxIcon name="sketch" />
+
+</ResourceCard>
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
@@ -179,6 +199,16 @@ title: Resources
   <ResourceCard
     subTitle="Carbon Design Kit"
     href="https://github.com/carbon-design-system/carbon-design-kit"
+    >
+
+<MdxIcon name="github" />
+
+  </ResourceCard>
+</Column>
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="IBM Design Language and Icon Kits"
+    href="https://github.com/IBM/design-kit"
     >
 
 <MdxIcon name="github" />

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -154,7 +154,7 @@ title: Resources
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
-    subTitle="Icons (16px, 20px) library"
+    subTitle="IBM Icons (16px, 20px) library"
     href="sketch://add-library/cloud/KW2yr"
     >
 
@@ -164,7 +164,7 @@ title: Resources
 </Column>
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
-    subTitle="Icons (24px, 32px) library"
+    subTitle="IBM Icons (24px, 32px) library"
     href="sketch://add-library/cloud/2bwkM"
     >
 


### PR DESCRIPTION
Changes:

Get Started > Design
3. (revised content)
-IBM Design Language library: change link out 
-Added two new tiles/links for icon libraries

Guidelines > Iconography > Usage tab
Resources:
-Added two new tiles/links for icon libraries.

Resources
Design Resources
Color, grid, and icons:
-Added new tiles/links for icon libraries

Github repos:
-Added new tile to github link for IDL and Icon kits

