### PR TITLE
fixed spelling/reference error on contribute page

### DIFF
--- a/src/pages/community/contribute-a-chart.mdx
+++ b/src/pages/community/contribute-a-chart.mdx
@@ -9,12 +9,12 @@ tabs: ['Data visualization index', 'Contribute a chart']
 
 <PageDescription>
 
-Anyone can add assets to the community chartindex. Maintainers can submit a
+Anyone can add assets to the community chart index. Maintainers can submit a
 short pull request in GitHub to add a chart to the index.
 
 </PageDescription>
 
-## Add a component using the GitHub UI
+## Add a chart using the GitHub UI
 
 1. In the
    [index folder](https://github.com/carbon-design-system/carbon-website/tree/master/src/data/chart-index)


### PR DESCRIPTION
Still referenced "component" instead of chart.