### PR TITLE
Set correct Gray 10 background hex value

### DIFF
--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -168,7 +168,7 @@ color.
 | Theme    | Primary background      | Token            | Hex value |                                             |
 | -------- | ----------------------- | ---------------- | --------- | ------------------------------------------: |
 | White    | Global Background Light | `$ui-background` | `#ffffff` |  <ColorBlock size="xs">#ffffff</ColorBlock> |
-| Gray 10  | Global Background Light | `$ui-background` | `#f3f3f3` | <ColorBlock  size="xs">#f3f3f3</ColorBlock> |
+| Gray 10  | Global Background Light | `$ui-background` | `#f4f4f4` | <ColorBlock  size="xs">#f4f4f4</ColorBlock> |
 | Gray 90  | Global Background Dark  | `$ui-background` | `#282828` | <ColorBlock  size="xs">#282828</ColorBlock> |
 | Gray 100 | Global Background Dark  | `$ui-background` | `#171717` | <ColorBlock  size="xs">#171717</ColorBlock> |
 


### PR DESCRIPTION
The hex value of Gray 10 background was not correct.

#### Changelog

**Changed**

- Hex value from `#f3f3f3` to `#f4f4f4`