### PR TITLE
Removed references to Slack channels that do not exist

### DIFF
--- a/src/pages/help/support/index.mdx
+++ b/src/pages/help/support/index.mdx
@@ -14,16 +14,6 @@ Please take some time to explore the content on this website before engaging the
 
 Answers to the most common questions about the design system can be found in the [Carbon FAQ](faq).
 
-### Slack channels
-
-_Internal IBM users only._ The Carbon core team maintains the following channels and will provide support as time permits.
-
-**Please try searching the Slack channel for your topic first.** Slack’s filtering feature will return more targeted and relevant results. For instance, if you have a technical question about the `DataTable` component, you could search “DataTable” in Slack and then filter by the #carbon-components channel. _Tip: You can start a new search directly from the message box using the `/s` slash command._
-
-For designer questions: [#carbon-design-system](https://ibm-studios.slack.com/messages/C0M053VPT/)
-
-For developer questions: [#carbon-components](https://ibm-studios.slack.com/messages/C046Y0YUD/), [#carbon-react](https://ibm-studios.slack.com/messages/C2K6RFJ1G/)
-
 ### Email
 
 Messages to <carbon@us.ibm.com> will be addressed by the Carbon technical team as quickly as possible.


### PR DESCRIPTION
#### Changelog

**Removed**

- Slack section of page, as those Slack channels don't exist
