### PR TITLE
fix(colors page): Update overview.mdx to dl the new colors files…

### DIFF
--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -26,7 +26,7 @@ import ColorGrid from 'components/ColorGrid';
 <Column  colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="RGB color palettes (.ase and .clr)"
-    href="https://www.carbondesignsystem.com/files/IBM_Colors_RGB.zip"
+    href="https://github.com/carbon-design-system/carbon/tree/master/packages/colors/artifacts/IBM_Colors.zip"
     >
 
 <MdxIcon name="ase" />

--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -26,7 +26,7 @@ import ColorGrid from 'components/ColorGrid';
 <Column  colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="RGB color palettes (.ase and .clr)"
-    href="https://github.com/carbon-design-system/carbon/tree/master/packages/colors/artifacts/IBM_Colors.zip"
+    href="https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip"
     >
 
 <MdxIcon name="ase" />

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -148,7 +148,7 @@ Everything you need to work with, learn about, and contribute to Carbon.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="RGB color palettes (.ase and .clr)"
-    href="https://github.com/carbon-design-system/carbon/tree/master/packages/colors/artifacts/IBM_Colors.zip"
+    href="https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip"
     >
 
 ![](/images/ase.png)


### PR DESCRIPTION
These two RGB Color resource tiles don’t point at the same .zip file for download.

https://www.carbondesignsystem.com/resources/#design-resources
https://www.carbondesignsystem.com/guidelines/color/overview#resources

if you go to the Resources page you get the new clr/ase files.
if you go to the color page you do not.

this fixes so both cards point at the resource in the color package (https://github.com/carbon-design-system/carbon/raw/master/packages/colors/artifacts/IBM_Colors.zip) and dl directly rather than opening the GH page.

#### Changelog

**Changed**

- src/pages/guidelines/color/overview.mdx
- src/pages/resources/index.mdx

**Testing / Reviewing**
verify dl links work for the resource and both point to the zip in this package (https://github.com/carbon-design-system/carbon/tree/master/packages/colors/artifacts/IBM_Colors.zip)

https://www.carbondesignsystem.com/resources/#design-resources
https://www.carbondesignsystem.com/guidelines/color/overview#resources

DL'd file should be IBM_Colors.zip **NOT** IBM_Colors_RGB.zip

after https://github.com/carbon-design-system/carbon/pull/4395 is merged IBM_Colors.zip should expand to:
IBM_Colors_V10.2/
IBM_Colors_V10.2/IBM_Colors_RGB_HEX_V10.2_REFERENCE.pdf
IBM_Colors_V10.2/IBM_Colors_PANTONE_V10.2_REFERENCE.pdf
IBM_Colors_V10.2/IBM_Colors_CMYK_V10.2_REFERENCE.pdf
IBM_Colors_V10.2/IBM_Colors_CMYK_V10.2.ase
IBM_Colors_V10.2/IBM_Colors_PANTONE_V10.2.ase
IBM_Colors_V10.2/IBM_Colors_RGB_HEX_V10.2.clr
IBM_Colors_V10.2/IBM_Colors_RGB_HEX_V10.2.ase


