### PR TITLE
fix: don't use css transitions while the page is still hydrating

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,1 +1,9 @@
+/* eslint-disable import/prefer-default-export */
 import './src/styles/index.scss';
+
+export const onClientEntry = () => {
+  const body = document.querySelector('body');
+  window.addEventListener('load', () => {
+    body.classList.remove('body--preload');
+  });
+};

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -2,7 +2,10 @@
 import React from 'react';
 import ogimage from './src/images/ogimage.png';
 
-export const onRenderBody = ({ setHeadComponents }) => {
+export const onRenderBody = ({ setHeadComponents, setBodyAttributes }) => {
+  setBodyAttributes({
+    class: 'body--preload',
+  });
   setHeadComponents([
     <link
       key="serif"
@@ -21,8 +24,16 @@ export const onRenderBody = ({ setHeadComponents }) => {
       property="twitter:image:alt"
       content="Carbon Design System logo"
     />,
-    <meta property="og:type" content="website" />,
-    <meta property="twitter:card" content="summary_large_image" />,
-    <meta property="twitter:site" content="@_carbondesign" />,
+    <meta key="og:type" property="og:type" content="website" />,
+    <meta
+      key="twitter:card"
+      property="twitter:card"
+      content="summary_large_image"
+    />,
+    <meta
+      key="twitter:site"
+      property="twitter:site"
+      content="@_carbondesign"
+    />,
   ]);
 };

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -5,6 +5,11 @@
   color: var(--cds-text-01, #161616);
 }
 
+// prevent loading wonky
+.body--preload * {
+  transition: none !important;
+}
+
 // Code snippet background?
 
 //---------------------------------------


### PR DESCRIPTION
This is really a major issue only on sites with an extensive load time and even then only on mobile/tablet.