### PR TITLE
docs: curly quote fix for left nav

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -44,7 +44,7 @@
       path: /contributing/contribute-pictograms
     - title: Add ons
       path: /contributing/add-ons
-- title: What's happening
+- title: What’s happening
   pages:
     - title: Changelog and roadmap
       path: /whats-happening/changelog-and-roadmap


### PR DESCRIPTION
Adding curly quote to left nav for What’s happening section, for @mjabbink. 