### PR TITLE
fix(index item tags): hide icons from a11y tree; add descriptive aria labels

### DIFF
--- a/src/components/ComponentIndexPage/ComponentIndexListItem.js
+++ b/src/components/ComponentIndexPage/ComponentIndexListItem.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/display-name */
 /**
  * Copyright IBM Corp. 2016, 2020
  *
@@ -61,10 +62,7 @@ const ComponentIndexListItem = React.memo(
       );
     } else {
       img = (
-        <img
-          src={placeholder}
-          alt={`Placeholder image for the ${name} component`}
-        />
+        <img src={placeholder} alt={`Placeholder for the ${name} component`} />
       );
     }
 
@@ -98,8 +96,12 @@ const ComponentIndexListItem = React.memo(
               <ul className="component-index-item__tags">
                 {framework && (
                   <li className="component-index-item__tag component-index-item__tag--framework">
-                    <TooltipIcon direction="top" tooltipText={framework}>
+                    <TooltipIcon
+                      aria-label={`framework type ${framework}`}
+                      direction="top"
+                      tooltipText={framework}>
                       <img
+                        aria-hidden="true"
                         src={frameworkIcons[framework] || null}
                         alt={framework}
                       />
@@ -108,8 +110,12 @@ const ComponentIndexListItem = React.memo(
                 )}
                 {designAsset && (
                   <li className="component-index-item__tag component-index-item__tag--design-asset">
-                    <TooltipIcon direction="top" tooltipText={designAsset}>
+                    <TooltipIcon
+                      aria-label={`design asset type ${designAsset}`}
+                      direction="top"
+                      tooltipText={designAsset}>
                       <img
+                        aria-hidden="true"
                         src={designAssetIcons[designAsset] || null}
                         alt={designAsset}
                       />
@@ -118,8 +124,11 @@ const ComponentIndexListItem = React.memo(
                 )}
                 {maintainer && (
                   <li className="component-index-item__tag component-index-item__tag--maintainer">
-                    <TooltipIcon direction="top" tooltipText="Maintainer">
-                      <Tag>{maintainer}</Tag>
+                    <TooltipIcon
+                      direction="top"
+                      tooltipText="Maintainer"
+                      aria-label={`Component maintainer ${maintainer}`}>
+                      <Tag aria-hidden="true">{maintainer}</Tag>
                     </TooltipIcon>
                   </li>
                 )}


### PR DESCRIPTION
ref #1744 

In my screen reader testing the index tags were being read twice -- once for the list item itself and another time for the image (icon) inside of it. It was also difficult to discern the information the tags were trying to convey. This PR does two things:

- hides the icons from the accessibility tree with `aria-hidden`
- adds more descriptive aria labeling so the information (framework type, design asset type, and maintainer) is more understandable
- BONUS THING: removes the word 'image' in our asset placeholder which was being flagged by jsx-a11y as redundant and unnecessary given it's context in the accessibility tree (cool!)

### note for testing
The elements are still read as buttons which is confusing. I started a more thorough discussion of this at the referenced issue above 🏄 