### PR TITLE
Removed dribbble from the footer

### DIFF
--- a/src/gatsby-theme-carbon/components/Footer.js
+++ b/src/gatsby-theme-carbon/components/Footer.js
@@ -48,7 +48,6 @@ const links = {
     { href: 'https://www.ibm.com/', linkText: 'IBM.com' },
   ],
   secondCol: [
-    { href: 'https://dribbble.com/_carbondesign', linkText: 'Dribble' },
     { href: 'https://medium.com/carbondesign', linkText: 'Medium' },
     { href: 'https://twitter.com/_carbondesign', linkText: 'Twitter' },
     { href: 'https://www.netlify.com/', linkText: 'Netlify' },


### PR DESCRIPTION
This removed the dribbble link from the footer

Before:
![image](https://user-images.githubusercontent.com/19270502/66157347-3886a680-e5e9-11e9-8beb-441a2f37eeac.png)



After:
![image](https://user-images.githubusercontent.com/19270502/66157330-302e6b80-e5e9-11e9-8dd0-78c50b6d944b.png)
