### PR TITLE
docs: combo box content fixes

### DIFF
--- a/src/pages/components/dropdown/usage.mdx
+++ b/src/pages/components/dropdown/usage.mdx
@@ -19,7 +19,7 @@ Dropdowns present a list of options from which a user can select one option, or 
 <AnchorLink>Universal behaviors</AnchorLink>
 <AnchorLink>Dropdown</AnchorLink>
 <AnchorLink>Multiselect</AnchorLink>
-<AnchorLink>Combobox</AnchorLink>
+<AnchorLink>Combo box</AnchorLink>
 <AnchorLink>Modifiers</AnchorLink>
 <AnchorLink>Related</AnchorLink>
 <AnchorLink>References</AnchorLink>
@@ -31,7 +31,7 @@ import items from "../../../data/components/dropdown.js";
 
 ## Overview
 
-There are three different types of dropdowns that support various kinds of functionality—dropdown, multiselect, and combobox.
+There are three different types of dropdowns that support various kinds of functionality—dropdown, multiselect, and combo box.
 
 ### Types
 
@@ -39,7 +39,7 @@ There are three different types of dropdowns that support various kinds of funct
 | --------------------------- | -------------------------------------------------------------------------------------------------------- |
 | [Dropdown](#dropdown)       | Allows the user to select one option from a list.                                                        |
 | [Multiselect](#multiselect) | Allows the user to select multiple options from a list and filter.                                       |
-| [Combobox](#combobox)       | Allows a user to enter any value, or select a value from a list of suggested, likely, or desired values. |
+| [Combo box](#combo box)     | Allows a user to enter any value, or select a value from a list of suggested, likely, or desired values. |
 
 #### When to use
 
@@ -317,7 +317,7 @@ Scroll bars may not always be enabled so we recommend showing 50% of the last op
 
 #### Mouse
 
-Users trigger a dropdown menu to open by clicking the chevron icon or clicking anywhere within the field. Users can close the menu by clicking the chevron icon or clicking outside of the menu. _Note: You can only open a combobox by clicking the chevron icon or by typing in the field._
+Users trigger a dropdown menu to open by clicking the chevron icon or clicking anywhere within the field. Users can close the menu by clicking the chevron icon or clicking outside of the menu. _Note: You can only open a combo box by clicking the chevron icon or by typing in the field._
 
 <Row>
 <Column colLg={8}>
@@ -347,12 +347,12 @@ Users trigger a dropdown menu to open by clicking the chevron icon or clicking a
 </Column>
 </Row>
 
-- To clear a selected value in a `combobox` or a filterable dropdown, click the “x” icon to the right of the field input text.
+- To clear a selected value in a `combo box` or a filterable dropdown, click the “x” icon to the right of the field input text.
 
 <Row>
 <Column colLg={8}>
 
-![Combobox and filterable dropdown clear click target.](images/dropdown-usage-8d.png)
+![Combo box and filterable dropdown clear click target.](images/dropdown-usage-8d.png)
 
 </Column>
 </Row>
@@ -367,7 +367,7 @@ Users trigger a dropdown menu to open by clicking the chevron icon or clicking a
 - Users can open the dropdown menu by pressing `Space`, `Enter`, `Down arrow` or the `Up arrow`.
 - Users can close the dropdown menu by pressing `Escape`, `Space`, or `Enter`.
 
-#### Combobox and filtering:
+#### Combo box and filtering:
 
 - When typing a character: focus stays on the field while an option in the menu is highlighted that best matches the typed character.
 - When typing multiple characters in rapid succession: focus stays on the field while an option in the menu is highlighted that best matches the string of characters typed.
@@ -430,7 +430,7 @@ Use when you can select multiple options from a list or to filter information.
 
 - Once options have been selected from the menu, a tag appears to the left of the text in the field containing the total number of selected options. The placeholder text can change to text that better reflects what is selected.
 - Selected options shift to the top of the menu in alphanumeric order.
-- Unlike dropdown and combobox, the menu does not close once the user makes selections. Because multiple selections are possible, the user needs to click outside of the dropdown or on the parent element to close the menu.
+- Unlike dropdown and combo box, the menu does not close once the user makes selections. Because multiple selections are possible, the user needs to click outside of the dropdown or on the parent element to close the menu.
 
 <Row>
 <Column colLg={8}>
@@ -467,8 +467,8 @@ Use filtering to narrow down a long list of options to find the option you want 
 </Column>
 </Row>
 
-- The menu opens by clicking anywhere in the field and you can start typing to filter the list of options.
-- After typing text in the field, the close (x) icon appears to the right of the text in the field. This clears any user-inputted text. The options that start to match your entry remain in the list while other existing options are temporarily removed.
+- The menu opens by clicking anywhere in the field and you can start typing to filter the list of options. The options that start to match your entry remain in the list while other existing options are temporarily removed.
+- After typing text in the field, the close (x) icon appears to the right of the text in the field. This clears any text that’s been entered in the field.
 
 <Row>
 <Column colLg={8}>
@@ -490,28 +490,28 @@ Use filtering to narrow down a long list of options to find the option you want 
 </Column>
 </Row>
 
-## Combobox
+## Combo box
 
 Allows the the user to make a selection from a predefined list of options and is typically used when there are a large amount of options to choose from.
 
-- By default, the combobox displays placeholder text in the field when closed.
+- By default, the combo box displays placeholder text in the field when closed.
 - When hovering over the field, a text cursor appears.
 
 <Row>
 <Column colLg={8}>
 
-![Combobox closed enabled and hover states.](images/dropdown-usage-11a.png)
+![Combo box closed enabled and hover states.](images/dropdown-usage-11a.png)
 
 </Column>
 </Row>
 
-- The menu opens by clicking anywhere in the field and you can start typing to sort through the list of options.
-- After typing text in the field, the close (x) icon appears to the right of the text in the field. The close icon clears any user-inputted text. The option that matches your entry receives a hover and comes into view.
+- The menu opens by clicking anywhere in the field and you can start typing to sort through the list of options. The options that start to match your entry remain in the list while other existing options are temporarily removed.
+- After typing text in the field, the close (x) icon appears to the right of the text in the field. This clears any text that’s been entered in the field.
 
 <Row>
 <Column colLg={8}>
 
-![Combobox typing and option hover jumping to matched entry in the menu.](images/dropdown-usage-11b.png)
+![Combo box typing and option hover jumping to matched entry in the menu.](images/dropdown-usage-11b.png)
 
 </Column>
 </Row>
@@ -521,7 +521,7 @@ Allows the the user to make a selection from a predefined list of options and is
 <Row>
 <Column colLg={8}>
 
-![Combobox selected state.](images/dropdown-usage-11c.png)
+![Combo box selected state.](images/dropdown-usage-11c.png)
 
 </Column>
 </Row>
@@ -587,12 +587,12 @@ Dropdown and select components have functionality and style differences.
 - Use a select dropdown component if most of your experience is form based. Custom dropdowns can be used in these situations, but the native select works more easily with a native form when submitting data.
 - Use a select dropdown component if your experience will be frequently used on mobile. The native select dropdown uses the native control for the platform which makes it easier to use.
 
-#### Dropdown versus Combobox
+#### Dropdown versus Combo box
 
-While the dropdown and combobox look similar they have different functions.
+While the dropdown and combo box look similar they have different functions.
 
 - With a dropdown list, the selected option is always visible, and the other options are visible by clicking and opening the list.
-- A combobox is a combination of a standard list box or a dropdown list and an editable text box and users are able to enter a value that isn't in the list.
+- A combo box is a combination of a standard list box or a dropdown list and an editable text box and users are able to enter a value that isn't in the list.
 
 ## References
 


### PR DESCRIPTION
Fixes "combo box" to be two words in the dropdown usage docs.