### PR TITLE
fix: temporarily disable lock file to pin charts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,22 +1,21 @@
 name: Test site build
 
-on: 
+on:
   pull_request:
     branches:
-    - master
+      - master
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Use Node.js 10.x
-      uses: actions/setup-node@v1
-      with:
-        version: 10.x
-    - name: Test site build
-      run: |
-        yarn install
-        yarn build
+      - uses: actions/checkout@master
+      - name: Use Node.js 10.x
+        uses: actions/setup-node@v1
+        with:
+          version: 10.x
+      - name: Test site build
+        run: |
+          yarn install --no-lockfile
+          yarn build

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "timestamp": "./build-timestamp.sh"
   },
   "dependencies": {
-    "@carbon/charts": "0.16.8",
-    "@carbon/charts-react": "0.16.8",
+    "@carbon/charts": "0.16.7",
+    "@carbon/charts-react": "0.16.7",
     "@carbon/elements": "^10.6.0",
     "@carbon/icons": "^10.6.0",
     "@carbon/icons-react": "^10.6.0",


### PR DESCRIPTION
Latest charts release is broken: https://github.com/carbon-design-system/carbon-charts/issues/363

Because their release process is also broken, we can't lock those packages down, yarn ignores their entries.
