### PR TITLE
update pictogram repo links

### DIFF
--- a/src/pages/guidelines/pictograms/contribute.mdx
+++ b/src/pages/guidelines/pictograms/contribute.mdx
@@ -87,7 +87,7 @@ To be considered production-ready, all pictogram submissions must be delivered i
 
 ## Contribution process
 
-Does your pictogram have potential for other materials at IBM? If so, please consider contributing to the design system. IBM welcomes pictogram contributions in the form of a pull request to our pictogram repository (coming soon). In the mean time to make a pull request, please [submit an issue in the repo](https://github.com/carbon-design-system/carbon-icons/issues/new) with the pictogram attached.
+Does your pictogram have potential for other materials at IBM? If so, please consider contributing to the design system. IBM welcomes pictogram contributions in the form of a pull request to our pictogram repository (coming soon). In the mean time to make a pull request, please [submit an issue in the repo](https://github.ibm.com/brand/pictograms/issues/new) with the pictogram attached.
 
 Please note that Carbon contribution is **not required** in order to introduce a new pictogram into your materials. If your pictogram is determined to be broadly useful in Carbon and passes IBM Brand design reviews, then it may also be integrated into the design system.
 


### PR DESCRIPTION
Changed contribution link to `brand/pictograms` instead of carbon/icons.