### PR TITLE
Update vanilla urls on code example pages

### DIFF
--- a/src/pages/components/accordion/code.mdx
+++ b/src/pages/components/accordion/code.mdx
@@ -12,7 +12,7 @@ tabs: ['Code', 'Usage', 'Style', 'Accessibility']
       'https://angular.carbondesignsystem.com/?path=/story/components-accordion--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvaccordion--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=accordion',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=accordion',
   }}
   knobs={{ AccordionItem: ['open'] }}>{`
 <Accordion>

--- a/src/pages/components/breadcrumb/code.mdx
+++ b/src/pages/components/breadcrumb/code.mdx
@@ -12,7 +12,7 @@ tabs: ['Code', 'Usage', 'Style', 'Accessibility']
       'https://angular.carbondesignsystem.com/?path=/story/components-breadcrumb--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvbreadcrumb--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=breadcrumb',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=breadcrumb',
   }}
   knobs={{
     Breadcrumb: ['noTrailingSlash'],

--- a/src/pages/components/button/code.mdx
+++ b/src/pages/components/button/code.mdx
@@ -11,7 +11,7 @@ tabs: ['Code', 'Usage', 'Style']
       'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvbutton--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=button',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=button',
   }}
   knobs={{
     Button: ['kind', 'disabled', 'size'],

--- a/src/pages/components/checkbox/code.mdx
+++ b/src/pages/components/checkbox/code.mdx
@@ -11,7 +11,7 @@ tabs: ['Code', 'Usage', 'Style', 'Accessibility']
       'https://angular.carbondesignsystem.com/?path=/story/components-checkbox--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvcheckbox--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=checkbox',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=checkbox',
   }}
   knobs={{ Checkbox: ['indeterminate', 'disabled', 'hideLabel'] }}>
   {`

--- a/src/pages/components/code-snippet/code.mdx
+++ b/src/pages/components/code-snippet/code.mdx
@@ -12,7 +12,7 @@ tabs: ['Code', 'Usage', 'Style']
       'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvcodesnippet--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=code-snippet',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=code-snippet',
   }}
   knobs={{ CodeSnippet: ['type'] }}>
   {`

--- a/src/pages/components/content-switcher/code.mdx
+++ b/src/pages/components/content-switcher/code.mdx
@@ -12,7 +12,7 @@ tabs: ['Code', 'Usage', 'Style', 'Accessibility']
       'https://angular.carbondesignsystem.com/?path=/story/components-content-switcher--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvcontentswitcher--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=content-switcher',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=content-switcher',
   }}>{`
 <ContentSwitcher onChange={console.log}>
   <Switch name={'first'} text='First section' />

--- a/src/pages/components/inline-loading/code.mdx
+++ b/src/pages/components/inline-loading/code.mdx
@@ -12,7 +12,7 @@ tabs: ['Code', 'Usage', 'Style', 'Accessibility']
       'https://angular.carbondesignsystem.com/?path=/story/components-inline-loading--basic',
     Vue:
       'http://vue.carbondesignsystem.com/?path=/story/components-cvinlineloading--default',
-    Vanilla: 'https://the-carbon-components.netlify.com/?nav=inline-loading',
+    Vanilla: 'https://vanilla.carbondesignsystem.com/?nav=inline-loading',
   }}
   knobs={{
     InlineLoading: ['status'],


### PR DESCRIPTION
Replaces links to `https://the-carbon-components.netlify.com`  with `https://vanilla.carbondesignsystem.com` on the code example pages