### PR TITLE
docs: add resource card to text toolbar pattern

### DIFF
--- a/src/pages/patterns/text-toolbar-pattern/index.mdx
+++ b/src/pages/patterns/text-toolbar-pattern/index.mdx
@@ -34,6 +34,15 @@ contributions.
 
 </AnchorLinks>
 
+## Resources
+
+<Row className="resource-card-group">
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Text toolbar pattern library"
+    href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"
+    >
+
 ## Overview
 
 A text toolbar is a set of buttons and menus that is grouped horizontally. These

--- a/src/pages/patterns/text-toolbar-pattern/index.mdx
+++ b/src/pages/patterns/text-toolbar-pattern/index.mdx
@@ -36,12 +36,14 @@ contributions.
 
 ## Resources
 
+<Row>
 <Row className="resource-card-group">
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Text toolbar pattern library"
     href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"
     >
+</Row>
 
 ## Overview
 

--- a/src/pages/patterns/text-toolbar-pattern/index.mdx
+++ b/src/pages/patterns/text-toolbar-pattern/index.mdx
@@ -36,9 +36,16 @@ contributions.
 
 ## Resources
 
-<ResourceCard
-  subTitle="Text toolbar pattern library"
-  href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"></ResourceCard>
+<Row className="resource-card-group">
+<Column colMd={4} colLg={4} noGutterSm>
+  <ResourceCard
+    subTitle="Text toolbar pattern library"
+    href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"
+    actionIcon="download">
+
+  </ResourceCard>
+</Column>
+</Row>
 
 ## Overview
 

--- a/src/pages/patterns/text-toolbar-pattern/index.mdx
+++ b/src/pages/patterns/text-toolbar-pattern/index.mdx
@@ -36,14 +36,9 @@ contributions.
 
 ## Resources
 
-<Row>
-<Row className="resource-card-group">
-<Column colLg={4} colMd={4} noGutterSm>
-  <ResourceCard
-    subTitle="Text toolbar pattern library"
-    href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"
-    >
-</Row>
+<ResourceCard
+  subTitle="Text toolbar pattern library"
+  href="sketch://add-library/cloud/f32b7e90-d97e-48ef-ae53-beabf75f5846"></ResourceCard>
 
 ## Overview
 


### PR DESCRIPTION
Closes #1676 

Add a card with the sketch cloud link to the top of the Text toolbar pattern page.