### PR TITLE
chore(dialog): update language in dialog pattern

### DIFF
--- a/src/pages/patterns/dialog-pattern/index.mdx
+++ b/src/pages/patterns/dialog-pattern/index.mdx
@@ -5,7 +5,7 @@ description: A dialog is a “conversation” between the system and the user. I
 
 <PageDescription>
 
-A dialog is a “conversation” between the system and the user. It is prompted when the sytem needs input from the user or to give the user urgent information concerning their current workflow. There are two types of dialogs, modal and modeless.
+A dialog is a “conversation” between the system and the user. It is prompted when the sytem needs input from the user or to give the user urgent information concerning their current workflow. There are two types of dialogs, modal and non-modal.
 
 </PageDescription>
 
@@ -13,7 +13,7 @@ A dialog is a “conversation” between the system and the user. It is prompted
 
 <AnchorLink>Overview</AnchorLink>
 <AnchorLink>Modal dialogs</AnchorLink>
-<AnchorLink>Modeless dialogs</AnchorLink>
+<AnchorLink>Non-modal  dialogs</AnchorLink>
 <AnchorLink>Designing with dialogs</AnchorLink>
 <AnchorLink>Related components and patterns</AnchorLink>
 <AnchorLink>Accessibility</AnchorLink>
@@ -60,16 +60,16 @@ A dialog is triggered by a user’s action, appears on top of the main page cont
 
 ### Dialog types
 
-There are two types of dialogs, modal and modeless.
+There are two types of dialogs, modal and non-modal.
 
 A _modal_ dialog triggers a state (or mode) that focuses the user’s attention exclusively on one task or piece of relevant information. When a modal dialog is active, the content of the underneath page is obscured and inaccessible until the user completes the task or dismisses the modal.
 
-When a _modeless_ dialog is active the user can continue viewing and interacting with the main page while the dialog is open. Modeless dialogs are commonly used to present non-critical information or optional user tasks.
+When a _non-modal_ dialog is active the user can continue viewing and interacting with the main page while the dialog is open. Non-modal dialogs are commonly used to present non-critical information or optional user tasks.
 
 | Type     | Usage                                                                                        | Context                                                                                                                                                |
 | -------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Modal    | Use to present critical information or request required input needed to complete a workflow. | Focuses the users attention exclusively on one task or piece of information. On-page content is obscured from the user while the modal dialog is open. |
-| Modeless | Use to present non-critical information or optional user tasks.                              | On-page content can be accessed and interacted with while the dialog is still open.                                                                    |
+| Non-modal | Use to present non-critical information or optional user tasks.                              | On-page content can be accessed and interacted with while the dialog is still open.                                                                    |
 
 <Row>
 <Column colLg={8}>
@@ -79,7 +79,7 @@ When a _modeless_ dialog is active the user can continue viewing and interacting
 </Column>
 </Row>
 
-<Caption>Modal dialog (left) and modeless dialog (right)</Caption>
+<Caption>Modal dialog (left) and non-modal dialog (right)</Caption>
 
 ### Best practices
 
@@ -169,14 +169,14 @@ For transactional, progress, and acknowledgement modals:
 - **x**: Clicking the close `x` icon in the upper right will close the modal without submitting any data and return the user to its previous context.
 - **Esc**: Press `ESC` on the keyboard
 
-## Modeless dialogs
+## Non-modal dialogs
 
-Use modeless dialogs to display non-critical information or optional tasks related to the user’s current workflow, like "find and replace." A user still has access to the on-page content while the modeless dialog is open and a response is not required to continue working. However, a modeless dialog does require an action from the user to be dismissed.
+Use non-modal dialogs to display non-critical information or optional tasks related to the user’s current workflow, like "find and replace." A user still has access to the on-page content while the non-modal dialog is open and a response is not required to continue working. However, a non-modal dialog does require an action from the user to be dismissed.
 
 <Row>
 <Column colLg={8}>
 
-![modeless example](images/dialog-modeless.png)
+![non-modal example](images/dialog-modeless.png)
 
 </Column>
 </Row>
@@ -187,9 +187,9 @@ Use modeless dialogs to display non-critical information or optional tasks relat
 
 #### When access to the page is needed
 
-Use when a user needs to compare or refer to information in the main page alongside the modal. users can interact with the modeless content and the on-page content simultaneously.
+Use when a user needs to compare or refer to information in the main page alongside the modal. users can interact with the non-modal content and the on-page content simultaneously.
 
-A modeless dialog window can be moved from its original placement on the screen. This allows the user to access information that might otherwise be hidden by the dialog.
+A non-modal dialog window can be moved from its original placement on the screen. This allows the user to access information that might otherwise be hidden by the dialog.
 
 #### Aid or accelerate a user’s work flow
 
@@ -205,16 +205,16 @@ Use to display additional information that can help inform a user’s decision o
 
 Use for optional or non-critical tasks only. If a user’s response or input is required to progress the workflow, use a modal dialog.
 
-### Modeless variants
+### Non-modal variants
 
 | Name          | Description                                                                                                                 |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Passive       | Presents additional information concerning the user’s current workflow. Contains no actions for the user to take.           |
 | Transactional | Presents the user with optional action/s. Actions can be repeated without closing the dialog. Contains at least one button. |
 
-### Dismissing modeless dialogs
+### Dismissing non-modal dialogs
 
-There are several possible ways to exit a modeless dialog.
+There are several possible ways to exit a non-modal dialog.
 
 - **x**: Clicking the close `x` icon in the upper right will close the modal without submitting any data.
 - **Cancel button**: If a cancel button is used then clicking it will close the modal. Cancel undoes all applied changes.


### PR DESCRIPTION
Opened this up as a discussion around switching from "modeless" to "non-modal" in our dialog pattern.

It seems like there may be conflicting sources of truth so might be helpful to sync up and see which one makes most sense moving forward. Most likely the best sources we have for "non-modal" dialog include:

- [WAI ARIA](https://www.w3.org/TR/wai-aria-practices-1.1/#dialog_modal)
  - They mention non-modal dialogs in their guidance but don't explicitly talk about them
- [MDN](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/dialog_role)
  - "Dialogs can be either non-modal ... or modal"
- [Nielsen](https://www.nngroup.com/articles/modal-nonmodal-dialog/)
  - Uses `nonmodal` as the primary terminology but does mention `modeless`

Links that use modeless
- [Apple](https://developer.apple.com/design/human-interface-guidelines/macos/windows-and-views/dialogs/)
  - They use modeless to apply to windows in macOS
- [Microsoft](https://docs.microsoft.com/en-us/windows/win32/dlgbox/about-dialog-boxes#modeless-dialog-boxes)
  - They use modeless to apply to windows in Windows

It seems from some quick research that modeless may be prevalent on desktop but non-modal is the preference on the Web. Could easily be wrong here, though!


#### Changelog

**New**

**Changed**

- Update `modeless` to `non-modal`

**Removed**
