### PR TITLE
fix(links): update links on get-started page

### DIFF
--- a/src/pages/get-started/design/sketch.mdx
+++ b/src/pages/get-started/design/sketch.mdx
@@ -113,7 +113,7 @@ Visit the [Sketch library](https://sketch.cloud/s/ngV7z) page and choose `Downlo
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download the IBM Grid template"
-      href="https://client.sketch.cloud/v1/documents/17f9be17-44ed-4553-be2b-350043b5f1b2/download/IBM+Grid+template.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjE3ZjliZTE3LTQ0ZWQtNDU1My1iZTJiLTM1MDA0M2I1ZjFiMiIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYwOTUzLCJpYXQiOjE1ODg5NTczNTMsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG9pcWRqMWZqZzBqM244ZWhyazUxIiwibmJmIjoxNTg4OTU3MzUzfQ.o-TfVs6DWYBx0V2U69cPTUafPqE8U4Oj2K7lTSKi96A"
+      href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -121,7 +121,7 @@ Visit the [Sketch library](https://sketch.cloud/s/ngV7z) page and choose `Downlo
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Download the UI Shell template"
-      href="https://client.sketch.cloud/v1/documents/6f9f95b5-eebf-4a66-a4ad-e84c42f88c3c/download/UI+Shell+templates.sketch?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZGVudCI6IjZmOWY5NWI1LWVlYmYtNGE2Ni1hNGFkLWU4NGM0MmY4OGMzYyIsImF1ZCI6Ikpva2VuIiwiZXhwIjoxNTg4OTYxMTMwLCJpYXQiOjE1ODg5NTc1MzAsImlzcyI6Ikpva2VuIiwianRpIjoiMm82aG90NG84YTZtM2ZxaG5nZDBzNjU1IiwibmJmIjoxNTg4OTU3NTMwfQ.kD4u_gOx15zGMpHiqcM5eekPzzKKa6nVZrrqB9yW02Y"
+      href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     >
       <MdxIcon name="sketch" />
     </ResourceCard>


### PR DESCRIPTION
Update links for resource tiles on the Getting started (designers) page for sketch:
-UI Shell template
-IBM Grid template

Related to: https://github.com/carbon-design-system/carbon-website/pull/1182