### PR TITLE
docs(vue-tutorial): update list of frameworks in step 2

### DIFF
--- a/src/pages/tutorial/vue/step-2.mdx
+++ b/src/pages/tutorial/vue/step-2.mdx
@@ -221,7 +221,7 @@ Modify the second row to use the `Tab` component.
         <div class="bx--grid bx--grid--no-gutter bx--grid--full-width">
           <div class="bx--row landing-page__tab-content">
             <div class="bx--col-lg-16">
-              Carbon provides styles and components in Vanilla, Vue, Angular,
+              Carbon provides styles and components in Vanilla, React, Angular,
               and Vue for anyone building on the web.
             </div>
           </div>


### PR DESCRIPTION
Looks like Step 2 of the Vue Tutorial mentions "Vue" twice, and leaves out React as a framework.

#### Changelog

**Changed**

- Update list of supported frameworks
