### PR TITLE
docs: update for rename of dotcom site

### DIFF
--- a/src/pages/community/domain-guidance.mdx
+++ b/src/pages/community/domain-guidance.mdx
@@ -20,8 +20,8 @@ digital experiences for the IBM.com site.
 <Row className="resource-card-group">
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="IBM.com Library"
-    href="https://www.ibm.com/standards/web/ibm-dotcom-library/"
+    subTitle="Carbon for IBM.com"
+    href="https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/"
     >
 
 ![Bee icon](images/bee.svg)


### PR DESCRIPTION
This updates the Community assets page with the new name for Carbon for IBM.com. 