### PR TITLE
fix: update color block type token

### DIFF
--- a/src/components/ColorBlock/color-block.scss
+++ b/src/components/ColorBlock/color-block.scss
@@ -56,6 +56,7 @@
 }
 
 .color-square {
+  @include carbon--type-style('body-short-01');
   padding: $spacing-05;
 }
 


### PR DESCRIPTION
Closes #296

Updates color swatch on themes section of Color page to use the `body-short-01` type token to match captions.

### Testing
 `/guidelines/color/overview#themes`