### PR TITLE
docs(notification pattern): fix typos

### DIFF
--- a/src/pages/patterns/notification-pattern/index.mdx
+++ b/src/pages/patterns/notification-pattern/index.mdx
@@ -188,7 +188,7 @@ If it is possible a toast will have a message longer than three lines, include a
 
 ![Toast notification in a product](/images/4_Toast_736.png)
 
-<Caption>Low-contrast toast noticiation</Caption>
+<Caption>Low-contrast toast notification</Caption>
 
 </Column>
 </Row>
@@ -303,7 +303,7 @@ Because task-generated notifications are sent in response to user action, it isn
 </DoDontRow>
 <DoDontRow>
   <DoDont
-    caption="Do ensure users konw how to take action if it is necessary."
+    caption="Do ensure users know how to take action if it is necessary."
     text="Script failed to run. Check the log for more detail."
     aspectRatio="1:1"
   />


### PR DESCRIPTION
Closes #1385 

Fixed two typos on notification patterns page
