### PR TITLE
fix: flashing of white background for homepage image

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -4,6 +4,12 @@ title: Homepage
 
 import HomepageTemplate from 'gatsby-theme-carbon/src/templates/Homepage';
 
+<!-- Don't use gatsby image for above the fold homepage content -->
+
+import gsdM from './homepage/images/getting-started-designers-mobile.png';
+import gsdT from './homepage/images/getting-started-designers-tablet.png';
+import gsd from './homepage/images/getting-started-designers.png';
+
 export default HomepageTemplate;
 
 <FeatureCard
@@ -17,9 +23,9 @@ export default HomepageTemplate;
 
 <ArtDirection>
 
-![Get started for designers](homepage/images/getting-started-designers-mobile.png)
-![Get started for designers](homepage/images/getting-started-designers-tablet.png)
-![Get started for designers](homepage/images/getting-started-designers.png)
+<img src={gsdM} alt="Get started for designers" />
+<img src={gsdT} alt="Get started for designers" />
+<img src={gsd} alt="Get started for designers" />
 
 </ArtDirection>
 


### PR DESCRIPTION
Using gatsby-image here results in a quick flash of the light background.

These images are super small, so we don't need gatsby-image's optimization or lazy loading. We can just import them normally.