### PR TITLE
fix(tutorial): pin dependencies to match later steps

### DIFF
--- a/src/pages/tutorial/react/step-3.mdx
+++ b/src/pages/tutorial/react/step-3.mdx
@@ -86,7 +86,7 @@ We'll need to install three new dependencies to incorporate Apollo into our appl
 Install them with the command:
 
 ```bash
-$ yarn add apollo-boost graphql react-apollo
+$ yarn add apollo-boost@0.4.2 graphql@14.3.1 react-apollo@2.5.6
 ```
 
 ## Create access token


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon-tutorial/pull/4611

This just pins the dependencies that are installed in Step 3 to the versions that are used in Step 4.