### PR TITLE
fix(links): updated sketch links

### DIFF
--- a/src/pages/get-started/design/sketch.mdx
+++ b/src/pages/get-started/design/sketch.mdx
@@ -34,7 +34,7 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
     <ResourceCard
       onClick={() => fathom("trackGoal", "P0OEN9TS", 0)}
       subTitle="Get the White theme"
-      href="sketch://add-library/cloud/JaVzz"
+      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -43,7 +43,7 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
     <ResourceCard
       onClick={() => fathom("trackGoal", "T7D1HJ3L", 0)}
       subTitle="Get the Gray 10 theme"
-      href="sketch://add-library/cloud/Onwv2"
+      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -52,7 +52,7 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
     <ResourceCard
       onClick={() => fathom("trackGoal", "LYFJTPDE", 0)}
       subTitle="Get the Gray 90 theme"
-      href="sketch://add-library/cloud/eo37p"
+      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -61,7 +61,7 @@ There are [four Carbon themes](/guidelines/color/overview#themes), two light (Wh
     <ResourceCard
       onClick={() => fathom("trackGoal", "3XH0SIBJ", 0)}
       subTitle="Get the Gray 100 theme"
-      href="sketch://add-library/cloud/d13Ll"
+      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -113,7 +113,7 @@ Visit the [Sketch library](https://sketch.cloud/s/ngV7z) page and choose `Downlo
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download the IBM Grid template"
-      href="https://sketch.cloud/s/ngV7z"
+      href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYwOTUzLCJpYXQiOjE1ODg5NTczNTMsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG9pcWRqMWZqZzBqM244ZWhyazUxIiwibmJmIjoxNTg4OTU3MzUzfQ.o-TfVs6DWYBx0V2U69cPTUafPqE8U4Oj2K7lTSKi96A"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -121,7 +121,7 @@ Visit the [Sketch library](https://sketch.cloud/s/ngV7z) page and choose `Downlo
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download the UI Shell template"
-      href="https://sketch.cloud/s/EjVmA"
+      href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYxMTMwLCJpYXQiOjE1ODg5NTc1MzAsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG90NG84YTZtM2ZxaG5nZDBzNjU1IiwibmJmIjoxNTg4OTU3NTMwfQ.kD4u_gOx15zGMpHiqcM5eekPzzKKa6nVZrrqB9yW02Y"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -117,7 +117,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="White theme"
-      href="sketch://add-library/cloud/JaVzz"
+      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1"
       actionIcon="download"
     >
       <MdxIcon name="sketch" />
@@ -126,7 +126,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Gray 10 theme"
-      href="sketch://add-library/cloud/Onwv2"
+      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f"
       actionIcon="download"
     >
       <MdxIcon name="sketch" />
@@ -135,7 +135,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Gray 90 theme"
-      href="sketch://add-library/cloud/eo37p"
+      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc"
       actionIcon="download"
     >
       <MdxIcon name="sketch" />
@@ -144,7 +144,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Gray 100 theme"
-      href="sketch://add-library/cloud/d13Ll"
+      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477"
       actionIcon="download"
     >
       <MdxIcon name="sketch" />
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="https://sketch.cloud/s/ngV7z"
+    href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYwOTUzLCJpYXQiOjE1ODg5NTczNTMsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG9pcWRqMWZqZzBqM244ZWhyazUxIiwibmJmIjoxNTg4OTU3MzUzfQ.o-TfVs6DWYBx0V2U69cPTUafPqE8U4Oj2K7lTSKi96A"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="https://sketch.cloud/s/EjVmA"
+    href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYxMTMwLCJpYXQiOjE1ODg5NTc1MzAsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG90NG84YTZtM2ZxaG5nZDBzNjU1IiwibmJmIjoxNTg4OTU3NTMwfQ.kD4u_gOx15zGMpHiqcM5eekPzzKKa6nVZrrqB9yW02Y"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>


### PR DESCRIPTION
- Update the links of the Sketch kits to new URLs in regards to: https://updates.sketch.cloud/we-re-changing-cloud-document-urls-143867
   - Updated on Getting started/sketch and Resource pages
- Also made the UI Shell and Grid templates direct downloads.