### PR TITLE
Change button class "inline" to "field"

### DIFF
--- a/src/pages/components/button/style.mdx
+++ b/src/pages/components/button/style.mdx
@@ -180,7 +180,7 @@ recommended by design as the proper distance between buttons.
 
 ## Sizes
 
-There are three common button sizes: default, inline, and small. Each button
+There are three common button sizes: default, field, and small. Each button
 type can use any of these three sizes based on need. The fourth button size,
 full bleed, has a more reserved application and should rarely be used.
 
@@ -188,7 +188,7 @@ full bleed, has a more reserved application and should rarely be used.
 | ----------- | ----------------- | ---------------------------------------------------------------------------------- |
 | Full bleed  | 64 / 4            | Use when buttons bleed to the edge of a component, like in side panels and modals. |
 | Default     | 48 / 3            | Use as primary page actions and other standalone actions.                          |
-| Inline      | 40 / 2.5          | Use when buttons are paired with input fields.                                     |
+| Field       | 40 / 2.5          | Use when buttons are paired with input fields.                                     |
 | Small       | 32 / 2            | Use when there is not enough vertical space for the default sized button.          |
 
 <Row>


### PR DESCRIPTION
"Inline" button type is not supported. The type that the documentation is referring to is "field".

#### Changelog

- "inline" button class type has been replaced with "field"