### PR TITLE
docs: Modify 'About Carbon' page

### DIFF
--- a/src/pages/get-started/about-carbon.mdx
+++ b/src/pages/get-started/about-carbon.mdx
@@ -63,7 +63,7 @@ The Carbon team encourages adoption through guidance and training, community dev
 - [Angular](https://angular.carbondesignsystem.com/): Community maintained
 - [Vue](https://github.com/carbon-design-system/carbon-components-vue): Community maintained
 
-**Design patterns are harvested from products built with Carbon.** These become part of the design system. Teams can can use these well-defined patterns in their work and contribute patterns back to the system.
+**Design patterns are harvested from products built with Carbon.** These become part of the design system. Teams can use these well-defined patterns in their work and contribute patterns back to the system.
 
 ### Contribution acceptance
 


### PR DESCRIPTION


Closes #

I found the wrong expression.
The word `can` is written twice in a row.

#### Changelog

**New**

-

**Changed**

-

**Removed**

- The word `can`
