### PR TITLE
typo(form): replaced &

### DIFF
--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -9,7 +9,7 @@ tabs: ['Code', 'Usage', 'Style']
 <AnchorLink>General guidance </AnchorLink>
 <AnchorLink>Format</AnchorLink>
 <AnchorLink>Form logic</AnchorLink>
-<AnchorLink>Validation & errors</AnchorLink>
+<AnchorLink>Validation and errors</AnchorLink>
 
 </AnchorLinks>
 
@@ -128,7 +128,7 @@ When the primary action implies a navigation step forward, as in a wizard, align
 </Column>
 </Row>
 
-## Validation & errors
+## Validation and errors
 
 ### Error messaging
 


### PR DESCRIPTION
`&` was making the anchor link not work. Replaced with the word "and"