### PR TITLE
docs(code-snippet): add a11y code snippet docs

### DIFF
--- a/src/pages/components/code-snippet/accessibility.mdx
+++ b/src/pages/components/code-snippet/accessibility.mdx
@@ -15,18 +15,18 @@ import {
   ListItem,
 } from 'carbon-components-react';
 
+<PageDescription>
+
+The code snippet React Carbon component has been tested against the latest [W3C Web Content Accessibility Guidelines (WCAG) 2.1 Level A and AA success criteria](https://www.w3.org/TR/WCAG21/) and violations have been identified as high priority issues. This document will be updated when these accessibility issues are resolved.
+
+</PageDescription>
+
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>
   <AnchorLink>Resources</AnchorLink>
   <AnchorLink>Accessibility testing</AnchorLink>
 </AnchorLinks>
-
-<PageDescription>
-
-The code snippet React Carbon component has been tested against the latest [W3C Web Content Accessibility Guidelines (WCAG) 2.1 Level A and AA success criteria](https://www.w3.org/TR/WCAG21/) and violations have been identified as high priority issues. This document will be updated when these accessibility issues are resolved.
-
-</PageDescription>
 
 ## Accessibility considerations
 

--- a/src/pages/components/code-snippet/accessibility.mdx
+++ b/src/pages/components/code-snippet/accessibility.mdx
@@ -1,0 +1,80 @@
+---
+title: Code snippet
+description: Code snippets are small blocks of reusable code that can be inserted in a code file.
+tabs: ['Code', 'Usage', 'Style', 'Accessibility']
+---
+
+import {
+  StructuredListWrapper,
+  StructuredListHead,
+  StructuredListBody,
+  StructuredListRow,
+  StructuredListInput,
+  StructuredListCell,
+  OrderedList,
+  ListItem,
+} from 'carbon-components-react';
+
+<AnchorLinks>
+  <AnchorLink>How it works</AnchorLink>
+  <AnchorLink>Accessibility considerations</AnchorLink>
+  <AnchorLink>Resources</AnchorLink>
+  <AnchorLink>Accessibility testing</AnchorLink>
+</AnchorLinks>
+
+<PageDescription>
+
+The code snippet React Carbon component has been tested against the latest [W3C Web Content Accessibility Guidelines (WCAG) 2.1 Level A and AA success criteria](https://www.w3.org/TR/WCAG21/) and violations have been identified as high priority issues. This document will be updated when these accessibility issues are resolved.
+
+</PageDescription>
+
+## Accessibility considerations
+
+1. The code snippet copy button can be activated using both the `Space` or `Enter` key.
+2. The code snippet copy button label accurately describes what the button does.
+3. After the button is activated the focus remains on the button since there is no change in context.
+
+## Resources
+
+- [W3C WAI-ARIA Authoring Practices Button Design Pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#buttonn) covers the usage of ARIA names, state and roles, as well as the expected keyboard interactions.
+- [IBM Accessibility Checklist Checkpoint:](https://www.ibm.com/able/guidelines/ci162/accessibility_checklist.html)
+  - [2.4.7 Focus Visible](https://www.ibm.com/able/guidelines/ci162/focus_visible.html) (WCAG Success Criteria [2.4.7](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible))
+  - [3.2.2 On Input](https://www.ibm.com/able/guidelines/ci162/on_input.html) (WCAG Success Criteria [3.2.2](https://www.w3.org/TR/2016/NOTE-UNDERSTANDING-WCAG20-20161007/consistent-behavior-unpredictable-change.html))
+
+## Accessibility testing
+
+Automated, manual and screen reader accessibility verification test has been performed on the code snippet React Carbon component. [WCAG 2.1 Level A and AA success criteria](https://www.w3.org/TR/WCAG21/) issues have been identified and the list of open accessibility violations is available in the Carbon Component GitHub repository.
+
+### Automated test
+
+<Row>
+  <Column noGutterSm>
+    <StructuredListWrapper>
+      <StructuredListHead>
+        <StructuredListRow head>
+          <StructuredListCell head>
+            Automated test environment
+          </StructuredListCell>
+          <StructuredListCell head>Results</StructuredListCell>
+        </StructuredListRow>
+      </StructuredListHead>
+      <StructuredListBody>
+        <StructuredListRow>
+          <StructuredListCell>
+            - macOS Mojave version 10.14.6 with VoiceOver
+            <br />
+            - Chrome version 77.0.3865.90
+            <br />
+            - Dynamic Assessment Plugin (DAP) version 1.8.0.0 - IBM
+            Accessibility WCAG 2.1 Sept. 2019 Ruleset
+            <br />- Carbon React version 7.7.1
+          </StructuredListCell>
+          <StructuredListCell>
+            <strong>DAP test:</strong>
+            <br />- Violations
+          </StructuredListCell>
+        </StructuredListRow>
+      </StructuredListBody>
+    </StructuredListWrapper>
+  </Column>
+</Row>

--- a/src/pages/components/code-snippet/code.mdx
+++ b/src/pages/components/code-snippet/code.mdx
@@ -1,7 +1,7 @@
 ---
 title: Code snippet
 description: Code snippets are small blocks of reusable code that can be inserted in a code file.
-tabs: ['Code', 'Usage', 'Style']
+tabs: ['Code', 'Usage', 'Style', 'Accessibility']
 ---
 
 <ComponentDemo

--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -1,7 +1,7 @@
 ---
 title: Code snippet
 description: Code snippets are small blocks of reusable code that can be inserted in a code file.
-tabs: ['Code', 'Usage', 'Style']
+tabs: ['Code', 'Usage', 'Style', 'Accessibility']
 ---
 
 ## Color

--- a/src/pages/components/code-snippet/usage.mdx
+++ b/src/pages/components/code-snippet/usage.mdx
@@ -1,7 +1,7 @@
 ---
 title: Code snippet
 description: Code snippets are small blocks of reusable code that can be inserted in a code file.
-tabs: ['Code', 'Usage', 'Style']
+tabs: ['Code', 'Usage', 'Style', 'Accessibility']
 ---
 
 ## General guidance


### PR DESCRIPTION
Closes #491 

Adds last a11y documentation to the website. Code snippet

Make sure content matches https://pages.github.ibm.com/IBMa/Carbon_Integration/Doc/CodeSnippet-doc.html