### PR TITLE
fix(links): update links for ui shell and grid

### DIFF
--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -197,7 +197,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <ResourceCard
     subTitle="IBM Grid template"
     href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
-    actionIcon="download">
+    actionIcon="launch">
 
 <MdxIcon name="sketch" />
 
@@ -207,7 +207,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
   <ResourceCard
     subTitle="UI Shell template"
     href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
-    actionIcon="download">
+    actionIcon="launch">
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYwOTUzLCJpYXQiOjE1ODg5NTczNTMsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG9pcWRqMWZqZzBqM244ZWhyazUxIiwibmJmIjoxNTg4OTU3MzUzfQ.o-TfVs6DWYBx0V2U69cPTUafPqE8U4Oj2K7lTSKi96A"
+    href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYxMTMwLCJpYXQiOjE1ODg5NTc1MzAsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG90NG84YTZtM2ZxaG5nZDBzNjU1IiwibmJmIjoxNTg4OTU3NTMwfQ.kD4u_gOx15zGMpHiqcM5eekPzzKKa6nVZrrqB9yW02Y"
+    href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="sketch://add-library/cloud/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
+    href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="sketch://add-library/cloud/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
+    href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg5MjQyNzM1LCJpYXQiOjE1ODkyMzkxMzUsImlzcyI6Ikpva2VuIiwianRpIjoiMm83MXA0bTZiOG41NWxxZTE0YTNtNW8xIiwibmJmIjoxNTg5MjM5MTM1fQ.Ac4uoULF2YG7rrhLbC9M6PT0jBnxWwRIYnHB7tZMThU"
+    href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg5MjQyNTI2LCJpYXQiOjE1ODkyMzg5MjYsImlzcyI6Ikpva2VuIiwianRpIjoiMm83MW9vaGlpOTNtc2FpcXRrNzBzb3QyIiwibmJmIjoxNTg5MjM4OTI2fQ.hgh48P8WxneZJHOuWITc3lEI0T4ez1qCknioMS2x0rs"
+    href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
+    href="sketch://add-library/cloud/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
+    href="sketch://add-library/cloud/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/resources/index.mdx
+++ b/src/pages/resources/index.mdx
@@ -196,7 +196,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="IBM Grid template"
-    href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
+    href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg5MjQyNzM1LCJpYXQiOjE1ODkyMzkxMzUsImlzcyI6Ikpva2VuIiwianRpIjoiMm83MXA0bTZiOG41NWxxZTE0YTNtNW8xIiwibmJmIjoxNTg5MjM5MTM1fQ.Ac4uoULF2YG7rrhLbC9M6PT0jBnxWwRIYnHB7tZMThU"
     actionIcon="download">
 
 <MdxIcon name="sketch" />
@@ -206,7 +206,7 @@ To use Sketch libraries you must have the **most recent version** of [Sketch](ht
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="UI Shell template"
-    href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
+    href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg5MjQyNTI2LCJpYXQiOjE1ODkyMzg5MjYsImlzcyI6Ikpva2VuIiwianRpIjoiMm83MW9vaGlpOTNtc2FpcXRrNzBzb3QyIiwibmJmIjoxNTg5MjM4OTI2fQ.hgh48P8WxneZJHOuWITc3lEI0T4ez1qCknioMS2x0rs"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>


### PR DESCRIPTION
Update links for resource tiles on the Resources page:
-UI Shell template
-IBM Grid template

- Was originally getting this error message:
`{"message":"You don't have permission to download this file","code":403,"status":"Forbidden","errors":[]}`

