### PR TITLE
fix(data-table): add missing prop getter for sortable headers

### DIFF
--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -94,9 +94,9 @@ import {
     {`<DataTable
     rows={rowData}
     headers={headerData}
-    render={({ rows, headers, getHeaderProps }) => (
+    render={({ rows, headers, getHeaderProps, getTableProps }) => (
     <TableContainer title="DataTable">
-      <Table>
+      <Table {...getTableProps()}>
         <TableHead>
           <TableRow>
             {headers.map(header => (
@@ -135,9 +135,16 @@ import {
     {`<DataTable
   rows={rowData}
   headers={headerData}
-  render={({ rows, headers, getHeaderProps, getSelectionProps, getRowProps }) => (
+  render={({
+    rows,
+    headers,
+    getHeaderProps,
+    getSelectionProps,
+    getRowProps,
+    getTableProps
+  }) => (
   <TableContainer title="DataTable with selection">
-    <Table>
+    <Table {...getTableProps()}>
       <TableHead>
         <TableRow>
           <TableSelectAll {...getSelectionProps()} />


### PR DESCRIPTION
Closes #1462

This PR adds missing prop getters to the data table examples so that setting the `isSortable` prop for sortable headers does not break the component's appearance