### PR TITLE
Charts sketch file is now published and can remove from WIP page

### DIFF
--- a/src/pages/data-visualization/getting-started/index.mdx
+++ b/src/pages/data-visualization/getting-started/index.mdx
@@ -39,7 +39,7 @@ requests to the
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="Data visualization master Sketch file (WIP)"
+    subTitle="Data visualization master Sketch file"
     href="https://github.com/carbon-design-system/carbon-design-kit/tree/master/Carbon%20Design%20Kit%20-%2010.10.0/data-visualization"
     actionIcon="download">
     <MdxIcon name="sketch" />

--- a/src/pages/updates/work-in-progress/index.mdx
+++ b/src/pages/updates/work-in-progress/index.mdx
@@ -40,12 +40,6 @@ provide feedback and have a say in Carbon's direction.
     href="https://www.sketch.com/s/a3343128-adb6-489c-9e62-709d89ba76e9"
     actionIcon="launch"
   />
-  <MiniCard
-    onClick={() => fathom('trackGoal', 'GP38VQMY', 0)}
-    title="Data viz sticker sheet"
-    href="https://ibm.box.com/s/epx74uadotxbx36aknn1s2nmvhpzgk4o"
-    actionIcon="download"
-  />
 </CardGroup>
 
 ### Components and patterns


### PR DESCRIPTION
The data viz sketch sheet is now on the main Data Viz page as a downloadable asset, and announced in main Carbon channels on Slack etc.

Have removed from the Work in progress page.