### PR TITLE
docs: typo fix

### DIFF
--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -114,7 +114,7 @@ do you gain by collecting this information?
   `}</ComponentVariant>
 </ComponentDemo>
 
-## Formattting
+## Formatting
 
 All forms are comprised of six elements:
 


### PR DESCRIPTION
This fixes a typo in the form component usage docs.