### PR TITLE
docs: update links on charts pages

### DIFF
--- a/src/pages/data-visualization/getting-started/other-frameworks.mdx
+++ b/src/pages/data-visualization/getting-started/other-frameworks.mdx
@@ -18,7 +18,15 @@ tabs: ['Vanilla', 'React', 'Angular', 'Vue', 'Other frameworks']
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Download WIP charting design specifications (IBM internal link)"
-    href="https://ibm.box.com/v/Charts-designs-WIP-October"
+    disabled>
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Data visualization color palettes (IBM internal link)"
+    href="https://ibm.box.com/s/3mt8fshtgy70r7rhxjhfo3gbdt0n3x5y"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/data-visualization/getting-started/vanilla.mdx
+++ b/src/pages/data-visualization/getting-started/vanilla.mdx
@@ -44,7 +44,15 @@ Carbon charts help you tell accurate and convincing stories around data with bea
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Download WIP charting design specifications (IBM internal link)"
-    href="https://ibm.box.com/v/Charts-designs-WIP-October"
+    disabled>
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+
+<Column colLg={4} colMd={4} noGutterSm>
+<ResourceCard
+    subTitle="Data visualization color palettes (IBM internal link)"
+    href="https://ibm.box.com/s/3mt8fshtgy70r7rhxjhfo3gbdt0n3x5y"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -209,8 +209,7 @@ Everything you need to work with, learn about, and contribute to Carbon.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download WIP charting design specifications (IBM internal link)"
-      href="https://ibm.box.com/v/Charts-designs-WIP-October"
-      actionIcon="download">
+      disabled>
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>


### PR DESCRIPTION
Closes #437

#### Changelog

**New**

- Adds color palette download cards to vanilla/other frameworks 

**Removed**

- Removes links to WIP charts
