### PR TITLE
feat: split carbon deps into their own chunk

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ actions, stage, getConfig }) => {
   // Allows importing html files for component code examples
   actions.setWebpackConfig({
     module: {
@@ -26,4 +26,14 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       },
     },
   });
+  if (stage === `build-javascript`) {
+    const config = getConfig();
+    config.optimization.splitChunks.cacheGroups.carbon = {
+      name: `carbon`,
+      chunks: `all`,
+      test: /[\\/]node_modules[\\/]@?carbon/,
+    };
+    // This will completely replace the webpack config with the modified object.
+    actions.replaceWebpackConfig(config);
+  }
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "clean": "gatsby clean",
     "build": "node --max-old-space-size=8192 ./node_modules/.bin/gatsby build",
     "build:clean": "gatsby clean && yarn build",
-    "build:analyze": "ANALYZE=true yarn build:clean",
+    "build:analyze": "ANALYZE=true yarn build",
     "serve": "gatsby serve",
     "lint:js": "eslint src --fix",
     "format": "prettier --write 'src/**/*.{js,json,css,scss,md,mdx,yaml}'",


### PR DESCRIPTION
Additional follow up for #381 

By default, all of our deps are being lumped together. This is problematic considering the size of some of our dependencies (@carbon/icons-react, carbon-components, carbon-components-react). 

By chunking these carbon deps together, they can be cached independently from our app bundle which is much more volatile/subject to change.

before: 
- `app-*.js` (911kb)

after: 
- `app-*.js` (507kb)
- `carbon-*.js` (513kb)