### PR TITLE
docs: Added note and fathom tracking to component status page

### DIFF
--- a/src/pages/components/component-status/index.mdx
+++ b/src/pages/components/component-status/index.mdx
@@ -2,6 +2,12 @@
 title: Component status
 ---
 
+<InlineNotification kind="warning">
+
+The team is currently reviewing the intent and accuracy of this data. Please [let us know](https://github.com/carbon-design-system/carbon-website/issues/961) what status information you would like to see surfaced here.
+
+</InlineNotification>
+
 import ComponentStatus from 'components/ComponentStatus';
 
 <ComponentStatus />

--- a/src/pages/components/component-status/index.mdx
+++ b/src/pages/components/component-status/index.mdx
@@ -4,7 +4,7 @@ title: Component status
 
 <InlineNotification kind="warning">
 
-The team is currently reviewing the intent and accuracy of this data. Please [let us know](https://github.com/carbon-design-system/carbon-website/issues/961) what status information you would like to see surfaced here.
+The team is currently reviewing the intent and accuracy of this data. Please <a href="https://github.com/carbon-design-system/carbon-website/issues/961" onClick={() => fathom('trackGoal', '74Y37LB2', 0)}>let us know</a> what status information you would like to see surfaced here.
 
 </InlineNotification>
 

--- a/src/pages/components/component-status/index.mdx
+++ b/src/pages/components/component-status/index.mdx
@@ -2,9 +2,9 @@
 title: Component status
 ---
 
-<InlineNotification kind="warning">
+<InlineNotification>
 
-The team is currently reviewing the intent and accuracy of this data. Please <a href="https://github.com/carbon-design-system/carbon-website/issues/961" onClick={() => fathom('trackGoal', '74Y37LB2', 0)}>let us know</a> what status information you would like to see surfaced here.
+The team is currently reviewing the intent and usefulness of this page. Please <a href="https://github.com/carbon-design-system/carbon-website/issues/961" onClick={() => fathom('trackGoal', '74Y37LB2', 0)}>let us know</a> if there is any information in particular you would like to see surfaced here.
 
 </InlineNotification>
 


### PR DESCRIPTION
Added an accuracy warning and fathom tracking link to component status page. Related to: https://github.com/carbon-design-system/carbon-website/issues/961