### PR TITLE
fix: typo on typography page

### DIFF
--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -56,7 +56,7 @@ import TypeWeight from '../../../../src/components/TypeWeight';
     href="https://github.com/carbon-design-system/carbon/tree/master/packages/type"
     >
 
-<MdxIcon name="codesandbox" />)
+<MdxIcon name="codesandbox" />
 
  </ResourceCard> 
 </Column>


### PR DESCRIPTION
removes extra parenthesis 

![image](https://user-images.githubusercontent.com/2753488/64723363-04aadc00-d496-11e9-9b3d-a8b03c7e8a27.png)
