### PR TITLE
fix: 1307-BLM-banner-typeset-slider-bug

### DIFF
--- a/src/components/TypesetStyle/typeset-style.scss
+++ b/src/components/TypesetStyle/typeset-style.scss
@@ -228,7 +228,7 @@ $prefix: "bx";
 }
 
 .#{$prefix}--typeset-style-title-shiv {
-  padding-top: $spacing-05;
+  padding-top: $spacing-09;
   background-color: $carbon--gray-10;
   position: relative;
 }


### PR DESCRIPTION
Closes #1307 

This fixes the Typetester Slider bug that was introduced by the BLM banner 

#### Changelog

Navigate to: https://www.carbondesignsystem.com/guidelines/typography/expressive
You should now see a fixed Typetester as seen below
 
<img width="1679" alt="Screen Shot 2020-06-18 at 3 35 05 PM" src="https://user-images.githubusercontent.com/32720851/85078658-c1df0880-b179-11ea-9743-eeac033e8749.png">
