### PR TITLE
chore: enable webp

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -15,6 +15,7 @@ module.exports = {
         isSearchEnabled: true,
         iconPath: './src/images/favicon-32.png',
         titleType: 'prepend',
+        withWebp: true,
         repository: {
           baseUrl: 'https://github.com/carbon-design-system/carbon-website',
           subDirectory: '',


### PR DESCRIPTION
Webp can result in some big performance improvements for browsers that support it, testing to see if the build time is significantly increased.