### PR TITLE
chore(tutorial): pin more dependencies

### DIFF
--- a/src/pages/tutorial/react/step-1.mdx
+++ b/src/pages/tutorial/react/step-1.mdx
@@ -123,7 +123,7 @@ Even though we installed existing dependencies, we've yet to install the Carbon 
 Stop your development server with `CTRL-C` and install Carbon dependencies with:
 
 ```bash
-$ yarn add carbon-components carbon-components-react carbon-icons @carbon/icons-react
+$ yarn add carbon-components@10.3.0 carbon-components-react@7.3.0 @carbon/icons-react@10.3.0
 ```
 
 ## Install and build Sass
@@ -131,7 +131,7 @@ $ yarn add carbon-components carbon-components-react carbon-icons @carbon/icons-
 We need to run a Sass build as the Carbon styles are authored in Sass, so run the following command to install `node-sass` as a dependency.
 
 ```bash
-$ yarn add node-sass
+$ yarn add node-sass@4.12.0
 ```
 
 To avoid having to add the `~` prefix when importing SCSS files from `node_modules`, create a `.env` file at the project root that contains:
@@ -446,7 +446,7 @@ Awesome! We've just created our content pages. Next thing we need to do is rende
 We've updated our app to render our header, but now we need to add routing functionality. To do this we need to install `react-router-dom`. Go ahead and stop your development server (with `CTRL-C`) and then:
 
 ```bash
-$ yarn add react-router-dom
+$ yarn add react-router-dom@5.0.0
 $ yarn start
 ```
 


### PR DESCRIPTION
Refs https://github.com/carbon-design-system/carbon-website/pull/1228

Another PR that pins dependencies that are added in step 1 to the version that is used in Step 2. This will hopefully prevent any errors caused by changes upstream in Carbon.

