### PR TITLE
Update deploy app command in Step-5

### DIFF
--- a/src/pages/tutorial/angular/step-5.mdx
+++ b/src/pages/tutorial/angular/step-5.mdx
@@ -175,7 +175,7 @@ You can speed up deploys by decreasing the files uploaded through cloud foundry.
 Login to IBM Cloud with:
 
 ```bash
-$ cf login -a https://api.ng.bluemix.net -sso
+$ cf login -a https://api.ng.bluemix.net -sso target -s dev
 ```
 
 Deploy app using the `cf push` command. Since `manifest.yml` is in our root directory, we don't need to specify it in the push command. But, if you have multiple manifest files that target different environments, it's good practice to specify the file.


### PR DESCRIPTION
Updated the command
- from: `$ cf login -a https://api.ng.bluemix.net -sso`
- to: `$cf login -a https://api.ng.bluemix.net -sso target -s dev`

Reference: https://github.com/carbon-design-system/carbon-tutorial-angular/issues/220

Closes #220

The command on Step 5 - Deploy to IBM Cloud - cf fails.

#### Changelog

**New**

- None

**Changed**

Deploy App command
- from: `$ cf login -a https://api.ng.bluemix.net -sso`
- to: `$cf login -a https://api.ng.bluemix.net -sso target -s dev`

**Removed**

- None
