### PR TITLE
fix(Component Index): move legends as direct descendants to fieldsets

### DIFF
--- a/src/components/ComponentIndexPage/component-index.scss
+++ b/src/components/ComponentIndexPage/component-index.scss
@@ -197,12 +197,13 @@
 .component-index-filter__header {
   @include carbon--type-style('heading-01');
   color: $text-01;
+  margin-bottom: $spacing-05;
 }
 
 // Filter fieldset & label
 .component-index-filter__fieldset {
   padding-bottom: $spacing-05;
-  margin-top: $spacing-05;
+  margin-top: 0;
 }
 
 .component-index-filter__label {

--- a/src/components/ComponentIndexPage/index.js
+++ b/src/components/ComponentIndexPage/index.js
@@ -63,7 +63,13 @@ function sortByNewest(a, b) {
 const filterLabels = [
   {
     title: 'Maintainer',
-    options: ['Cloud Data & AI', 'Cloud PAL', 'Watson Health', 'AI Apps', 'IBM.com'],
+    options: [
+      'Cloud Data & AI',
+      'Cloud PAL',
+      'Watson Health',
+      'AI Apps',
+      'IBM.com',
+    ],
   },
   {
     title: 'Framework',
@@ -149,10 +155,10 @@ function ComponentIndexPage() {
       </Column>
       <Column sm={0} md={2} lg={3} className="component-index-filter-container">
         <header className="component-index-filter__header">Filters</header>
-        <fieldset className="component-index-filter__fieldset">
-          {filterLabels.map(({ title, options, key }) => (
+        {filterLabels.map(({ title, options, key }) => (
+          <fieldset className="component-index-filter__fieldset">
+            <legend className="component-index-filter__label">{title}</legend>
             <div key={key} className="component-index-filter__option">
-              <legend className="component-index-filter__label">{title}</legend>
               {options.map((selectedFilter) => (
                 <Checkbox
                   labelText={selectedFilter}
@@ -164,8 +170,8 @@ function ComponentIndexPage() {
                 />
               ))}
             </div>
-          ))}
-        </fieldset>
+          </fieldset>
+        ))}
       </Column>
     </Row>
   );


### PR DESCRIPTION
Closes #1741 

AC is throwing a violation for the index fieldsets not having legends -- it _has_ legends, they were just nested. This PR makes legends direct descendants to fieldset and updates the styling accordingly 👍 🏄 