### PR TITLE
Small typo in the class names

### DIFF
--- a/src/pages/guidelines/2x-grid/implementation.mdx
+++ b/src/pages/guidelines/2x-grid/implementation.mdx
@@ -838,7 +838,7 @@ The most commonly used product shell is the flexible panel. The collapsed flexib
 
 ### Offsetting
 
-Use offset classes to offset content by a given column span. These classes increase the left margin of a column by \* columns. For example, `bx—offset-lg-8` moves `bx—col-lg-8` over eight columns.
+Use offset classes to offset content by a given column span. These classes increase the left margin of a column by \* columns. For example, `bx--offset-lg-8` moves `bx--col-lg-8` over eight columns.
 
 <Row>
   <Column noGutterSm>


### PR DESCRIPTION
Closes #

In the grid guidelines, the Offseting description has a typo in the class names.

#### Changelog

**New**

Use offset classes to offset content by a given column span. These classes increase the left margin of a column by * columns. For example, `bx--offset-lg-8` moves `bx--col-lg-8` over eight columns. 

**Changed**

Use offset classes to offset content by a given column span. These classes increase the left margin of a column by * columns. For example, `bx—offset-lg-8` moves `bx—col-lg-8` over eight columns.
