### PR TITLE
docs(Contact-us): add discord link

### DIFF
--- a/src/pages/help/contact-us/index.mdx
+++ b/src/pages/help/contact-us/index.mdx
@@ -70,6 +70,11 @@ the appropriate Carbon repo.
 
 ## Start a new discussion
 
+### Discord
+
+Come chat and get support from Carbon maintainers and fellow community members
+on our [Discord server](https://discord.gg/SYjvP8epkM).
+
 ### Slack channels
 
 _For internal IBM users only._ The Carbon core team maintains the following


### PR DESCRIPTION
Closes #2023 

Adds a Discord server invite link to the /contact-us page. Worth noting is that it's _above_ our Slack links which led off the section previously. Made sense to me to have our first point of contact reachable as an open source project, but happy to adjust if I need to.

_sorry for the double PR submission 🙏_