### PR TITLE
fix: resource cards link

### DIFF
--- a/src/pages/data-visualization/getting-started/other-frameworks.mdx
+++ b/src/pages/data-visualization/getting-started/other-frameworks.mdx
@@ -18,7 +18,7 @@ tabs: ['Vanilla', 'React', 'Angular', 'Vue', 'Other frameworks']
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Download WIP charting design specifications (IBM internal link)"
-    href="https://ibm.box.com/s/e4u7jaupf6pcvqd1ulxgrt1kmsf6o4bt"
+    href="https://ibm.box.com/v/Charts-designs-WIP-October"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/data-visualization/getting-started/vanilla.mdx
+++ b/src/pages/data-visualization/getting-started/vanilla.mdx
@@ -44,7 +44,7 @@ Carbon charts help you tell accurate and convincing stories around data with bea
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Download WIP charting design specifications (IBM internal link)"
-    href="https://ibm.box.com/s/e4u7jaupf6pcvqd1ulxgrt1kmsf6o4bt"
+    href="https://ibm.box.com/v/Charts-designs-WIP-October"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -209,7 +209,7 @@ Everything you need to work with, learn about, and contribute to Carbon.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download WIP charting design specifications (IBM internal link)"
-      href="https://ibm.box.com/s/e4u7jaupf6pcvqd1ulxgrt1kmsf6o4bt"
+      href="https://ibm.box.com/v/Charts-designs-WIP-October"
       actionIcon="download">
       <MdxIcon name="sketch" />
     </ResourceCard>


### PR DESCRIPTION
Resource cards's download link is broken. Box doesn't make it easy. Here's the correct link: 

https://ibm.box.com/v/Charts-designs-WIP-October