### PR TITLE
fix(ComponentDemo): add padding to align dropdown labels

### DIFF
--- a/src/components/ComponentDemo/ComponentDemo.js
+++ b/src/components/ComponentDemo/ComponentDemo.js
@@ -112,7 +112,7 @@ const ComponentDemo = ({ children, src, scope, noInline, components }) => {
             initialSelectedItem={components[0]}
             id="component-variant"
             titleText={childrenArray.length === 1 ? '' : 'Variant selector'}
-            label="Variant selection"
+            label="Variant selector"
             items={components}
             size="xl"
             className={cx(variantDropdown, {

--- a/src/components/ComponentDemo/ComponentDemo.js
+++ b/src/components/ComponentDemo/ComponentDemo.js
@@ -101,8 +101,8 @@ const ComponentDemo = ({ children, src, scope, noInline, components }) => {
             }
             initialSelectedItem="White"
             id="theme-variant"
-            label="Theme variant selection"
-            titleText="Theme variant selection"
+            label="Theme selector"
+            titleText="Theme selector"
             items={Object.keys(themes)}
             size="xl"
           />
@@ -111,10 +111,8 @@ const ComponentDemo = ({ children, src, scope, noInline, components }) => {
             light
             initialSelectedItem={components[0]}
             id="component-variant"
-            titleText={
-              childrenArray.length === 1 ? '' : 'Component variant selection'
-            }
-            label="Component variant selection"
+            titleText={childrenArray.length === 1 ? '' : 'Variant selector'}
+            label="Variant selection"
             items={components}
             size="xl"
             className={cx(variantDropdown, {

--- a/src/components/ComponentDemo/ComponentDemo.module.scss
+++ b/src/components/ComponentDemo/ComponentDemo.module.scss
@@ -256,6 +256,10 @@ fieldset.form-group:last-of-type {
   [class*='--list-box--light'][class*='--list-box--expanded'] {
     border-bottom-width: 1px;
   }
+
+  [class*='--label'] {
+    margin-left: 1rem;
+  }
 }
 
 .dropdownRow .variantDropdown {


### PR DESCRIPTION
Temporary workaround for https://github.com/carbon-design-system/carbon-website/issues/1688 until we implement the fluid versions of all form components. 

#### Changelog

**Changed**

- `1rem` margin to labels on `ComponentDemo` dropdowns to align the text
- Updated copy per @janchild / @aagonzales 
