### PR TITLE
fix: wrong value font-weight in UI shell header

### DIFF
--- a/src/pages/components/UI-shell-header/style.mdx
+++ b/src/pages/components/UI-shell-header/style.mdx
@@ -104,8 +104,8 @@ Menu labels and text should be set in sentence case.
 
 | Class                       | Font-size (px/rem) | Font-weight    | Type token       |
 | --------------------------- | ------------------ | -------------- | ---------------- |
-| `.bx--header__name`         | 14 / 0.875         | Regular / 400  | `$body-short-01` |
-| `.bx--header__name--prefix` | 14 / 0.875         | SemiBold / 600 | `$heading-01`    |
+| `.bx--header__name`         | 14 / 0.875         | SemiBold / 600 | `$heading-01`    |
+| `.bx--header__name--prefix` | 14 / 0.875         | Regular / 400  | `$body-short-01` |
 | `.bx--header__menu-item`    | 14 / 0.875         | Regular / 400  | `$body-short-01` |
 
 ## Structure


### PR DESCRIPTION
Closes #616 

Swap 2 values in font-weight in UI shell header

#### Changelog

**Changed**

- swap 2 values in typo font-weight UI-shell-header

