### PR TITLE
chore: update theme to beta for spacing audit

### DIFF
--- a/now.json
+++ b/now.json
@@ -1,3 +1,6 @@
 {
+  "version": 2,
+  "name": "carbondesignsystem",
+  "alias": "carbondesignsystem",
   "public": true
 }

--- a/now.json
+++ b/now.json
@@ -1,6 +1,3 @@
 {
-  "version": 2,
-  "name": "carbondesignsystem",
-  "alias": "carbondesignsystem",
   "public": true
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gatsby-plugin-compile-es6-packages": "^2.1.0",
     "gatsby-plugin-lodash": "^3.1.3",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",
-    "gatsby-theme-carbon": "^1.11.3-alpha.12",
+    "gatsby-theme-carbon": "^1.16.0-alpha.0",
     "html-loader": "^0.5.5",
     "lodash": "^4.17.15",
     "markdown-it": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gatsby-plugin-compile-es6-packages": "^2.1.0",
     "gatsby-plugin-lodash": "^3.1.3",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",
-    "gatsby-theme-carbon": "^1.16.0-alpha.0",
+    "gatsby-theme-carbon": "^1.16.0-alpha.1",
     "html-loader": "^0.5.5",
     "lodash": "^4.17.15",
     "markdown-it": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "gatsby-plugin-compile-es6-packages": "^2.1.0",
     "gatsby-plugin-lodash": "^3.1.3",
     "gatsby-plugin-remove-serviceworker": "^1.0.0",
-    "gatsby-theme-carbon": "^1.14.2",
+    "gatsby-theme-carbon": "^1.11.3-alpha.12",
     "html-loader": "^0.5.5",
     "lodash": "^4.17.15",
     "markdown-it": "^9.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3108,24 +3108,6 @@ capture-stack-trace@^1.0.0:
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
-carbon-components-react@^7.7.1:
-  version "7.7.1"
-  resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.7.1.tgz#18a0fadf80122bc284c7407be8ef0545a56968a3"
-  integrity sha512-FJGaW+Y73qu4y7Za81JRN7pUM1g8ztRLVTo1UxmPWGrFwmIpxtoGkEsrpzIrvw7e4p6s4f8e6LAzZyzp+JmCTA==
-  dependencies:
-    "@carbon/icons-react" "10.6.0"
-    classnames "2.2.6"
-    downshift "^1.31.14"
-    flatpickr "4.6.1"
-    focus-trap-react "^6.0.0"
-    invariant "^2.2.3"
-    lodash.debounce "^4.0.8"
-    lodash.isequal "^4.5.0"
-    lodash.omit "^4.5.0"
-    react-is "^16.8.6"
-    warning "^3.0.0"
-    window-or-global "^1.0.1"
-
 carbon-components-react@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.7.3.tgz#51cfcb7223e7a3f7069f8bcd9ef415917bb527eb"
@@ -3148,16 +3130,6 @@ carbon-components@10.3.2:
   version "10.3.2"
   resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.3.2.tgz#1d1571ce43ccbef06fa506605d60fbc5d75b6fa9"
   integrity sha512-u6EoEBr7f/QoxuGA3yqv/1qvjwgtnqBQxge3kVXpTIyhq2oGE9fOl6g2fk4KlMNu1zV2hlbyhr+2vvsJuS3n4g==
-  dependencies:
-    carbon-icons "^7.0.7"
-    flatpickr "4.6.1"
-    lodash.debounce "^4.0.8"
-    warning "^3.0.0"
-
-carbon-components@^10.7.1:
-  version "10.7.1"
-  resolved "https://registry.yarnpkg.com/carbon-components/-/carbon-components-10.7.1.tgz#74ebb771eedb6c61ee264d02609ac06b5d87d090"
-  integrity sha512-DRc8xv9PT+3XJXZ2fUBAVvZMJ302YYz5CRrEZrukKv1Rrmm6IKwAfzjF4VCoGLyrt7+TPghQNE2c4Xnbfor3wg==
   dependencies:
     carbon-icons "^7.0.7"
     flatpickr "4.6.1"
@@ -6739,10 +6711,10 @@ gatsby-telemetry@^1.1.33:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-carbon@^1.14.2:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.15.1.tgz#411a44fd4a7dc05506e5ee1e2f83c0d121841691"
-  integrity sha512-Z0m91LnzB0FDIHVQMkJaTjWMTAgm0V7qL2E4gVkO4+aFJXFabOMPBR5Vufl7n5N411+h18VzKoaR++b+u4FaAg==
+gatsby-theme-carbon@^1.11.3-alpha.12:
+  version "1.11.3-alpha.12"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.11.3-alpha.12.tgz#705b8097c3b1f047de3b572005509a6ed0585582"
+  integrity sha512-kWdxveDVPNF7G+GC5Bgo64tMsPmJmk0L7CqgX1rG7sVoM+XzkQfHMstzqiOx/gzW8VZ9Eq6U5538kb5Fr9dcGg==
   dependencies:
     "@carbon/elements" "^10.5.1"
     "@carbon/icons-react" "^10.5.0"
@@ -6752,8 +6724,8 @@ gatsby-theme-carbon@^1.14.2:
     "@mdx-js/react" "^1.0.20"
     "@reach/router" "^1.2.1"
     "@vimeo/player" "^2.9.1"
-    carbon-components "^10.7.1"
-    carbon-components-react "^7.7.1"
+    carbon-components "^10.7.3"
+    carbon-components-react "^7.7.3"
     classnames "^2.2.6"
     copy-to-clipboard "^3.2.0"
     emotion-theming "^10.0.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6711,10 +6711,10 @@ gatsby-telemetry@^1.1.33:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-carbon@^1.16.0-alpha.0:
-  version "1.16.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.16.0-alpha.0.tgz#e7480330e7e73976ffc0f4a3c1a4b6aabc751a52"
-  integrity sha512-qk2Ig4VOKrRQRX+6AGoha4ii+50DK8SAKjwPi18iy05ORXDvZlCOIiSSFGeGC2pRY+xxFcaCSJWQ2c4z6+WWaQ==
+gatsby-theme-carbon@^1.16.0-alpha.1:
+  version "1.16.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.16.0-alpha.1.tgz#902be5d33f6f54620ba58ccef80e86566a9854a3"
+  integrity sha512-KylGuknS7qUpq+ggjItJsIxKN41/xBvEo/F7aiHGN4DOzDnJBoiDBH6QWCF9VhhAYO/CqvvbKuOP0lfN+K0Hnw==
   dependencies:
     "@carbon/elements" "^10.5.1"
     "@carbon/icons-react" "^10.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6711,10 +6711,10 @@ gatsby-telemetry@^1.1.33:
     stack-utils "1.0.2"
     uuid "3.3.3"
 
-gatsby-theme-carbon@^1.11.3-alpha.12:
-  version "1.11.3-alpha.12"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.11.3-alpha.12.tgz#705b8097c3b1f047de3b572005509a6ed0585582"
-  integrity sha512-kWdxveDVPNF7G+GC5Bgo64tMsPmJmk0L7CqgX1rG7sVoM+XzkQfHMstzqiOx/gzW8VZ9Eq6U5538kb5Fr9dcGg==
+gatsby-theme-carbon@^1.16.0-alpha.0:
+  version "1.16.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-1.16.0-alpha.0.tgz#e7480330e7e73976ffc0f4a3c1a4b6aabc751a52"
+  integrity sha512-qk2Ig4VOKrRQRX+6AGoha4ii+50DK8SAKjwPi18iy05ORXDvZlCOIiSSFGeGC2pRY+xxFcaCSJWQ2c4z6+WWaQ==
   dependencies:
     "@carbon/elements" "^10.5.1"
     "@carbon/icons-react" "^10.5.0"


### PR DESCRIPTION
This uses a beta version of the theme to give a better idea of what the spacing audit will look like in situ.