### PR TITLE
(fix) remove wip note on component index

### DIFF
--- a/src/pages/community/component-index.mdx
+++ b/src/pages/community/component-index.mdx
@@ -18,9 +18,4 @@ the contributors listed on each page.
 
 </PageDescription>
 
-<InlineNotification>
-
-The community index is a work in progress and is not ready for production use.
-
-</InlineNotification>
 <ComponentIndexPage />


### PR DESCRIPTION
The community index is no longer a work in progress, so this notification should be removed.