### PR TITLE
docs: remove hyphenation from multiselect

### DIFF
--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -12,7 +12,7 @@ The basic data table is shipped with a base style, which includes:
 
 - Borders
 - No zebra striping, row dividers instead.
-- No Pagination, search, table toolbar, or multi-select
+- No Pagination, search, table toolbar, or multiselect
 
 <div className="image--fixed">
 
@@ -76,7 +76,7 @@ The table toolbar is reserved for global table actions such as table settings, c
 
 <Caption>Table toolbar: table settings</Caption>
 
-### Multi-select / batch action
+### Multiselect / batch action
 
 Batch actions are functions that may be performed on multiple items within a table. Once the user selects at least one row from the table, the **batch action bar** appears at the top of the table, presenting the user with actions they can take. To exit or escape "batch action mode," the user can cancel out or deselect the items.
 


### PR DESCRIPTION
Docs clean up to remove unnecessary hyphenation. 