### PR TITLE
fix: Do/don't example on iconography usage page now shows one do and …

### DIFF
--- a/src/pages/guidelines/iconography/usage.mdx
+++ b/src/pages/guidelines/iconography/usage.mdx
@@ -104,7 +104,7 @@ It's also important to note that Carbon v10 icons themselves do not have interac
 <Row>
 <Column colMd={4} colLg={4}>
   <DoDontExample
-    correct
+    type="do"
     caption="Do match your icon color with your text color when pairing them.">
 
 ![proper alignment](images/iconography-color-01.png)
@@ -127,7 +127,7 @@ When used next to text, icons should be center-aligned.
 <Row>
 <Column colMd={4} colLg={4}>
   <DoDontExample
-    correct
+    type="do"
     caption="Do center-align icons when they’re next to text.">
 
 ![proper alignment](images/iconography-usage-sizing-5.svg)


### PR DESCRIPTION
…one don't, instead of two donts.

I updated the prop on two `DoDontExample />`s from `correct` to `type="do"`. After doing so, it displayed one correct example, and one incorrect example.

On this page:
https://www.carbondesignsystem.com/guidelines/iconography/usage/

_Before_
![Screen Shot 2019-09-03 at 10 22 33 AM](https://user-images.githubusercontent.com/10215203/64181600-c75ea280-ce34-11e9-8a78-2d62b7954aab.png)

_After_
![Screen Shot 2019-09-03 at 10 22 14 AM](https://user-images.githubusercontent.com/10215203/64181601-c75ea280-ce34-11e9-885e-5c1f35548023.png)

