### PR TITLE
fix(contribute): code examples to valid yaml frontmatter

### DIFF
--- a/src/pages/how-to-contribute/component/index.mdx
+++ b/src/pages/how-to-contribute/component/index.mdx
@@ -50,8 +50,8 @@ variants. You can see this template in use for
 
 ```markdown
 ---
-title: [Component name]
-description: [Explains what the component is in one or two sentences.]
+title: Component name
+description: Explains what the component is in one or two sentences.
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
@@ -285,8 +285,8 @@ variants. You can see this template in use for
 
 ```markdown
 ---
-title: [Component name]
-description: [Explains what the component is in one or two sentences.]
+title: Component name
+description: Explains what the component is in one or two sentences.
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
@@ -554,8 +554,8 @@ snippets, and be sure to update as dependencies and versions change.
 
 ```markdown
 ---
-title: [Component name (you won't need to write this)]
-description: [Component description (you won't need to write this)]
+title: Component name (you won't need to write this)
+description: Component description (you won't need to write this)
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 


### PR DESCRIPTION
Some of our team have been copy pasting the component contribution examples from the Carbon website to our AI Applications site built with `gatsby-theme-carbon`. The code examples break because the title and description frontmatter fields have brackets which is invalid syntax for the theme.

#### Changelog

**Changed**

- contribution markdown examples to have frontmatter that is compatible with `gatsby-theme-carbon`