### PR TITLE
docs(react): improve .cfignore

### DIFF
--- a/src/pages/tutorial/react/step-5.mdx
+++ b/src/pages/tutorial/react/step-5.mdx
@@ -157,7 +157,16 @@ After telling Cloud Foundry what to include, we can also specify what to ignore.
 node_modules/.cache
 ```
 
-You can speed up deploys by decreasing the files uploaded through cloud foundry. To accomplish this, ignore any folder not required by the production application on IBM Cloud. For example, in the case of serving static files, you can ignore `node_modules/` and `src/` because the only folder being served is `build/`.
+You can speed up deploys by decreasing the files uploaded through cloud foundry. To accomplish this, ignore any folder not required by the production application on IBM Cloud. 
+
+In our case we can ignore everything except the `build/` directory and `Staticfile`.  To speed up our deploys change `.cfignore` to:
+
+```bash path=.cfignore
+*
+
+!Staticfile
+!build
+```
 
 ## Deploy app
 


### PR DESCRIPTION
With a proper `.cfignore` the deploy speed is about 25 times faster.

See also: carbon-design-system/carbon-tutorial#3178

#### Changelog

**Changed**

- In the react tutorial, step 5: Use a `.cfignore` that only sends the static site.
