### PR TITLE
docs: Update pictogram link

### DIFF
--- a/src/pages/guidelines/pictograms/contribute.mdx
+++ b/src/pages/guidelines/pictograms/contribute.mdx
@@ -87,7 +87,7 @@ To be considered production-ready, all pictogram submissions must be delivered i
 
 ## Contribution process
 
-Does your pictogram have potential for other materials at IBM? If so, please consider contributing to the design system. IBM welcomes pictogram contributions in the form of a pull request to our pictogram repository (coming soon). In the mean time to make a pull request, please [submit an issue in the repo](https://github.com/carbon-design-system/carbon-icons/issues/new) with the pictogram attached.
+If you believe your pictogram would be useful for other IBM product teams, please consider contributing back to the system. To contribute, open an issue in the [Carbon repo](https://github.com/carbon-design-system/carbon/issues/new?assignees=&labels=type%3A+enhancement+💡&template=feature-request-or-enhancement.md&title=contrib[picto]: ) with the pictogram attached.
 
 Please note that Carbon contribution is **not required** in order to introduce a new pictogram into your materials. If your pictogram is determined to be broadly useful in Carbon and passes IBM Brand design reviews, then it may also be integrated into the design system.
 

--- a/src/pages/guidelines/pictograms/contribute.mdx
+++ b/src/pages/guidelines/pictograms/contribute.mdx
@@ -87,7 +87,7 @@ To be considered production-ready, all pictogram submissions must be delivered i
 
 ## Contribution process
 
-If you believe your pictogram would be useful for other IBM product teams, please consider contributing back to the system. To contribute, open an issue in the [Carbon repo](https://github.com/carbon-design-system/carbon/issues/new?assignees=&labels=type%3A+enhancement+💡&template=feature-request-or-enhancement.md&title=contrib[picto]: ) with the pictogram attached.
+If you believe your pictogram would be useful for other IBM product teams, please consider contributing back to the system. To contribute, open an issue in the [Carbon repo](https://github.com/carbon-design-system/carbon/issues/new?assignees=&labels=type%3A+enhancement+💡&template=feature-request-or-enhancement.md&title=contrib[picto]:) with the pictogram attached.
 
 Please note that Carbon contribution is **not required** in order to introduce a new pictogram into your materials. If your pictogram is determined to be broadly useful in Carbon and passes IBM Brand design reviews, then it may also be integrated into the design system.
 


### PR DESCRIPTION
Contribution link pointed users to defunct repo. Link now directs users to the correct location.

P.S. This copy needs some love and we should standardize the guidance between the IDL site and the Carbon site.

@joshblack This contribution process is quite similar to the icons contribution process, correct?