### PR TITLE
Fix broken link in guidelines/2x-grid/basics.mdx

### DIFF
--- a/src/pages/guidelines/2x-grid/basics.mdx
+++ b/src/pages/guidelines/2x-grid/basics.mdx
@@ -101,7 +101,7 @@ When tiling fixed boxes, the column count is not known in advance, but a grid em
 
 #### Hybrid grid
 
-[Hybrid grids](#hybrid) are also frequent in practice, and hybrid boxes have properties of both.
+[Hybrid grids](#hybrid-grid) are also frequent in practice, and hybrid boxes have properties of both.
 
 #### Decision tree
 


### PR DESCRIPTION
There is a broken link in https://www.carbondesignsystem.com/guidelines/2x-grid/basics, section "Hybrid Grid". It links to `#hybrid`, but no such anchor exists. I assume `#hybrid-grid` was intended. If so, this PR fixes that.

#### Changelog

**Changed**

- Broken link fixed.
