### PR TITLE
fix angular step one repo init command

### DIFF
--- a/src/pages/tutorial/angular/step-1.mdx
+++ b/src/pages/tutorial/angular/step-1.mdx
@@ -135,7 +135,7 @@ Now that we a have starter remote, we can rebase our branch to match whatever is
 
 ```bash
 git fetch starter
-git pull --allow-unrelated-histories starter master
+git reset --hard starter/master
 ```
 
 ### Remove starter remote


### PR DESCRIPTION
`git pull --allow-unrelated-histories starter master` doesn't seem to actually fetch anything (it definitely did when testing 😕), so instead we can just reset the branch to the head of the starter remote (confirmed working by a few people on Slack).