### PR TITLE
docs: removed the remaining idioms section

### DIFF
--- a/src/data/guidelines/glossary.js
+++ b/src/data/guidelines/glossary.js
@@ -364,17 +364,6 @@ module.exports = {
         subtext: 'Use instead of Back to top.',
       },
     },
-    Idioms: {
-      'test drive': {
-        desc:
-          '(noun) a test or evaluation of a piece of software for a specified amount of time.',
-        subtext: 'Context: You have 1 day left in your Bluemix test drive.',
-      },
-      'time flies': {
-        desc: '(phrase) time passes quickly.',
-        subtext: 'Context: Wow, time flies!',
-      },
-    },
   },
   U: {
     'Action labels': {


### PR DESCRIPTION
This is a minor change - partly for me to check my setup and go through the GitHub workflow (with help from @connor-leech !) 

**Removed**
- On the Content page > Glossary tab, I've removed the "Idioms" section that still existed under the "Tt" section. 
(All other "Idioms" section had previously been removed, but this one must have been overlooked.)
