### PR TITLE
docs: update COO point of contact

### DIFF
--- a/src/pages/get-started/about-carbon.mdx
+++ b/src/pages/get-started/about-carbon.mdx
@@ -83,11 +83,11 @@ This information is only relevant for IBM teams building with Carbon.
 - COO reference number: COO20190204
 - Name of IBM material (with version number): IBM Design System [Version 10, Release n/a, Modification n/a]
 - Last release date: March 31, 2019
-- Name of Product/Program manager or author of material: Daniel Kuehn/Austin/IBM
+- Name of Product/Program manager or author of material: Matt Rosno/US/IBM
 
 ### Carbon v9.x
 
 - COO number of IBM material (if any): AUS720180239
 - Name of IBM material (with version number): IBM Design System [Version 9, Release n/a, Modification n/a]
 - Last release date: June 4, 2018
-- Name of Product/Program manager or author of material: DanielKuehn/Austin/IBM
+- Name of Product/Program manager or author of material: Matt Rosno/US/IBM

--- a/src/pages/help/faq/index.mdx
+++ b/src/pages/help/faq/index.mdx
@@ -80,14 +80,14 @@ Carbon v10.x
 - COO reference number: COO20190204
 - Name of IBM material (with version number): IBM Design System [Version 10, Release n/a, Modification n/a]
 - Last release date: March 31, 2019
-- Name of Product/Program manager or author of material: Daniel Kuehn/Austin/IBM
+- Name of Product/Program manager or author of material: Matt Rosno/US/IBM
 
 Carbon v9.x
 
 - COO number of IBM material (if any): AUS720180239
 - Name of IBM material (with version number): IBM Design System [Version 9, Release n/a, Modification n/a]
 - Last release date: June 4, 2018
-- Name of Product/Program manager or author of material: Daniel Kuehn/Austin/IBM
+- Name of Product/Program manager or author of material: Matt Rosno/US/IBM
 
 ### Where do I find charts and data visualization?
 


### PR DESCRIPTION
Swaps out Daniel Keuhn with Matt Rosno as point of contact for Carbon's active Certificates of Originalities (COOs).