### PR TITLE
docs: adjusted lead paragraph on experimental overview

### DIFF
--- a/src/pages/experimental/overview/index.mdx
+++ b/src/pages/experimental/overview/index.mdx
@@ -4,7 +4,7 @@ title: Overview
 
 <PageDescription>
 
-Experimental resources are components, patterns, and tools currently in the works. These resources are still in development, and may be deprecated, changed, or removed at any time.
+Carbon is always getting better. This happens through feature and usability upgrades to our elements and components. It also happens through exploration and experimentation. The Carbon team will surface these explorations here.
 
 </PageDescription>
 
@@ -28,8 +28,6 @@ We are actively seeking to include these components, patterns, and tools in the 
 | [Uploading](https://github.com/carbon-design-system/carbon-website/pull/200) | Pattern | Under review |
 
 ## How experimental works
-
-Carbon is always getting better. This happens through continual feature and usability upgrades to our elements and core components. It also happens through exploration and experimentation. The Carbon team will surface this exploration here.
 
 We use experimental projects to surface future resources and get them into the hands of teams who will use them. Expect these components, patterns, and tools to change over time. They may have some non-functional pieces, or be lacking in documentation. **There is no guarantee of support**.
 


### PR DESCRIPTION
Moved paragraph to `PageDescription`.