### PR TITLE
fix(overview-card): update markup to handle min-height change for tag

### DIFF
--- a/src/components/OverviewCard/OverviewCard.js
+++ b/src/components/OverviewCard/OverviewCard.js
@@ -25,8 +25,10 @@ export default class OverviewCard extends React.Component {
 
     const cardContent = (
       <>
-        <h4 className="overview-card__title">{title}</h4>
-        {tag && <Tag type="teal">{tag}</Tag>}
+        <div className="overview-card__info">
+          <h4 className="overview-card__title">{title}</h4>
+          {tag && <Tag type="teal">{tag}</Tag>}
+        </div>
         <div className="overview-card__img">{children}</div>
       </>
     );

--- a/src/components/OverviewCard/overview-card.scss
+++ b/src/components/OverviewCard/overview-card.scss
@@ -21,6 +21,13 @@
   }
 }
 
+.overview-card__info {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: fit-content;
+}
+
 .overview-card__title {
   @include carbon--type-style("caption-01");
   text-decoration: none;


### PR DESCRIPTION
Closes #1294

#### Changelog

**New**

**Changed**

- Updated `OverviewCard` and associated styles to handle change from `height` to `min-height` upstream on tag

**Removed**
