### PR TITLE
Docs: missing word on text input

### DIFF
--- a/src/pages/components/text-input/usage.mdx
+++ b/src/pages/components/text-input/usage.mdx
@@ -24,7 +24,7 @@ tabs: ['Code', 'Usage', 'Style']
 
 ## General guidance
 
-There instances, sometimes in the same form, where you need users to enter both short and long form content. Allow the size of the text input box to reflect the length of the content you expect the user to enter.
+There are instances, sometimes in the same form, where you need users to enter both short and long form content. Allow the size of the text input box to reflect the length of the content you expect the user to enter.
 
 | Type       | Purpose                                                                           |
 | ---------- | --------------------------------------------------------------------------------- |


### PR DESCRIPTION
Missing word on text input usage page 