### PR TITLE
fix broken dataviz sketch file links

### DIFF
--- a/src/pages/data-visualization/getting-started/index.mdx
+++ b/src/pages/data-visualization/getting-started/index.mdx
@@ -40,7 +40,7 @@ requests to the
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Data visualization master Sketch file"
-    href="https://github.com/carbon-design-system/carbon-design-kit/tree/master/Carbon%20Design%20Kit%20-%2010.10.0/data-visualization"
+    href="https://www.sketch.com/s/1a36060a-7a5d-4ddb-aab1-639caa1f74d4"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -104,7 +104,7 @@ design kit, visit the [Design kits](/designing/kits/sketch) page.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Data visualization master Sketch file"
-    href="https://github.com/carbon-design-system/carbon-design-kit/tree/master/Carbon%20Design%20Kit%20-%2010.10.0/data-visualization"
+    href="https://www.sketch.com/s/1a36060a-7a5d-4ddb-aab1-639caa1f74d4"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8558,6 +8558,19 @@ gatsby-core-utils@^1.3.20:
     tmp "^0.2.1"
     xdg-basedir "^4.0.0"
 
+gatsby-core-utils@^1.3.23:
+  version "1.3.23"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.23.tgz#5d99e86178b2aa3561f58fde4fdffbebecb0dd0c"
+  integrity sha512-H6n6dDeRZ22HAJaBUIt5YjB/BSaE8Jq+kayMUv/YzL1RL2yFZ5lqcLwIL1OE2vWk1mQjMUBZCRxLODU0q1i3bQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-design-tokens@^2.0.2:
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/gatsby-design-tokens/-/gatsby-design-tokens-2.0.11.tgz#b0cf12abc283c73e13de3f610fbcec5fce3e7b48"
@@ -8955,7 +8968,7 @@ gatsby-remark-copy-linked-files@^2.2.1:
     probe-image-size "^5.0.0"
     unist-util-visit "^1.4.1"
 
-gatsby-remark-images@^3.2.1, gatsby-remark-images@^3.3.25:
+gatsby-remark-images@^3.2.1:
   version "3.3.30"
   resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.30.tgz#a9eb4828eb0a373dcb116de6064e06756e9fd327"
   integrity sha512-TqRX3tNMfoUOcx2L+8v9mOEagabp1gLaCqHREvTjwVqi3ybzRe6g46dRoCiCJGp66jDfW8ovemfpdjBOZwXG8A==
@@ -8969,6 +8982,23 @@ gatsby-remark-images@^3.2.1, gatsby-remark-images@^3.3.25:
     mdast-util-definitions "^1.2.5"
     potrace "^2.1.8"
     query-string "^6.13.1"
+    unist-util-select "^1.5.0"
+    unist-util-visit-parents "^2.1.2"
+
+gatsby-remark-images@^3.3.33:
+  version "3.3.33"
+  resolved "https://registry.yarnpkg.com/gatsby-remark-images/-/gatsby-remark-images-3.3.33.tgz#04e834ca2aa27ad4b8fa58ec44c08b3aca3e60ab"
+  integrity sha512-P8oRpv/LGSuLdWRP2b785Ve1N/JXyy+gkgatxoxhOadU5G2r0U+RDv86M12VNytJIuwp4TpfEOsuqbZhzPSQbA==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    chalk "^2.4.2"
+    cheerio "^1.0.0-rc.3"
+    gatsby-core-utils "^1.3.23"
+    is-relative-url "^3.0.0"
+    lodash "^4.17.20"
+    mdast-util-definitions "^1.2.5"
+    potrace "^2.1.8"
+    query-string "^6.13.3"
     unist-util-select "^1.5.0"
     unist-util-visit-parents "^2.1.2"
 
@@ -14868,6 +14898,15 @@ query-string@^6.13.1:
   version "6.13.2"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.2.tgz#3585aa9412c957cbd358fd5eaca7466f05586dda"
   integrity sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
+query-string@^6.13.3:
+  version "6.13.5"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.13.5.tgz#99e95e2fb7021db90a6f373f990c0c814b3812d8"
+  integrity sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==
   dependencies:
     decode-uri-component "^0.2.0"
     split-on-first "^1.0.0"


### PR DESCRIPTION
The dataviz master sketch file links are pointing to a broken link now, changing that to Sketch cloud