### PR TITLE
chore: disable source-maps in production

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,6 @@
 const path = require('path');
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ actions, getConfig }) => {
   // Allows importing html files for component code examples
   actions.setWebpackConfig({
     module: {
@@ -26,4 +26,11 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       },
     },
   });
+
+  // Disable sourcemaps in production
+  if (getConfig().mode === 'production') {
+    actions.setWebpackConfig({
+      devtool: false,
+    });
+  }
 };


### PR DESCRIPTION
Gatsby generates source-maps even production. This is an issue with our dynamic icon strategy which generates hundreds of javascript files.

This removes source-maps in when in production.