### PR TITLE
Fix example Dropdown data object

### DIFF
--- a/src/pages/components/dropdown/code.mdx
+++ b/src/pages/components/dropdown/code.mdx
@@ -124,19 +124,19 @@ import items from "../../../data/components/dropdown.js";
 const items = [
   {
     id: "option-1",
-    text: "Option 1",
+    label: "Option 1",
   },
   {
     id: "option-2",
-    text: "Option 2",
+    label: "Option 2",
   },
   {
     id: "option-3",
-    text: "Option 3",
+    label: "Option 3",
   },
   {
     id: "option-4",
-    text: "Option 4",
+    label: "Option 4",
   },
 ];
 ```


### PR DESCRIPTION
When the <Dropdown> component is given an `items` array with each object having a `text` field, no text shows up in the dropdown items—just blank options.

Changing each object in the `items` array to have a `label` field makes them show up in the dropdown. I'm not sure why, or where to even look for further documentation on this, and changing it to `label` was just a wild guess that ended up working.

Example here: https://codesandbox.io/s/quirky-morse-4z9hx

#### Changelog

**Changed**

- Updated structure of the example `items` array passed into the `<Dropdown>` in the example code to make the example work.