### PR TITLE
fix(WIP Page): revert deletion of carbon native mobile links

### DIFF
--- a/src/pages/whats-happening/work-in-progress/index.mdx
+++ b/src/pages/whats-happening/work-in-progress/index.mdx
@@ -33,12 +33,26 @@ provide feedback and have a say in Carbon's direction.
 
 ### Tools and resources
 
+**React Native Sketch kits for mobile**
+
 <CardGroup>
   <MiniCard
-    onClick={() => fathom('trackGoal', 'GC8C8OMU', 0)}
-    title="Carbon mobile sketch kit"
-    href="https://www.sketch.com/s/a3343128-adb6-489c-9e62-709d89ba76e9"
+    title="Light theme"
+    href="sketch://add-library/cloud/a3343128-adb6-489c-9e62-709d89ba76e9"
     actionIcon="launch"
+    onClick={() => fathom('trackGoal', 'GZNMLWPV', 0)}
+  />
+  <MiniCard
+    title="Dark theme"
+    href="sketch://add-library/cloud/1f59f590-6915-47b0-bf06-6fd66209b3b3"
+    actionIcon="launch"
+    onClick={() => fathom('trackGoal', 'BHFADJ59', 0)}
+  />
+  <MiniCard
+    title="IBM Grid template"
+    href="https://www.sketch.com/s/42e694ee-4b37-41c9-8c8f-480e2415d9de"
+    actionIcon="launch"
+    onClick={() => fathom('trackGoal', 'TWMSHNQP', 0)}
   />
 </CardGroup>
 


### PR DESCRIPTION
A recent PR (#1770) was accidentally deleted by a recent PR https://github.com/carbon-design-system/carbon-website/pull/1827/files#diff-edcb7dcce4b004f2d0937b832c9dfa61

This PR just adds back in that content 