### PR TITLE
docs: content guidelines heading fix

### DIFF
--- a/src/pages/guidelines/content/action-labels.mdx
+++ b/src/pages/guidelines/content/action-labels.mdx
@@ -2,7 +2,7 @@
 label:
   Content design can make or break an online experience. Always strive for
   writing that is clear, concise, and on-brand.
-title: Action labels
+title: Content
 description:
   Users rely on consistent labels for common actions to predict how to interact
   with an interface. This list includes the common UI terms and recommended

--- a/src/pages/guidelines/content/overview.mdx
+++ b/src/pages/guidelines/content/overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Content
 description:
   Well-designed content empowers people to use our offerings with ease. Words
   form the conversation a user has with a product, working with the visual

--- a/src/pages/guidelines/content/writing-style.mdx
+++ b/src/pages/guidelines/content/writing-style.mdx
@@ -1,5 +1,5 @@
 ---
-title: Writing style
+title: Content
 description:
   Writing should always be simple, clear, and easy to understand. Using everyday
   language keeps the tone friendly, human, and inviting. And choose short words


### PR DESCRIPTION
Fixing headings to be consistent across the tabs in the Content guidelines. 