### PR TITLE
fix: component overview styles

### DIFF
--- a/src/components/ComponentOverview/component-overview.scss
+++ b/src/components/ComponentOverview/component-overview.scss
@@ -113,9 +113,9 @@ $hover-ui: #e5e5e5;
   width: 100%;
 }
 
-body .component-item__img {
-  margin-bottom: 0 !important;
-  background: transparent !important;
+.container .component-item__img[src*='svg'] {
+  margin-bottom: 0;
+  background: transparent;
   display: block;
 }
 

--- a/src/components/ComponentOverview/component-overview.scss
+++ b/src/components/ComponentOverview/component-overview.scss
@@ -113,8 +113,9 @@ $hover-ui: #e5e5e5;
   width: 100%;
 }
 
-.component-item__img {
-  margin: 0;
+body .component-item__img {
+  margin-bottom: 0 !important;
+  background: transparent !important;
   display: block;
 }
 


### PR DESCRIPTION
Closes #254

Removes background and margin from component overview page images.