### PR TITLE
fix: add white background back to images

### DIFF
--- a/src/styles/_images.scss
+++ b/src/styles/_images.scss
@@ -17,11 +17,11 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: $ui-02;
+  background: $ui-01;
 }
 
 .image--fixed span.gatsby-resp-image-wrapper {
-  background: $ui-02;
+  background: $ui-01;
   display: flex !important;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Updates token so that there should now be a white background behind usage page images

### Testing

Need to make sure this doesn't add a white background to images where it shouldn't