### PR TITLE
chore: update deployments to point toward main branch

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -9,20 +9,26 @@ Want to contribute to this repository? Please read below first:
 
 ## Issues and bugs
 
-If you find a bug in the source code or a mistake in the documentation, you can help us by
-submitting an issue to this repo. Even better you can submit a Pull Request with a fix.
+If you find a bug in the source code or a mistake in the documentation, you can
+help us by submitting an issue to this repo. Even better you can submit a Pull
+Request with a fix.
 
 **Please see the submission guidelines below**.
 
 ## Feature requests
 
-You can request a new feature by submitting an issue to this repo. Proposed features (with suitable design documentation and reasoning) can be crafted and submitted to this repo as a Pull Request.
+You can request a new feature by submitting an issue to this repo. Proposed
+features (with suitable design documentation and reasoning) can be crafted and
+submitted to this repo as a Pull Request.
 
 **Please see the Submission Guidelines below**.
 
 ## Doc fixes
 
-If you want to help improve the docs, it's a good idea to let others know what you're working on to minimize duplication of effort. Comment on an issue to let others know what you're working on, or create a new issue if your work doesn't fit within the scope of any of the existing doc fix projects.
+If you want to help improve the docs, it's a good idea to let others know what
+you're working on to minimize duplication of effort. Comment on an issue to let
+others know what you're working on, or create a new issue if your work doesn't
+fit within the scope of any of the existing doc fix projects.
 
 **Please see the submission guidelines below**.
 
@@ -30,18 +36,24 @@ If you want to help improve the docs, it's a good idea to let others know what y
 
 ### Setup
 
