### PR TITLE
fix[layout page content]:update breakpoint class names

### DIFF
--- a/src/pages/guidelines/2x-grid/implementation.mdx
+++ b/src/pages/guidelines/2x-grid/implementation.mdx
@@ -153,11 +153,11 @@ The below example creates four equal-width columns at small, medium, large, and 
 
 | Breakpoints     | Class prefix | # of cols | Gutter width\* |
 | --------------- | ------------ | --------- | -------------- |
-| Small (<320)    | `.col-sm-`   | 4         | 32px           |
-| Medium (≥675)   | `.col-md-`   | 8         | 32px           |
-| Large (≥1056)   | `.col-lg-`   | 16        | 32px           |
-| X-Large (≥1312) | `.col-xl-`   | 16        | 32px           |
-| Max (≥1584)     | `.col-max-`  | 16        | 32px           |
+| Small (<320)    | `.bx--col-sm-`   | 4         | 32px           |
+| Medium (≥675)   | `.bx--col-md-`   | 8         | 32px           |
+| Large (≥1056)   | `.bx--col-lg-`   | 16        | 32px           |
+| X-Large (≥1312) | `.bx--col-xl-`   | 16        | 32px           |
+| Max (≥1584)     | `.bx--col-max-`  | 16        | 32px           |
 
 <Caption>
   * Gutter width is 32px — with 16px on each side of a column — at every


### PR DESCRIPTION
@photodow mentioned that breakpoint classes were wrong, need to update asap.