### PR TITLE
fix: color sticky switcher z-index

### DIFF
--- a/src/components/ColorTokenTable/color-token-table.scss
+++ b/src/components/ColorTokenTable/color-token-table.scss
@@ -25,7 +25,7 @@
 .color-token-table__theme-switcher--sticky {
   position: fixed;
   top: 112px;
-  z-index: 9999;
+  z-index: 10;
   max-width: 1164px;
   box-shadow: 0px 2px 6px 0px rgba($carbon--black-100, 0.2);
 


### PR DESCRIPTION
Closes #324 

Fixes issue where content switcher was overlaying nav on mobile/tablet when stuck. 