### PR TITLE
Docs: Accordion anchor link typo

### DIFF
--- a/src/pages/components/accordion/usage.mdx
+++ b/src/pages/components/accordion/usage.mdx
@@ -15,7 +15,7 @@ An accordion is a vertically stacked list of headers that reveal or hide associa
 <AnchorLink>Overview</AnchorLink>
 <AnchorLink>Formatting</AnchorLink>
 <AnchorLink>Content</AnchorLink>
-<AnchorLink>Behavior</AnchorLink>
+<AnchorLink>Behaviors</AnchorLink>
 <AnchorLink>Related</AnchorLink>
 <AnchorLink>References</AnchorLink>
 <AnchorLink>Feedback</AnchorLink>


### PR DESCRIPTION
Fixing a small typo in the behavior anchor link.