### PR TITLE
fix: temp workaround to display pictograms

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -22,3 +22,8 @@
 @import "src/components/OverviewCard/overview-card.scss";
 @import "src/components/OverviewCard/overview-card-group.scss";
 @import "src/pages/data-visualization/data-visualization.scss";
+
+// temp workaround to show pictograms. should be removed with next update of Carbon
+[class*="SvgLibrary-module--svg-page"] svg[width="35%"] {
+  stroke: currentColor;
+}


### PR DESCRIPTION
Temporary ugly fix to get pictograms displaying until patch release from Carbon is ready. 