### PR TITLE
fix(TypesetStyle): add missing 'id' to resolve a11y issue

### DIFF
--- a/src/components/TypesetStyle/InputRange.js
+++ b/src/components/TypesetStyle/InputRange.js
@@ -4,8 +4,9 @@ import { settings } from 'carbon-components';
 
 const { prefix } = settings;
 
-const InputRange = ({ step, min, max, value, onChange }) => (
+const InputRange = ({ step, min, max, value, onChange, id }) => (
   <input
+    id={id}
     type="range"
     step={step || 1}
     min={min}
@@ -32,6 +33,9 @@ InputRange.propTypes = {
 
   // onChange function
   onChange: PropTypes.func.isRequired,
+
+  // input id
+  id: PropTypes.string,
 };
 
 export default InputRange;

--- a/src/components/TypesetStyle/TypesetStyle.js
+++ b/src/components/TypesetStyle/TypesetStyle.js
@@ -996,6 +996,7 @@ class TypesetStyle extends React.Component {
                     Screen width
                   </span>
                   <InputRange
+                    id="screenWidthInput"
                     min={breakpoints.sm}
                     max={breakpoints.max}
                     value={this.state.simulatedScreenWidth}


### PR DESCRIPTION
Closes #1510 

add missing `id` for input

#### Changelog

**New**

- Added `id` prop to `InputRange`
