### PR TITLE
docs: adding Feedback anchorlink

### DIFF
--- a/src/pages/patterns/dialog-pattern/index.mdx
+++ b/src/pages/patterns/dialog-pattern/index.mdx
@@ -18,6 +18,7 @@ A dialog is a “conversation” between the system and the user. It is prompted
 <AnchorLink>Related components and patterns</AnchorLink>
 <AnchorLink>Accessibility</AnchorLink>
 <AnchorLink>References</AnchorLink>
+<AnchorLink>Feedback</AnchorLink>
 
 </AnchorLinks>
 


### PR DESCRIPTION
We elected to keep `Feedback` as an anchorlink for all production patterns. Adding in here.
