### PR TITLE
fix(react-tutorial-step-1): update import path in react tutorial

### DIFF
--- a/src/pages/tutorial/react/step-1.mdx
+++ b/src/pages/tutorial/react/step-1.mdx
@@ -256,7 +256,7 @@ import {
   HeaderGlobalBar,
   HeaderGlobalAction,
   SkipToContent,
-} from "carbon-components-react/es/components/UIShell";
+} from "carbon-components-react/lib/components/UIShell";
 
 const TutorialHeader = () => (
   <Header aria-label="Carbon Tutorial">
@@ -332,7 +332,7 @@ Next we'll render our UI Shell by importing our `TutorialHeader` component and `
 import React, { Component } from "react";
 import "./app.scss";
 import { Button } from "carbon-components-react";
-import { Content } from "carbon-components-react/es/components/UIShell";
+import { Content } from "carbon-components-react/lib/components/UIShell";
 import TutorialHeader from "./components/TutorialHeader";
 ```
 


### PR DESCRIPTION
In step 1 of the tutorial, we are pulling the UI Shell components from the `es` directory, which is causing issues when implementing tests that will help automate the tutorial review process. THis changes the step 1 instructions to match the import path found in [later steps ](https://github.com/carbon-design-system/carbon-tutorial/blob/e7dcec44bfe5f77a6944793af0b79508b39b0395/src/components/TutorialHeader/TutorialHeader.js#L10)

#### Changelog

**Changed**

- Changed import path in step 1

