### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,11 @@
 # This file determines the code owners for various directories within the IBM Carbon website.
 
+# Default to the aux team
+* @carbon-design-system/developers-auxiliary
+
+# If updating content (mdx) opt for systems team
+*.mdx @carbon-design-system/developers-system
+
 # Vikki Paterson is code owner for Experimental IDE patterns
 src/pages/experimental/create-flows/* @vikkipaterson
 src/pages/experimental/delete-pattern/* @vikkipaterson

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 * @carbon-design-system/developers-auxiliary
 
 # If updating content (mdx) opt for systems team
-*.mdx @carbon-design-system/developers-system
+*.mdx @carbon-design-system/developers-system @carbon-design-system/content
 
 # Vikki Paterson is code owner for Experimental IDE patterns
 src/pages/experimental/create-flows/* @vikkipaterson


### PR DESCRIPTION
This should default new pr's reviews to aux squad, unless content is being updated, in which case the systems squad will be added for review.