### PR TITLE
chore: pre-process unnecessary data from svg metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ public
 # Vscode settings
 .vscode/settings.json
 
-# Build timestamp
-build-timestamp
+# Icon metadata
+metadata.json
 
 .now

--- a/plugins/gatsby-theme-carbon-svgs/components/IconLibrary/IconLibrary.js
+++ b/plugins/gatsby-theme-carbon-svgs/components/IconLibrary/IconLibrary.js
@@ -7,7 +7,7 @@ import loadable from '@loadable/component';
 import {
   icons as iconMetaData,
   categories as iconCategoryMetadata,
-} from '@carbon/icons/metadata.json';
+} from './metadata.json';
 import { svgPage, svgLibrary } from '../shared/SvgLibrary.module.scss';
 
 import FilterRow from '../shared/FilterRow';

--- a/plugins/gatsby-theme-carbon-svgs/components/PictogramLibrary/PictogramLibrary.js
+++ b/plugins/gatsby-theme-carbon-svgs/components/PictogramLibrary/PictogramLibrary.js
@@ -7,7 +7,7 @@ import { groupBy, debounce } from 'lodash-es';
 import {
   icons as pictogramMetaData,
   categories as pictogramCatagoryMetadata,
-} from '@carbon/pictograms/metadata.json';
+} from './metadata.json';
 
 import FilterRow from '../shared/FilterRow';
 import { svgPage, svgLibrary } from '../shared/SvgLibrary.module.scss';

--- a/plugins/gatsby-theme-carbon-svgs/gatsby-node.js
+++ b/plugins/gatsby-theme-carbon-svgs/gatsby-node.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+  icons: iconData,
+  categories: iconCategoryData,
+} = require('@carbon/icons/metadata.json');
+
+const {
+  icons: pictogramData,
+  categories: pictogramCategoryData,
+} = require('@carbon/pictograms/metadata.json');
+
+exports.onPreBootstrap = async ({ store, reporter }) => {
+  // eslint-disable-next-line no-unused-vars
+  const removeUnusedData = ({ output, assets, ...metadata }) => metadata;
+  const { program } = store.getState();
+  const outDir = path.join(
+    program.directory,
+    'plugins/gatsby-theme-carbon-svgs'
+  );
+
+  reporter.log(`Processing SVG metadata`);
+
+  const essentialIconData = iconData.map(removeUnusedData);
+  const essentialPictogramData = pictogramData.map(removeUnusedData);
+
+  fs.writeFileSync(
+    path.join(outDir, 'components/IconLibrary/metadata.json'),
+    JSON.stringify({ icons: essentialIconData, categories: iconCategoryData })
+  );
+
+  fs.writeFileSync(
+    path.join(outDir, 'components/PictogramLibrary/metadata.json'),
+    JSON.stringify({
+      icons: essentialPictogramData,
+      categories: pictogramCategoryData,
+    })
+  );
+};


### PR DESCRIPTION
**note:** putting this on hold for a sec for https://github.com/carbon-design-system/carbon-website/pull/1329

This adds a step to our site build that removes the unused data from our SVG library metadata. It creates temporary `metadata.json` files for icons and pictograms which contain only the necessary data required for the icon/pictogram library pages. We’re able slash most of that 1.2mb of json.

By doing this, we avoid loading most of the metadata and shave 1.6s off the time to interactive.

## Before
<img width="767" alt="Screen Shot 2020-06-25 at 8 11 53 PM" src="https://user-images.githubusercontent.com/4078018/85810300-38eb4280-b720-11ea-9033-05fde56efe94.png">

## After
<img width="752" alt="Screen Shot 2020-06-25 at 8 11 44 PM" src="https://user-images.githubusercontent.com/4078018/85810306-3f79ba00-b720-11ea-92b8-140f342233ee.png">

