### PR TITLE
Fix scss import path

### DIFF
--- a/src/pages/tutorial/react/step-1.mdx
+++ b/src/pages/tutorial/react/step-1.mdx
@@ -393,8 +393,8 @@ Next, we'll import our content Sass files in `app.scss`, like so:
 
 ```scss path=src/app.scss
 @import "./components/TutorialHeader/tutorial-header.scss";
-@import "./content/LandingPage/landing-page.scss";
-@import "./content/RepoPage/repo-page.scss";
+@import "./content/LandingPage/_landing-page.scss";
+@import "./content/RepoPage/_repo-page.scss";
 ```
 
 ### Import and export content pages


### PR DESCRIPTION
As we have to create a `_landing-page.scss` and a `_repo-page.scss`, the imports must match these files.

https://www.carbondesignsystem.com/tutorial/react/step-1#create-pages
![image](https://user-images.githubusercontent.com/15236942/86817562-91450d00-c05b-11ea-9f88-b80d1779f6b3.png)
![image](https://user-images.githubusercontent.com/15236942/86817859-fef13900-c05b-11ea-956c-7f56bf88fa7d.png)


#### Changelog
- Fix import path of landing and repo pages in step-1

**Changed**

- Import path of landing and repo pages in step-1


