### PR TITLE
[Link] Style tab spec typo

### DIFF
--- a/src/pages/components/link/style.mdx
+++ b/src/pages/components/link/style.mdx
@@ -7,7 +7,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 | Class       | Property | Color token       |
 | ----------- | -------- | ----------------- |
-| `.bx--link` | color    | `$interactive-01` |
+| `.bx--link` | color    | `$link-01` |
 
 ### Interactive states
 
@@ -16,7 +16,7 @@ tabs: ['Code', 'Usage', 'Style']
 | `:hover`    | text color | `$hover-primary-text` |
 | `:active`   | text color | `$text-01`            |
 | `:focus`    | border     | `$focus`              |
-| `:visited`  | text color | `$visited`            |
+| `:visited`  | text color | `$visited-link`            |
 | `:disabled` | text color | `$disabled-02`        |
 
 <div className="image--fixed">


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/3902

Link style page is showing two wrong color token: default color & visited.
