### PR TITLE
docs(colors): add two tokens to color usage tab

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -246,7 +246,7 @@ const colorTokens = {
     },
     '$decorative-01': {
       role: [
-        '"Light" variant elements',
+        '“Light” variant elements',
       ],
       value: {
         white: {
@@ -926,7 +926,7 @@ const colorTokens = {
       },
     },
     '$hover-ui-light': {
-      role: ['$“Light” variant hover'],
+      role: ['“Light” variant hover'],
       value: {
         white: {
           name: 'Gray 10 hover',

--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -244,6 +244,29 @@ const colorTokens = {
         },
       },
     },
+    '$decorative-01': {
+      role: [
+        '"Light" variant elements',
+      ],
+      value: {
+        white: {
+          name: 'Gray 20',
+          hex: '#e0e0e0',
+        },
+        g10: {
+          name: 'Gray 20',
+          hex: '#e0e0e0',
+        },
+        g90: {
+          name: 'Gray 60',
+          hex: '#6f6f6f',
+        },
+        g100: {
+          name: 'Gray 70',
+          hex: '#525252',
+        },
+      },
+    },
     '$text-01': {
       role: [
         'Primary text',
@@ -899,6 +922,27 @@ const colorTokens = {
         g100: {
           name: 'Gray 90 hover',
           hex: '#353535',
+        },
+      },
+    },
+    '$hover-ui-light': {
+      role: ['$“Light” variant hover'],
+      value: {
+        white: {
+          name: 'Gray 10 hover',
+          hex: '#e5e5e5',
+        },
+        g10: {
+          name: 'Gray 10 hover',
+          hex: '#e5e5e5',
+        },
+        g90: {
+          name: 'Gray 60',
+          hex: '#6f6f6f',
+        },
+        g100: {
+          name: 'Gray 70',
+          hex: '#525252',
         },
       },
     },


### PR DESCRIPTION
Adding `decorative-01` and `hover-ui-light` to the color usage tab table.

Related:
https://github.com/carbon-design-system/carbon/pull/6442
https://github.com/carbon-design-system/carbon/issues/2439