### PR TITLE
add table-layout to make cell equal

### DIFF
--- a/src/components/ComponentStatus/component-status.scss
+++ b/src/components/ComponentStatus/component-status.scss
@@ -2,6 +2,10 @@
   white-space: nowrap;
 }
 
+.component-status .page-table {
+  table-layout: fixed;
+}
+
 .component-status .page-table td {
   padding: $spacing-04 $spacing-05;
 }


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/gatsby-theme-carbon/issues/708

I add table-layout: fixed to make every column have same width.

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
