### PR TITLE
fix(tutorial): update cf login command on step 5

### DIFF
--- a/src/pages/tutorial/react/step-5.mdx
+++ b/src/pages/tutorial/react/step-5.mdx
@@ -189,12 +189,16 @@ In our case we can ignore everything except the `build/` directory and `Staticfi
 Login to IBM Cloud with:
 
 ```bash
-$ cf login -a https://api.ng.bluemix.net --sso
+$ cf login -a https://api.us-south.cf.cloud.ibm.com --sso
 ```
 
 Deploy app using the `cf push` command. Since `manifest.yml` is in our root directory, we don't need to specify it in the push command. But, if you have multiple manifest files that target different environments, it's good practice to specify the file.
 
-_Note: To successfully deploy, you might need to update the region code (e.g. `api.[REGION].bluemix.net`). [Learn more.](https://developer.ibm.com/answers/answers/166990/view.html)_
+<InlineNotification>
+
+**Note:** This step assumes your spaces are in the US South region. To successfully deploy, you might need to update the region code (e.g. `api.[REGION].cf.cloud.ibm.com`) to the region where your spaces were created, or create a space in the US South region. [Learn more.](https://cloud.ibm.com/docs/overview?topic=overview-whatsnew&origin_team=T02M79KSB#new-cloud-foundry-api-endpoints)
+
+</InlineNotification>
 
 ```bash
 $ cf push -f manifest.yml


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-tutorial/issues/1790

Step 5 in the tutorial is using a deprecated command which can cause confusion for users following the tutorial, especially if they do not have spaces created in the US SOUTH region. This PR updates the command, as well as give more info on why they may be seeing errors. 

#### Changelog

**New**

- Used `InlineNotification` component to display tutorial note

**Changed**

- Command to login to IBM Cloud, as well as a note on regions

