### PR TITLE
docs: update messaging around React first

### DIFF
--- a/src/pages/get-started/about-carbon.mdx
+++ b/src/pages/get-started/about-carbon.mdx
@@ -24,7 +24,7 @@ As IBM's official design system, Carbon serves a wide range of designers and dev
 
 The goals of the design system include improving UI consistency and quality, making the design and development process more efficient and focused, establishing a shared vocabulary between designer and developer, and providing clear, discoverable guidance around design and development best practices.
 
-The Carbon Design System is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re you’re using a different framework, you can still build components by following our guidelines for [other frameworks](/get-started/develop/other-frameworks).
+The design system is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re you’re using a different framework, you can still build components by following our guidelines for [other frameworks](/get-started/develop/other-frameworks).
 
 ## Guiding principles
 

--- a/src/pages/get-started/about-carbon.mdx
+++ b/src/pages/get-started/about-carbon.mdx
@@ -24,6 +24,8 @@ As IBM's official design system, Carbon serves a wide range of designers and dev
 
 The goals of the design system include improving UI consistency and quality, making the design and development process more efficient and focused, establishing a shared vocabulary between designer and developer, and providing clear, discoverable guidance around design and development best practices.
 
+The Carbon Design System is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re you’re using a different framework, you can still build components by following our guidelines for [other frameworks](/get-started/develop/other-frameworks).
+
 ## Guiding principles
 
 **Carbon is open.** The design system is a distributed effort, guided by the principles of the [open-source movement](https://en.wikipedia.org/wiki/Open-source-software_movement). Carbon's users are also its makers, and everyone is encouraged to contribute.

--- a/src/pages/get-started/about-carbon.mdx
+++ b/src/pages/get-started/about-carbon.mdx
@@ -24,7 +24,7 @@ As IBM's official design system, Carbon serves a wide range of designers and dev
 
 The goals of the design system include improving UI consistency and quality, making the design and development process more efficient and focused, establishing a shared vocabulary between designer and developer, and providing clear, discoverable guidance around design and development best practices.
 
-The design system is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re you’re using a different framework, you can still build components by following our guidelines for [other frameworks](/get-started/develop/other-frameworks).
+The design system is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re using a different framework, you can still build components by following our guidelines for [other frameworks](/get-started/develop/other-frameworks).
 
 ## Guiding principles
 

--- a/src/pages/get-started/develop/angular.mdx
+++ b/src/pages/get-started/develop/angular.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/angular.mdx
+++ b/src/pages/get-started/develop/angular.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/other-frameworks.mdx
+++ b/src/pages/get-started/develop/other-frameworks.mdx
@@ -26,7 +26,7 @@ The Carbon Design System is built [React](/get-started/develop/react) first. We 
 
 ### Using just the styles
 
-Developers wanting to build in different ways follow the instructions for the [vanilla JS](/get-started/develop/vanilla) library to access the styles and build out their own components.
+Developers wanting to build in different ways, follow the instructions for the [vanilla JS](/get-started/develop/vanilla) library to access the styles and build out their own components.
 
 ### Wrapping components with JavaScript frameworks
 

--- a/src/pages/get-started/develop/other-frameworks.mdx
+++ b/src/pages/get-started/develop/other-frameworks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/other-frameworks.mdx
+++ b/src/pages/get-started/develop/other-frameworks.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 
@@ -13,7 +13,7 @@ tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 
 ## Development options
 
-The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+The Carbon Design System is built [React](/get-started/develop/react) first. We also support core parts of the system in [vanilla JS](/get-started/develop/vanilla), [Angular](/get-started/develop/angular), and [Vue](/get-started/develop/vue). If you’re you’re using a different framework, you can still build components by following the guidelines below.
 
 <AnchorLinks small>
   <AnchorLink>Using just the styles</AnchorLink>
@@ -26,7 +26,7 @@ The Carbon Design System supports vanilla JS, React and Angular as core parts of
 
 ### Using just the styles
 
-Developers wanting to build in different ways follow the instructions for the [Vanilla](/get-started/develop/vanilla) library to access the styles and build out their own components.
+Developers wanting to build in different ways follow the instructions for the [vanilla JS](/get-started/develop/vanilla) library to access the styles and build out their own components.
 
 ### Wrapping components with JavaScript frameworks
 

--- a/src/pages/get-started/develop/react.mdx
+++ b/src/pages/get-started/develop/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/react.mdx
+++ b/src/pages/get-started/develop/react.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/vanilla.mdx
+++ b/src/pages/get-started/develop/vanilla.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/vanilla.mdx
+++ b/src/pages/get-started/develop/vanilla.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/vue.mdx
+++ b/src/pages/get-started/develop/vue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System supports vanilla JS, React and Angular as core parts of the product. But you can still build components even if you're using a different framework.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 

--- a/src/pages/get-started/develop/vue.mdx
+++ b/src/pages/get-started/develop/vue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Develop
-description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. If you’re you’re using a different framework, you can still build components by following the guidelines below.
+description: The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue.
 tabs: ['React', 'Vanilla', 'Angular', 'Vue', 'Other frameworks']
 ---
 


### PR DESCRIPTION
Updated the paragraph on the "other frameworks" page along with the page descriptions. 

Do we want to add this paragraph to a more prominent place on the website also? 

> The Carbon Design System is built React first. We also support core parts of the system in vanilla JS, Angular, and Vue. 