### PR TITLE
fix(tutorial): add in fix for ci errors

### DIFF
--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -688,3 +688,12 @@ not merged. We'll close your PR so we can keep the repository's remote branches
 pristine and ready for the next person!
 
 </InlineNotification>
+
+<InlineNotification>
+
+**Note:** If your PR fails the CircleCI test with the error
+`Can't make a request in offline mode`, try running the following command:
+`rm -rf .yarn-offline-mirror node_modules && yarn cache clean && yarn install`.
+Add and commit the changes once this completes, and try pushing again.
+
+</InlineNotification>

--- a/src/pages/developing/react-tutorial/step-2.mdx
+++ b/src/pages/developing/react-tutorial/step-2.mdx
@@ -922,3 +922,12 @@ not merged. We'll close your PR so we can keep the repository's remote branches
 pristine and ready for the next person!
 
 </InlineNotification>
+
+<InlineNotification>
+
+**Note:** If your PR fails the CircleCI test with the error
+`Can't make a request in offline mode`, try running the following command:
+`rm -rf .yarn-offline-mirror node_modules && yarn cache clean && yarn install`.
+Add and commit the changes once this completes, and try pushing again.
+
+</InlineNotification>

--- a/src/pages/developing/react-tutorial/step-3.mdx
+++ b/src/pages/developing/react-tutorial/step-3.mdx
@@ -625,3 +625,12 @@ not merged. We'll close your PR so we can keep the repository's remote branches
 pristine and ready for the next person!
 
 </InlineNotification>
+
+<InlineNotification>
+
+**Note:** If your PR fails the CircleCI test with the error
+`Can't make a request in offline mode`, try running the following command:
+`rm -rf .yarn-offline-mirror node_modules && yarn cache clean && yarn install`.
+Add and commit the changes once this completes, and try pushing again.
+
+</InlineNotification>

--- a/src/pages/developing/react-tutorial/step-4.mdx
+++ b/src/pages/developing/react-tutorial/step-4.mdx
@@ -497,3 +497,12 @@ not merged. We'll close your PR so we can keep the repository's remote branches
 pristine and ready for the next person!
 
 </InlineNotification>
+
+<InlineNotification>
+
+**Note:** If your PR fails the CircleCI test with the error
+`Can't make a request in offline mode`, try running the following command:
+`rm -rf .yarn-offline-mirror node_modules && yarn cache clean && yarn install`.
+Add and commit the changes once this completes, and try pushing again.
+
+</InlineNotification>

--- a/src/pages/developing/react-tutorial/step-5.mdx
+++ b/src/pages/developing/react-tutorial/step-5.mdx
@@ -342,3 +342,12 @@ not merged. We'll close your PR so we can keep the repository's remote branches
 pristine and ready for the next person!
 
 </InlineNotification>
+
+<InlineNotification>
+
+**Note:** If your PR fails the CircleCI test with the error
+`Can't make a request in offline mode`, try running the following command:
+`rm -rf .yarn-offline-mirror node_modules && yarn cache clean && yarn install`.
+Add and commit the changes once this completes, and try pushing again.
+
+</InlineNotification>


### PR DESCRIPTION
Some PR's fail on the CircleCI step when the `yarn install --offline --frozen-lockfile` is run. This PR adds in a little note about how to fix this error to each step of the tutorial. 
