### PR TITLE
docs: fix broken link

### DIFF
--- a/src/pages/patterns/overview.mdx
+++ b/src/pages/patterns/overview.mdx
@@ -19,7 +19,7 @@ Patterns are best practice solutions for how a user achieves a goal. They show r
 | [Forms](/patterns/forms-pattern)                | A group of related input controls that allows users to provide data or configure options                                                |
 | [Global header](/patterns/global-header)        | Covers using UI Shell components for within and between product navigation; introduces techniques for achieving consistency in products |
 | [Loading](/patterns/loading-pattern)            | Used when information takes an extended amount of time to process and appear on screen                                                  |
-| [Login](/patterns/login)                        | Allows a user to gain access to an application by entering their user ID and password                                                   |
+| [Login](/patterns/login-pattern)                | Allows a user to gain access to an application by entering their user ID and password                                                   |
 | [Notifications](/patterns/notification-pattern) | An important method of communicating with users and providing feedback                                                                  |
 | [Overflow content](/patterns/overflow-content)  | Text, such as a paragraph or a text string, that exceeds a desired space                                                                |
 | [Search](/patterns/search-pattern)              | An intuitive method of discovery, offering users a way to explore a website or application using keywords                               |


### PR DESCRIPTION
Fix link to login pattern on Patterns overview page.  