### PR TITLE
docs: remove Dribble image

### DIFF
--- a/src/pages/experimental/cards/usage.mdx
+++ b/src/pages/experimental/cards/usage.mdx
@@ -153,18 +153,6 @@ Content cards can invite the user to start a specific process such as getting st
 
 Cards can be used to block groups of related content even if it doesn't fit into the above models.
 
-<Row>
-<Column colMd={8}>
-
-![Use cards to group related blocks of content](images/content-blocks-example.png)
-
-<Caption>
-  Example of grouping related pieces of content on a resource detail page
-</Caption>
-
-</Column>
-</Row>
-
 ## Best practices
 
 #### Do


### PR DESCRIPTION
One of the images on this page uses a Dribble image. The image needs to be fixed, removing for now.