-1. Fork the project by navigating to the main [repository](https://github.com/carbon-design-system/carbon-website) and clicking the **Fork** button on the top-right corner.
+1. Fork the project by navigating to the main
+   [repository](https://github.com/carbon-design-system/carbon-website) and
+   clicking the **Fork** button on the top-right corner.
 
-2. Navigate to your forked repository and copy the **SSH url**. Clone your fork by running the following in your terminal:
+2. Navigate to your forked repository and copy the **SSH url**. Clone your fork
+   by running the following in your terminal:
 
    ```
    $ git clone git@github.com:{ YOUR_USERNAME }/carbon-website.git
    $ cd carbon-website
    ```
 
-   See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more details on forking a repository.
+   See [GitHub docs](https://help.github.com/articles/fork-a-repo/) for more
+   details on forking a repository.
 
-3. Once cloned, you will see `origin` as your default remote, pointing to your personal forked repository. Add a remote named `upstream` pointing to the main `carbon-website`:
+3. Once cloned, you will see `origin` as your default remote, pointing to your
+   personal forked repository. Add a remote named `upstream` pointing to the
+   main `carbon-website`:
 
    ```
    $ git remote add upstream git@github.com:carbon-design-system/carbon-website.git
@@ -59,29 +71,37 @@ If you want to help improve the docs, it's a good idea to let others know what y
 
 ### Submitting an issue
 
-Before you submit your issue, search the repository. Maybe your question was already answered.
+Before you submit your issue, search the repository. Maybe your question was
+already answered.
 
-If your issue appears to be a bug, and hasn't been reported, open a new issue. Help us to maximize the effort we can spend fixing issues and adding new features, by not reporting duplicate issues.
+If your issue appears to be a bug, and hasn't been reported, open a new issue.
+Help us to maximize the effort we can spend fixing issues and adding new
+features, by not reporting duplicate issues.
 
 ### Submitting a pull request
 
-1. Search this repository for an open or closed pull request that relates to your submission. You don't want to duplicate effort.
+1. Search this repository for an open or closed pull request that relates to
+   your submission. You don't want to duplicate effort.
 
-2. Pull the latest master branch from `upstream`:
-
-   ```
-   $ git pull upstream master
-   ```
-
-3. Always work and submit pull requests from a branch. _Do not submit pull requests from the `master` branch of your fork_.
+2. Pull the latest main branch from `upstream`:
 
    ```
-   $ git checkout -b { YOUR_BRANCH_NAME } master
+   $ git pull upstream main
    ```
 
-4. Create your patch or feature following our [development guidelines](/README.md#development). Make sure to also follow our [coding standards](#coding-standards).
+3. Always work and submit pull requests from a branch. _Do not submit pull
+   requests from the `main` branch of your fork_.
 
-5. Test your branch and add new test cases where appropriate per the [testing guidelines](#testing).
+   ```
+   $ git checkout -b { YOUR_BRANCH_NAME } main
+   ```
+
+4. Create your patch or feature following our
+   [development guidelines](/README.md#development). Make sure to also follow
+   our [coding standards](#coding-standards).
+
+5. Test your branch and add new test cases where appropriate per the
+   [testing guidelines](#testing).
 
 6. Commit your changes using a descriptive commit message.
 
@@ -89,22 +109,37 @@ If your issue appears to be a bug, and hasn't been reported, open a new issue. H
    $ git commit -a -m "chore: Update header with newest designs, resolves #123"
    ```
 
-   **Note:** the optional commit `-a` command line option will automatically `add` and `rm` edited files. See [Close a commit via commit message](https://help.github.com/articles/closing-issues-via-commit-messages/) and [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages) for more details on commit messages.
+   **Note:** the optional commit `-a` command line option will automatically
+   `add` and `rm` edited files. See
+   [Close a commit via commit message](https://help.github.com/articles/closing-issues-via-commit-messages/)
+   and
+   [writing good commit messages](https://github.com/erlang/otp/wiki/Writing-good-commit-messages)
+   for more details on commit messages.
 
-7. Once ready for feedback from other contributors and maintainers, **push your commits to your fork** (be sure to run `yarn ci-check` before pushing, to make sure your code passes linting and unit tests):
+7. Once ready for feedback from other contributors and maintainers, **push your
+   commits to your fork** (be sure to run `yarn ci-check` before pushing, to
+   make sure your code passes linting and unit tests):
 
    ```
    $ git push origin { YOUR_BRANCH_NAME }
    ```
 
-8. In GitHub, navigate to [carbon-design-system/carbon-website](https://github.com/carbon-design-system/carbon-website) and click the button that reads "Compare & pull request".
+8. In GitHub, navigate to
+   [carbon-design-system/carbon-website](https://github.com/carbon-design-system/carbon-website)
+   and click the button that reads "Compare & pull request".
 
 9. Write a title and description, the click "Create pull request".
 
-   See [how to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request) for more details on writing good PRs.
+   See
+   [how to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
+   for more details on writing good PRs.
 
-10. Stay up to date with the activity in your pull request. Maintainers will be reviewing your work and making comments, asking questions and suggesting changes to be made before they merge your code. When you need to make a change, add, commit and push to your branch normally.
+10. Stay up to date with the activity in your pull request. Maintainers will be
+    reviewing your work and making comments, asking questions and suggesting
+    changes to be made before they merge your code. When you need to make a
+    change, add, commit and push to your branch normally.
 
-    Once all revisions to your pull request are complete, a maintainer will squash and merge your commits for you.
+    Once all revisions to your pull request are complete, a maintainer will
+    squash and merge your commits for you.
 
 **That's it! Thank you for your contribution!**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        description: "Reason"
+        description: 'Reason'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:
@@ -35,7 +35,9 @@ jobs:
       - name: Login to ibmcloud
         env:
           API_KEY: ${{ secrets.API_KEY }}
-        run: ibmcloud login -a "https://cloud.ibm.com" -u apikey -p "$API_KEY" -o "carbon-design-system" -s "production" -r "us-south"
+        run:
+          ibmcloud login -a "https://cloud.ibm.com" -u apikey -p "$API_KEY" -o
+          "carbon-design-system" -s "production" -r "us-south"
 
       - name: Deploy website
         run: |

--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@main
       - name: Compress Images
-        uses: calibreapp/image-actions@master
+        uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@main
+        uses: actions/checkout@master
       - name: Compress Images
-        uses: calibreapp/image-actions@main
+        uses: calibreapp/image-actions@master
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -2,7 +2,7 @@
 
 1. Update and install dependencies
    ```bash
-   git pull upstream master && yarn install --frozen-lockfile
+   git pull upstream main && yarn install --frozen-lockfile
    ```
 2. Run build and test locally
 
@@ -23,12 +23,13 @@
 5. Get your one time passcode for IBM Cloud
 
    1. Log in to https://cloud.ibm.com
-   2. Be sure you have the Carbon account selected (1569355 - IBM) in the dropdown to the right of "Manage" in the UI Shell header
+   2. Be sure you have the Carbon account selected (1569355 - IBM) in the
+      dropdown to the right of "Manage" in the UI Shell header
    3. Click on your profile picture and select "Log in to CLI and API"
-   4. Look for your "one time passcode" near the top of the modal and click to copy it
+   4. Look for your "one time passcode" near the top of the modal and click to
+      copy it
 
-6. Log in to IBM Cloud
-   Replace the asterisks with your one time passcode
+6. Log in to IBM Cloud Replace the asterisks with your one time passcode
 
    ```bash
    ibmcloud login -a "https://cloud.ibm.com" -u apikey -p ********** -o "carbon-design-system" -s "production" -r "us-south"
@@ -41,7 +42,8 @@
 
 ## Testing or Sharing builds without GitHub
 
-In the event you want to test/share a deployment without pushing to GitHub, download the `vercel` package globally through npm:
+In the event you want to test/share a deployment without pushing to GitHub,
+download the `vercel` package globally through npm:
 
 ```bash
 npm i -g vercel


### PR DESCRIPTION
I created a branch called `main` with all the commit history that `master` has BUT before switching over to main as our default branch, I need to update where our deployment points to:

#### Changelog

- updates deployments to point toward `main` instead of `master`
- _Note: this PR is being compared to/will be merged into the `main` branch, so it shouldn't affect anything on `master` or the current deployed website until we switch default branch over to main_

Lmk if there's any other config I missed :) 