### PR TITLE
chore: remove  image processing to improve build times

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,6 +7,12 @@ module.exports = {
       'IBM, design, system, Carbon, design system, Bluemix, styleguide, style, guide, components, library, pattern, kit, component, cloud',
   },
   plugins: [
+    {
+      resolve: `gatsby-plugin-sharp`,
+      options: {
+        useMozJpeg: false,
+      },
+    },
     'gatsby-plugin-lodash',
     {
       resolve: 'gatsby-theme-carbon',


### PR DESCRIPTION
We pre-process images, so don't need sharp to do so