### PR TITLE
fix: add missing links to a11y accordion docs

### DIFF
--- a/src/pages/components/accordion/accessibility.mdx
+++ b/src/pages/components/accordion/accessibility.mdx
@@ -51,16 +51,16 @@ This component has been validated to meet the [WCAG 2.0 AA](https://www.w3.org/T
 
 **Helpful Resources for Creating Customized Accessible Implementations**
 
-- [W3C WAI-ARIA Authoring Practices Accordion Design Pattern]() covers the usage of ARIA names, state and roles, as well as the expected keyboard interactions.
-- [IBM Accessibility Checklist Checkpoint:]()
-  - [1.3.1 Info and Relationship]()s (WCAG Success Criteria [1.3.1]())
-  - [1.3.2 Meaningful Sequence]() (WCAG Success Criteria [1.3.2]())
-  - [2.1.1 Keyboard]() (WCAG Success Criteria [2.1.1]())
-  - [2.1.2 No Keyboard Trap]() (WCAG Success Criteria [2.1.2]())
-  - [2.4.3 Focus Order]() (WCAG Success Criteria [2.4.3]())
-  - [2.4.6 Headings and Labels]() (WCAG Success Criteria [2.4.6]())
-  - [2.4.7 Focus Visible]() (WCAG Success Criteria [2.4.7]())
-  - [4.1.2 Name, Role, Value]() (WCAG Success Criteria [4.1.2]())
+- [W3C WAI-ARIA Authoring Practices Accordion Design Pattern](https://www.w3.org/TR/wai-aria-practices/#accordion) covers the usage of ARIA names, state and roles, as well as the expected keyboard interactions.
+- [IBM Accessibility Checklist Checkpoint:](https://www.ibm.com/able/guidelines/ci162/accessibility_checklist.html)
+  - [1.3.1 Info and Relationship](https://www.ibm.com/able/guidelines/ci162/info_and_relationships.html) (WCAG Success Criteria [1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships))
+  - [1.3.2 Meaningful Sequence](https://www.ibm.com/able/guidelines/ci162/meaningful_sequence.html) (WCAG Success Criteria [1.3.2](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence))
+  - [2.1.1 Keyboard](https://www.ibm.com/able/guidelines/ci162/keyboard.html) (WCAG Success Criteria [2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard))
+  - [2.1.2 No Keyboard Trap](https://www.ibm.com/able/guidelines/ci162/no_keyboard_trap.html) (WCAG Success Criteria [2.1.2](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap))
+  - [2.4.3 Focus Order](https://www.ibm.com/able/guidelines/ci162/focus_order.html) (WCAG Success Criteria [2.4.3](https://www.w3.org/WAI/WCAG21/Understanding/focus-order))
+  - [2.4.6 Headings and Labels](https://www.ibm.com/able/guidelines/ci162/headings_and_labels.html) (WCAG Success Criteria [2.4.6](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels))
+  - [2.4.7 Focus Visible](https://www.ibm.com/able/guidelines/ci162/focus_visible.html) (WCAG Success Criteria [2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible))
+  - [4.1.2 Name, Role, Value](https://www.ibm.com/able/guidelines/ci162/name_role_value.html) (WCAG Success Criteria [4.1.2](https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html))
 
 ## Accessibility Testing
 

--- a/src/pages/components/accordion/accessibility.mdx
+++ b/src/pages/components/accordion/accessibility.mdx
@@ -53,7 +53,7 @@ This component has been validated to meet the [WCAG 2.0 AA](https://www.w3.org/T
 
 - [W3C WAI-ARIA Authoring Practices Accordion Design Pattern](https://www.w3.org/TR/wai-aria-practices/#accordion) covers the usage of ARIA names, state and roles, as well as the expected keyboard interactions.
 - [IBM Accessibility Checklist Checkpoint:](https://www.ibm.com/able/guidelines/ci162/accessibility_checklist.html)
-  - [1.3.1 Info and Relationship](https://www.ibm.com/able/guidelines/ci162/info_and_relationships.html) (WCAG Success Criteria [1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships))
+  - [1.3.1 Info and Relationships](https://www.ibm.com/able/guidelines/ci162/info_and_relationships.html) (WCAG Success Criteria [1.3.1](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships))
   - [1.3.2 Meaningful Sequence](https://www.ibm.com/able/guidelines/ci162/meaningful_sequence.html) (WCAG Success Criteria [1.3.2](https://www.w3.org/WAI/WCAG21/Understanding/meaningful-sequence))
   - [2.1.1 Keyboard](https://www.ibm.com/able/guidelines/ci162/keyboard.html) (WCAG Success Criteria [2.1.1](https://www.w3.org/WAI/WCAG21/Understanding/keyboard))
   - [2.1.2 No Keyboard Trap](https://www.ibm.com/able/guidelines/ci162/no_keyboard_trap.html) (WCAG Success Criteria [2.1.2](https://www.w3.org/WAI/WCAG21/Understanding/no-keyboard-trap))


### PR DESCRIPTION
a11y PR for Accordion got merged and I forgot to add these links 🤦‍♀️