### PR TITLE
Added the full width grid modifier

### DIFF
--- a/src/pages/guidelines/2x-grid/implementation.mdx
+++ b/src/pages/guidelines/2x-grid/implementation.mdx
@@ -173,7 +173,7 @@ centered in the page within the parent container.
 
 `bx--grid` defines the overall grid context at the top level and applies the
 proper margin and our default max-width (1584px.) You can also remove this max
-width, by using a grid modifier class. See the full width example below.
+width, by using the grid modifier class `bx--grid--full-width`.
 
 #### Rows
 


### PR DESCRIPTION
The grid documentation actually tells you to look in the "full-width" example to learn more about the "full-width modifier" for the grid. But there is no such example in the page.
I think it would be a great idea to add this class directly in the paragraph.

#### Changelog

**Changed**

- the "container" paragraph in the Grid documentation page https://www.carbondesignsystem.com/guidelines/2x-grid/implementation/ added reference to the full width grid modifier class.
