### PR TITLE
fix(tokens): update text-02 color token value

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -274,12 +274,12 @@ const colorTokens = {
       role: ['Secondary text', 'Input labels'],
       value: {
         white: {
-          name: 'Gray 80',
-          hex: '#393939',
+          name: 'Gray 70',
+          hex: '#525252',
         },
         g10: {
-          name: 'Gray 80',
-          hex: '#393939',
+          name: 'Gray 70',
+          hex: '#525252',
         },
         g90: {
           name: 'Gray 30',


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/1374

`text-02` color token was updated when we made the [helper text changes](https://github.com/carbon-design-system/carbon/pull/5867/files#diff-b3c4e528475647f2fd1278cac41fe964) a few months ago, but the token was not updated on the site

#### Changelog

**Changed**

- `text-02` is now `Gray70` and not `Gray80`
