### PR TITLE
Update Weekly Design playback time block in Meet ups page

### DIFF
--- a/src/pages/whats-happening/meetups/index.mdx
+++ b/src/pages/whats-happening/meetups/index.mdx
@@ -27,7 +27,7 @@ peers, and getting reviews on work in progress.
 
 <h2>
   Weekly design playback
-  <span>Fridays, 11am–12pm Central</span>
+  <span>Fridays, 12–1pm Central</span>
 </h2>
 
 _For IBMers only:_ You’ve got some work in progress and you’re ready to open it


### PR DESCRIPTION
changed time black from 11am–12pm to 12–1pm