### PR TITLE
Fix manifest

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,6 @@ jobs:
         env:
           API_KEY: ${{ secrets.API_KEY }}
         run: ibmcloud login -a "https://cloud.ibm.com" -u apikey -p "$API_KEY" -o "carbon-design-system" -s "production" -r "us-south"
-      - name: Install ibmcloud plugins
-        run: |
-          ibmcloud cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-          ibmcloud cf install-plugin blue-green-deploy -f -r CF-Community
       - name: Deploy website
         run: |
-          ibmcloud cf blue-green-deploy carbon-website -f manifest.production.yml --delete-old-apps
+          ibmcloud cf v3-zdt-push carbon-website -b https://github.com/cloudfoundry/nginx-buildpack.git

--- a/manifest.production.yml
+++ b/manifest.production.yml
@@ -1,7 +1,8 @@
 ---
 applications:
   - name: carbon-website
-    buildpack: https://github.com/cloudfoundry/nginx-buildpack.git
+    buildpacks:
+      - https://github.com/cloudfoundry/nginx-buildpack.git
     routes:
       - route: www.carbondesignsystem.com
       - route: carbondesignsystem.com

--- a/manifest.production.yml
+++ b/manifest.production.yml
@@ -1,9 +1,0 @@
----
-applications:
-  - name: carbon-website
-    buildpacks:
-      - https://github.com/cloudfoundry/nginx-buildpack.git
-    routes:
-      - route: www.carbondesignsystem.com
-      - route: carbondesignsystem.com
-      - route: design-system.mybluemix.net


### PR DESCRIPTION
Closes #613 

ibmcloud doesn't use v7 of cf-cli yet so to use the zero down-time deployment, we need to use [`v3-zdt-cli`](https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html#deploy) for zero downtime deployments

One of the limitations of using this command is that in v6 of cf-cli, you can't use an app manifest file.

Turns out this is fine since we actually don't need to define the routes every time (like we currently are) and the buildpack/app name can be defined with the cli command.