### PR TITLE
update hex values for hover-primary-text token

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -877,12 +877,12 @@ const colorTokens = {
           hex: '#054ada',
         },
         g90: {
-          name: 'Blue 70',
-          hex: '#054ada',
+          name: 'Blue 30',
+          hex: '#a6c8ff',
         },
         g100: {
-          name: 'Blue 70',
-          hex: '#054ada',
+          name: 'Blue 30',
+          hex: '#a6c8ff',
         },
       },
     },


### PR DESCRIPTION
Closes # https://github.com/carbon-design-system/carbon-design-kit/issues/321

Update color hex for Gray 90 and Gray 100 theme. Should be Blue 30 (#a6c8ff) not Blue 60.
