### PR TITLE
docs: update tutorial wrapping up

### DIFF
--- a/src/pages/tutorial/react/wrapping-up.mdx
+++ b/src/pages/tutorial/react/wrapping-up.mdx
@@ -31,7 +31,7 @@ Once you complete all five steps of the tutorial, you can apply for an [IBM Digi
 </Column>
 </Row>
 
-Once you submit the application, please allow 2-4 days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
+Once you submit the application, please allow two to four days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
 
 ## Badge information
 

--- a/src/pages/tutorial/react/wrapping-up.mdx
+++ b/src/pages/tutorial/react/wrapping-up.mdx
@@ -4,7 +4,11 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-### Thanks for completing our tutorial and helping us improve it along the way. Want to show the world your new skills? Please apply for the IBM Digital Badge.
+<PageDescription>
+
+Thanks for completing the IBM Carbon tutorial and helping us improve it along the way. If you want to show the world your new skills, you can apply for an IBM Digital Badge.
+
+</PageDescription>
 
 <AnchorLinks>
 

--- a/src/pages/tutorial/react/wrapping-up.mdx
+++ b/src/pages/tutorial/react/wrapping-up.mdx
@@ -4,19 +4,18 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-### Thanks for completing our tutorial and helping us improve it along the way. As a way to say thanks, you can apply for an IBM Digital Badge and a free shirt!
+### Thanks for completing our tutorial and helping us improve it along the way. Want to show the world your new skills? Please apply for the IBM Digital Badge.
 
 <AnchorLinks>
 
-<AnchorLink>Badging</AnchorLink>
-<AnchorLink>Free t-shirt</AnchorLink>
-<AnchorLink>Application</AnchorLink>
+<AnchorLink>Application form</AnchorLink>
+<AnchorLink>Badge information</AnchorLink>
 
 </AnchorLinks>
 
-## Badging
+## Application form
 
-Once you complete all five steps of the tutorial, you can apply for the IBM Digital Badge. These badges are available to anybody—not just IBM employees.
+Once you complete all five steps of the tutorial, you can [apply for the IBM Digital Badge](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2). These badges are available to anybody — not just IBM employees.
 
 <Row>
 <Column colLg={8}>
@@ -28,18 +27,24 @@ Once you complete all five steps of the tutorial, you can apply for the IBM Digi
 </Column>
 </Row>
 
+Once you submit the application, please allow 2-4 days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
+
+## Badge information
+
 ### IBM Design System React Components
 
 This badge demonstrates knowledge about Carbon's React components. To earn the badge:
 
-1. Complete steps 1 through 5 of the React Carbon tutorial
+1. Complete steps 1 through 5 of the Carbon React tutorial
    - Step 1. [Installing Carbon](/tutorial/react/step-1)
    - Step 2. [Building pages](/tutorial/react/step-2)
    - Step 3. [Using APIs](/tutorial/react/step-3)
    - Step 4. [Creating components](/tutorial/react/step-4)
    - Step 5. [Deploying to IBM Cloud](/tutorial/react/step-5)
-2. Submit links to approved pull requests for steps 1 through 5 of the React Carbon tutorial in the [carbon-tutorial repository](https://github.com/carbon-design-system/carbon-tutorial).
-   - To quickly find your submitted PRs, you can [filter by author](https://github.com/carbon-design-system/carbon-tutorial/pulls?utf8=%E2%9C%93&q=author%3Ausername) (e.g. `author:${username}`)
+2. Have approved pull requests for steps 1 through 5 in the [carbon-tutorial repository](https://github.com/carbon-design-system/carbon-tutorial)
+3. Complete the [badge application](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2)
+
+_Note: To quickly find your submitted PRs, you can [filter by author](https://github.com/carbon-design-system/carbon-tutorial/pulls?utf8=%E2%9C%93&q=author%3Ausername) (e.g. _`author:${username}`_)._
 
 ### FAQ and help
 
@@ -51,22 +56,6 @@ Acclaim Support: For questions related to your Acclaim badge earner account and 
 
 NOTICE: IBM leverages the services of Credly's Acclaim platform, a 3rd party data processor authorized by IBM and located in the United States, to assist in the administration of the IBM Digital Badge program. In order to issue you an IBM Digital Badge, your personal information (name, email address, and badge earned) will be shared with the Credly's Acclaim platform. You will receive an email notification from Acclaim with instructions for claiming the badge. Your personal information is used to issue your badge and for program reporting and operational purposes. It will be handled in a manner consistent with IBM privacy practices. The IBM Privacy Statement can be viewed here: [https://www.ibm.com/privacy/us/en/](https://www.ibm.com/privacy/us/en/). IBM employees can view the IBM Internal Privacy Statement here: [https://w3.ibm.com/w3publisher/w3-privacy-notice](https://w3.ibm.com/w3publisher/w3-privacy-notice).
 
-## Free t-shirt
+### Application form
 
-Submit your completed IBM Digital Badge application by July 30, 2019, and receive a free\* Carbon t-shirt.
-
-<Row>
-<Column colLg={8}>
-
-![](../shared/wrapping-up/images/carbon-tee.png)
-
-<Caption>Carbon t-shirt, #swag #threads #highfashion</Caption>
-
-</Column>
-</Row>
-
-## Application
-
-Complete the [application form](https://www.surveygizmo.com/s3/5075530/Dev-Essentials-Badge-Application) to request the digital badge and t-shirt. Once you submit the application, please allow 2-4 days for issuing the badge and 4-6 weeks to receive the t-shirt. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
-
-_\* Shirts are available for a limited time while supplies last to U.S. shipping addresses and outside the U.S. to participating FED@IBM branches._
+To apply for the IBM Digital Badge, please use [this link](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2).

--- a/src/pages/tutorial/react/wrapping-up.mdx
+++ b/src/pages/tutorial/react/wrapping-up.mdx
@@ -62,4 +62,4 @@ NOTICE: IBM leverages the services of Credly's Acclaim platform, a 3rd party dat
 
 ### Application form
 
-To apply for the IBM Digital Badge, please use [this link](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2).
+To apply for the IBM Digital Badge, please complete the [form and survey](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2).

--- a/src/pages/tutorial/react/wrapping-up.mdx
+++ b/src/pages/tutorial/react/wrapping-up.mdx
@@ -19,7 +19,7 @@ Thanks for completing the IBM Carbon tutorial and helping us improve it along th
 
 ## Application form
 
-Once you complete all five steps of the tutorial, you can [apply for the IBM Digital Badge](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2). These badges are available to anybody — not just IBM employees.
+Once you complete all five steps of the tutorial, you can apply for an [IBM Digital Badge](https://www.surveygizmo.com/s3/5163103/IBM-Carbon-Design-System-Developer-Essentials-React-v2). These badges are available to anybody — not just IBM employees.
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/tutorial/vue/wrapping-up.mdx
+++ b/src/pages/tutorial/vue/wrapping-up.mdx
@@ -4,19 +4,18 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-### Thanks for completing our tutorial and helping us improve it along the way. As a way to say thanks, you can apply for an IBM Digital Badge and a free shirt!
+### Thanks for completing our tutorial and helping us improve it along the way. Want to show the world your new skills? Please apply for the IBM Digital Badge.
 
 <AnchorLinks>
 
-<AnchorLink>Badging</AnchorLink>
-<AnchorLink>Free t-shirt</AnchorLink>
-<AnchorLink>Application</AnchorLink>
+<AnchorLink>Application form</AnchorLink>
+<AnchorLink>Badge information</AnchorLink>
 
 </AnchorLinks>
 
-## Badging
+## Application form
 
-Once you complete all five steps of the tutorial, you can apply for the IBM Digital Badge. These badges are available to anybody—not just IBM employees.
+Once you complete all five steps of the tutorial, you can [apply for the IBM Digital Badge](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2). These badges are available to anybody — not just IBM employees.
 
 <Row>
 <Column colLg={8}>
@@ -28,19 +27,24 @@ Once you complete all five steps of the tutorial, you can apply for the IBM Digi
 </Column>
 </Row>
 
+Once you submit the application, please allow 2-4 days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
+
+## Badge information
+
 ### IBM Design System Vue Components
 
 This badge demonstrates knowledge about Carbon's Vue components. To earn the badge:
 
-1. Complete steps 1 through 5 of the Vue Carbon tutorial
+1. Complete steps 1 through 5 of the Carbon Vue tutorial
    - Step 1. [Installing Carbon](/tutorial/vue/step-1)
    - Step 2. [Building pages](/tutorial/vue/step-2)
    - Step 3. [Using APIs](/tutorial/vue/step-3)
    - Step 4. [Creating components](/tutorial/vue/step-4)
    - Step 5. [Deploying to IBM Cloud](/tutorial/vue/step-5)
-2. Submit links to approved pull requests for steps 1 through 5 of the Vue Carbon tutorial in the [carbon-tutorial-vue repository](https://github.com/carbon-design-system/carbon-tutorial-vue).
-   - To quickly find your submitted PRs, you can [filter by author](https://github.com/carbon-design-system/carbon-tutorial-vue/pulls?utf8=%E2%9C%93&q=author%3Ausername) (e.g. `author:${username}`)
-3. Complete the [badge application](/tutorial/vue/wrapping-up#application)
+2. Have approved pull requests for steps 1 through 5 in the [carbon-tutorial-vue repository](https://github.com/carbon-design-system/carbon-tutorial-vue)
+3. Complete the [badge application](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2)
+
+_Note: To quickly find your submitted PRs, you can [filter by author](https://github.com/carbon-design-system/carbon-tutorial-vue/pulls?utf8=%E2%9C%93&q=author%3Ausername) (e.g. _`author:${username}`_)._
 
 ### FAQ and help
 
@@ -52,22 +56,6 @@ Acclaim Support: For questions related to your Acclaim badge earner account and 
 
 NOTICE: IBM leverages the services of Credly's Acclaim platform, a 3rd party data processor authorized by IBM and located in the United States, to assist in the administration of the IBM Digital Badge program. In order to issue you an IBM Digital Badge, your personal information (name, email address, and badge earned) will be shared with the Credly's Acclaim platform. You will receive an email notification from Acclaim with instructions for claiming the badge. Your personal information is used to issue your badge and for program reporting and operational purposes. It will be handled in a manner consistent with IBM privacy practices. The IBM Privacy Statement can be viewed here: [https://www.ibm.com/privacy/us/en/](https://www.ibm.com/privacy/us/en/). IBM employees can view the IBM Internal Privacy Statement here: [https://w3.ibm.com/w3publisher/w3-privacy-notice](https://w3.ibm.com/w3publisher/w3-privacy-notice).
 
-## Free t-shirt
+### Application form
 
-Submit your completed IBM Digital Badge application by September 15, 2019, and receive a free\* Carbon t-shirt.
-
-<Row>
-<Column colLg={8}>
-
-![](../shared/wrapping-up/images/carbon-tee.png)
-
-<Caption>Carbon t-shirt, #swag #threads #highfashion</Caption>
-
-</Column>
-</Row>
-
-## Application
-
-Complete the [application form](https://www.surveygizmo.com/s3/5135615/IBM-Carbon-Design-System-Developer-Essentials-Vue) to request the digital badge and t-shirt. Once you submit the application, please allow 2-4 days for issuing the badge and 4-6 weeks to receive the t-shirt. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
-
-_\* Shirts are available for a limited time while supplies last to U.S. shipping addresses and outside the U.S. to participating FED@IBM branches._
+To apply for the IBM Digital Badge, please use [this link](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2).

--- a/src/pages/tutorial/vue/wrapping-up.mdx
+++ b/src/pages/tutorial/vue/wrapping-up.mdx
@@ -19,7 +19,7 @@ Thanks for completing our tutorial and helping us improve it along the way. If y
 
 ## Application form
 
-Once you complete all five steps of the tutorial, you can [apply for the IBM Digital Badge](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2). These badges are available to anybody — not just IBM employees.
+Once you complete all five steps of the tutorial, you can apply for an [IBM Digital Badge](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2). These badges are available to anybody — not just IBM employees.
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/tutorial/vue/wrapping-up.mdx
+++ b/src/pages/tutorial/vue/wrapping-up.mdx
@@ -4,7 +4,11 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-### Thanks for completing our tutorial and helping us improve it along the way. Want to show the world your new skills? Please apply for the IBM Digital Badge.
+<PageDescription>
+
+Thanks for completing our tutorial and helping us improve it along the way. If you want to show the world your new skills, you can apply for an IBM Digital Badge.
+
+</PageDescription>
 
 <AnchorLinks>
 

--- a/src/pages/tutorial/vue/wrapping-up.mdx
+++ b/src/pages/tutorial/vue/wrapping-up.mdx
@@ -62,4 +62,4 @@ NOTICE: IBM leverages the services of Credly's Acclaim platform, a 3rd party dat
 
 ### Application form
 
-To apply for the IBM Digital Badge, please use [this link](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2).
+To apply for the IBM Digital Badge, please complete the [form and survey](https://www.surveygizmo.com/s3/5215482/IBM-Carbon-Design-System-Developer-Essentials-Vue-v2).

--- a/src/pages/tutorial/vue/wrapping-up.mdx
+++ b/src/pages/tutorial/vue/wrapping-up.mdx
@@ -31,7 +31,7 @@ Once you complete all five steps of the tutorial, you can [apply for the IBM Dig
 </Column>
 </Row>
 
-Once you submit the application, please allow 2-4 days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
+Once you submit the application, please allow two to four days for issuing the badge. Once the badge is issued, you will be notified and must accept the badge via Acclaim.
 
 ## Badge information
 


### PR DESCRIPTION
Closes #269

- Removes references to t-shirts as we're past those deadlines
- Cleans up some AI so it's easier to find the badge application forms