### PR TITLE
chore(tutorial): update step-1 to use ESM for carbon

### DIFF
--- a/src/pages/tutorial/react/step-1.mdx
+++ b/src/pages/tutorial/react/step-1.mdx
@@ -256,7 +256,7 @@ import {
   HeaderGlobalBar,
   HeaderGlobalAction,
   SkipToContent,
-} from 'carbon-components-react/lib/components/UIShell';
+} from 'carbon-components-react/es/components/UIShell';
 
 const TutorialHeader = () => (
   <Header aria-label="Carbon Tutorial">
@@ -332,7 +332,7 @@ Next we'll render our UI Shell by importing our `TutorialHeader` component and `
 import React, { Component } from 'react';
 import './app.scss';
 import { Button } from 'carbon-components-react';
-import { Content } from 'carbon-components-react/lib/components/UIShell';
+import { Content } from 'carbon-components-react/es/components/UIShell';
 import TutorialHeader from './components/TutorialHeader';
 ```
 


### PR DESCRIPTION
Based on: https://github.com/carbon-design-system/carbon/issues/4847#issuecomment-590198880

This PR updates our tutorial to use ESM imports instead of `lib`. This helps with tree-shaking icons that are used by `carbon-components-react`.

#### Changelog

**New**

**Changed**

- Update step-1 to use `es` for `carbon-components-react`

**Removed**
