### PR TITLE
chore(tutorial): update install list to include peer dependencies

### DIFF
--- a/src/pages/tutorial/react/step-1.mdx
+++ b/src/pages/tutorial/react/step-1.mdx
@@ -123,7 +123,7 @@ Even though we installed existing dependencies, we've yet to install the Carbon 
 Stop your development server with `CTRL-C` and install Carbon dependencies with:
 
 ```bash
-$ yarn add carbon-components carbon-components-react @carbon/icons-react
+$ yarn add carbon-components carbon-components-react carbon-icons @carbon/icons-react
 ```
 
 ## Install and build Sass


### PR DESCRIPTION
The tutorial doesn't specify `carbon-icons` in the install command. This should be added as it is a peer dependency of carbon.

#### Changelog

**New**

**Changed**

- Add `carbon-icons` to the install list in step 1

**Removed**
