### PR TITLE
docs: new pattern templates

### DIFF
--- a/src/pages/contributing/component/index.mdx
+++ b/src/pages/contributing/component/index.mdx
@@ -13,39 +13,22 @@ enhancements or brand new assets.
 </PageDescription>
 
 <AnchorLinks>
-  <AnchorLink>First steps to contributing</AnchorLink>
-  <AnchorLink>Documentation templates</AnchorLink>
+  <AnchorLink>How to write component guidance</AnchorLink>
   <AnchorLink>Parts of a component contribution</AnchorLink>
+  <AnchorLink>First steps to contributing</AnchorLink>
+
 </AnchorLinks>
 
-## First steps to contributing
-
-To contribute a component to Carbon, start by
-[opening a Github issue](https://github.com/carbon-design-system/carbon/issues/new?assignees=&labels=type%3A+enhancement+%F0%9F%92%A1&template=feature-request-or-enhancement.md&title=).
-Include a detailed description in which you:
-
-- Explain the rationale
-- Detail the intended behavior
-- Clarify whether it's a variation of an existing component, or a new asset
-- Include mockups of any fidelity (optional)
-- Include any inspirations from other products (optional)
-
-This issue will be the staging ground for the contribution and an opportunity
-for the community to weigh in with any suggestions. We encourage you to surface
-work in progress. Someone in the community may be working on the same component
-and interested in collaborating with you.
-
-## Documentation templates
+## How to write component guidance
 
 Our component usage documentation typically contains three parts: usage
 guidance, style guidance, and code guidance. Some components are more complex
 than others but you should cover each topic included in these templates.
 
-### Usage guidance for components with one type
+### Template for components with one variant
 
-Use this template for documenting components with only one type, that is, no
-variants. You can see this template in use for
-[Accordion](/components/accordion/usage) and
+Use this template for documenting components with only one variant. You can see
+this template in use for [Accordion](/components/accordion/usage) and
 [Checkbox](/components/checkbox/usage).
 
 ```markdown
@@ -276,7 +259,7 @@ leaving any other comments on
 [GitHub](https://github.com/carbon-design-system/carbon-website/issues/new?assignees=&labels=feedback&template=feedback.md).
 ```
 
-### Usage guidance with multiple types
+### Template for components with multiple variants
 
 Use this template for documenting components that have multiple types or
 variants. You can see this template in use for
@@ -743,3 +726,20 @@ specific repo you intend to contribute to.
 
 Start with our [Code guidance](#code-guidance) template. We recommend reading
 through existing code documentation on this site for inspiration.
+
+## First steps to contributing
+
+To contribute a component to Carbon, start by
+[opening a Github issue](https://github.com/carbon-design-system/carbon/issues/new?assignees=&labels=type%3A+enhancement+%F0%9F%92%A1&template=feature-request-or-enhancement.md&title=).
+Include a detailed description in which you:
+
+- Explain the rationale
+- Detail the intended behavior
+- Clarify whether it's a variation of an existing component, or a new asset
+- Include mockups of any fidelity (optional)
+- Include any inspirations from other products (optional)
+
+This issue will be the staging ground for the contribution and an opportunity
+for the community to weigh in with any suggestions. We encourage you to surface
+work in progress. Someone in the community may be working on the same component
+and interested in collaborating with you.

--- a/src/pages/contributing/pattern.mdx
+++ b/src/pages/contributing/pattern.mdx
@@ -45,9 +45,11 @@ Explain the pattern in one or two sentences.
 
 <AnchorLinks>
 
-<AnchorLink>Overview</AnchorLink> <AnchorLink>Designing with
-[pattern]</AnchorLink> <AnchorLink>Accessibility</AnchorLink>
-<AnchorLink>Related</AnchorLink> <AnchorLink>References</AnchorLink>
+<AnchorLink>Overview</AnchorLink>  
+<AnchorLink>Designing with [pattern]</AnchorLink>  
+<AnchorLink>Accessibility</AnchorLink>  
+<AnchorLink>Related</AnchorLink>  
+<AnchorLink>References</AnchorLink>  
 <AnchorLink>Feedback</AnchorLink>
 
 </AnchorLinks>
@@ -198,10 +200,12 @@ Explain the pattern in one or two sentences.
 
 <AnchorLinks>
 
-<AnchorLink>Overview</AnchorLink> <AnchorLink>Designing with
-[pattern]</AnchorLink> <AnchorLink>[Pattern] variant</AnchorLink>
-<AnchorLink>Accessibility</AnchorLink> <AnchorLink>Related</AnchorLink>
-<AnchorLink>References</AnchorLink> <AnchorLink>Feedback</AnchorLink>
+<AnchorLink>Overview</AnchorLink>  
+<AnchorLink>Designing with [pattern]</AnchorLink> <AnchorLink>[Pattern]
+variant</AnchorLink> <AnchorLink>Accessibility</AnchorLink>  
+<AnchorLink>Related</AnchorLink>  
+<AnchorLink>References</AnchorLink>  
+<AnchorLink>Feedback</AnchorLink>
 
 </AnchorLinks>
 

--- a/src/pages/contributing/pattern.mdx
+++ b/src/pages/contributing/pattern.mdx
@@ -201,8 +201,9 @@ Explain the pattern in one or two sentences.
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>  
-<AnchorLink>Designing with [pattern]</AnchorLink> <AnchorLink>[Pattern]
-variant</AnchorLink> <AnchorLink>Accessibility</AnchorLink>  
+<AnchorLink>Designing with [pattern]</AnchorLink>  
+<AnchorLink>[Pattern] variant</AnchorLink>  
+<AnchorLink>Accessibility</AnchorLink>  
 <AnchorLink>Related</AnchorLink>  
 <AnchorLink>References</AnchorLink>  
 <AnchorLink>Feedback</AnchorLink>

--- a/src/pages/contributing/pattern.mdx
+++ b/src/pages/contributing/pattern.mdx
@@ -14,39 +14,44 @@ objectives with sequences and flows.
 
 </PageDescription>
 
-## First steps to contributing
-
-If you’ve designed a pattern that is not currently in Carbon, contributing it
-back allows others in the community to refine and use your pattern in their
-projects.
-
-Start by opening a
-[Github issue](https://github.com/carbon-design-system/carbon-website/issues/new).
-Include a detailed description in which you:
-
-- Define your pattern and explain the rationale
-- Include mockups and/or prototypes of any fidelity
-- Clarify whether it uses existing components, new components, or both
-- Include competitive and comparative analysis, and any inspirations from other
-  products
-
-This issue will be the staging ground for the pattern contribution, and you
-should expect the Carbon core team and the community to weigh in with
-suggestions.
-
-We encourage you to surface work in progress. If you’re not able to complete all
-of the parts yourself, someone in the community may be able to help.
-
 ## How to write a pattern
 
 We’ve created guidelines to help you prepare a complete and comprehensive
-pattern. These guidelines and the required structure are included in the
-Markdown template below.
+pattern. There are two Markdown templates to choose from:
 
-Depending on the pattern, you may need to adjust the structure but your pattern
-should cover all of the topics outlined here.
+- **Pattern with a single variant**: Use this template if your pattern has one
+  primary solution. This is the most common.
+- **Pattern with multiple variants**: Use this template if your content covers
+  multiple variants of the pattern.
+
+You may need to adjust the topic order to best tell the story but your pattern
+should cover all of the topics outlined in each of these templates.
+
+If you would like some assistance with the best approach for your pattern,
+please [reach out](https://www.carbondesignsystem.com/help/contact-us). We'd be
+happy to work through the options with you.
 
 ```markdown
+---
+title: Pattern name
+description: Explain the pattern in one or two sentences.
+---
+
+<PageDescription>
+
+Explain the pattern in one or two sentences.
+
+</PageDescription>
+
+<AnchorLinks>
+
+<AnchorLink>Overview</AnchorLink> <AnchorLink>Designing with
+[pattern]</AnchorLink> <AnchorLink>Accessibility</AnchorLink>
+<AnchorLink>Related</AnchorLink> <AnchorLink>References</AnchorLink>
+<AnchorLink>Feedback</AnchorLink>
+
+</AnchorLinks>
+
 ## Overview
 
 This section answers the question: “What problem does this pattern solve?”
@@ -56,9 +61,9 @@ This section answers the question: “What problem does this pattern solve?”
 
 ### Anatomy
 
-Include an image with callouts explaining each part of the pattern.
-
-`Show pattern in visual form`
+Include an image with callouts explaining each part of the pattern. See the
+[Forms pattern](https://www.carbondesignsystem.com/patterns/forms-pattern#anatomy-of-a-form)
+for an example.
 
 ### When to use
 
@@ -73,24 +78,19 @@ For example, use this pattern when:
 
 If required, include a short explanation about when not to use this pattern.
 
-## The solution
+## Designing with [pattern]
 
 This section explains the pattern in detail. Use a combination of written
 explanations and visuals to tell the story.
 
-### Behaviors, structure, and functionality
+Describe the elements, components, and content that make up the pattern.
 
-- Describe the elements, components, and content that make up the pattern.
-- Describe pattern behaviors, including guidance on interactions, and changes in
-  states and content.
-- Show the pattern in context. Use visuals throughout your written commentary to
-  illustrate your guidance.
+Show the pattern in context. Use visuals throughout your written commentary to
+illustrate your guidance.
 
 Different patterns require different visuals to best explain the behaviors and
 hierarchy. Choose the options that make the most sense for the story you are
-telling. See our
-[production guidelines](https://github.com/carbon-design-system/carbon-website/wiki/Production-guidelines)
-for information about creating assets for the IBM Design System.
+telling.
 
 - Use annotated wireframes or sketches to explain the visual hierarchy of
   components.
@@ -98,8 +98,169 @@ for information about creating assets for the IBM Design System.
 - Create a functional prototype if that is the best way to illustrate the
   pattern's behavior.
 
-Provide a [Sketch file](https://www.sketch.com/docs/getting-started/) with any
-symbols you've created in the development of this pattern.
+Provide a Sketch file with any symbols you've created in the development of this
+pattern.
+
+Use the following headings as guidelines for the kind of information to include.
+Depending on the requirements of your pattern, you may choose to present these
+headings as H2 headings or as H3 headings underneath a more general "Designing
+with [pattern]" heading. See the
+[Dialogs pattern](https://www.carbondesignsystem.com/patterns/dialog-pattern/#designing-with-dialogs)
+as an example.
+
+### Types of [pattern]
+
+If the pattern has different types or visual treatments that serve different use
+cases, cover them here and be sure to explain when to use each type.
+
+See the
+[Empty states](https://www.carbondesignsystem.com/patterns/empty-states-pattern#when-to-use)
+pattern and the
+[Notification](https://www.carbondesignsystem.com/patterns/notification-pattern#notification-types)
+pattern for examples.
+
+### Behaviors
+
+Describe behaviors, including guidance on interactions, and changes in states
+and content.
+
+### Best practices
+
+Are there any do's and don'ts specific to this variant? Include them here.
+
+For examples of how to lay out this kind of information, see
+[Dropdown](https://www.carbondesignsystem.com/components/dropdown/usage) and
+[Modal](https://www.carbondesignsystem.com/components/modal/usage#variations).
+
+### Visual guidance
+
+Cover any important topics such as alignment, image choice considerations, or
+special treatments in situations with no data or multiple instances of elements.
+See the
+[Empty states pattern](https://www.carbondesignsystem.com/patterns/empty-states-pattern#visual-guidelines-for-smaller-empty-spaces)
+and the
+[Forms pattern](https://www.carbondesignsystem.com/patterns/forms-pattern#designing-a-form)
+for examples.
+
+### Other use cases
+
+If there are use cases that require a different solution, include those here
+with corresponding explanations and visuals. Be sure to explain the reasons for
+using one solution over another.
+
+## Accessibility
+
+Evaluate your pattern to ensure it meets
+[accessibility standards](notion://www.notion.so/guidelines/accessibility/overview)
+and guidelines, and provide details of compliance.
+
+For example, “Users should be able to TAB into the input field of the search box
+to begin typing and press ENTER to run the search query.”
+
+For examples, see the
+[Text toolbar pattern](https://www.carbondesignsystem.com/patterns/text-toolbar-pattern#accessibility)
+and the
+[Search pattern](https://www.carbondesignsystem.com/patterns/search-pattern#accessibility).
+
+## Related
+
+Which components are used when building this pattern? Did you reference other
+patterns? List them here.
+
+If necessary, clarify any differences between this pattern and related patterns.
+
+## References
+
+Help designers understand your process by explaining your rationale for the way
+you implemented the pattern. Include any research, citations, books or articles
+that you found helpful.
+
+## Feedback
+
+Help us improve this pattern by providing feedback, asking questions, and
+leaving any other comments on
+[GitHub](https://github.com/carbon-design-system/carbon-website/issues/new?assignees=&labels=feedback&template=feedback.md).
+```
+
+<Caption>Template for patterns with one primary solution</Caption>
+
+```markdown
+---
+title: Pattern name (multiple variants)
+description: Explain the pattern in one or two sentences.
+---
+
+<PageDescription>
+
+Explain the pattern in one or two sentences.
+
+</PageDescription>
+
+<AnchorLinks>
+
+<AnchorLink>Overview</AnchorLink> <AnchorLink>Designing with
+[pattern]</AnchorLink> <AnchorLink>[Pattern] variant</AnchorLink>
+<AnchorLink>Accessibility</AnchorLink> <AnchorLink>Related</AnchorLink>
+<AnchorLink>References</AnchorLink> <AnchorLink>Feedback</AnchorLink>
+
+</AnchorLinks>
+
+## Overview
+
+Include a paragraph or two that describes the primary use cases for the pattern
+and details about how it helps the user achieve any tasks.
+
+The purpose of this overview section is to set context for your readers.
+
+### Anatomy
+
+It can be helpful to show images of all of the variants in small form together.
+See the
+[Dialogs pattern](https://www.carbondesignsystem.com/patterns/dialog-pattern#modal-variants)
+and the
+[Notifications pattern](https://www.carbondesignsystem.com/patterns/notification-pattern#notification-types)
+for examples of this visual treatment.
+
+Alternatively, if there is one variant that includes common aspects of the
+pattern that are seen across all or most variants, include an image with
+callouts explaining each part of the pattern. See the
+[Forms pattern](https://www.carbondesignsystem.com/patterns/forms-pattern#anatomy-of-a-form)
+for an example.
+
+### [Pattern] variants
+
+Include a table with the variants discussed in this pattern. Include a short
+description about the usage of each pattern variant. The table in
+[Modal component](https://www.carbondesignsystem.com/components/modal/usage/#variants)
+is a good example of the level of detail required.
+
+The variant names should link to the H2 headings for the variants below.
+
+Add more columns, if needed. For example, you could add a column that includes
+short explanations about when not to use the variant and guide the user to an
+alternative that may be more appropriate.
+
+## Designing with [pattern]
+
+This section covers _universal_ content related to all variants, and depending
+on the requirements of your pattern, may include the following H3s.
+
+### When to use
+
+If you need to elaborate on the content included in the pattern variants table
+in the Overview, include that detail here. The
+[Notifications pattern](https://www.carbondesignsystem.com/patterns/notification-pattern#when-to-use)
+is a good example of the kind of content to include.
+
+### When not to use (optional)
+
+If required, include a short explanation about when not to use this pattern and
+provide alternatives.
+
+### Universal behaviors
+
+Describe any behaviors that are universal to all pattern variants, and include
+guidance on interactions, and changes in states and content.
 
 ### Best practices
 
@@ -109,11 +270,105 @@ making choices.
 - Do's
 - Dont's
 
+### Visual guidance
+
+Cover any important topics such as alignment, image choice considerations, or
+special treatments in situations with no data or multiple instances of elements.
+See
+[Empty states](https://www.carbondesignsystem.com/patterns/empty-states-pattern#visual-guidelines-for-smaller-empty-spaces)
+for an example.
+
+### Other considerations
+
+If there are any other considerations particular to your pattern that are
+applicable to all variants, include them here.
+
+## [Pattern] variant
+
+Rename this H2 heading with the first pattern variant name, and repeat for all
+variants within this pattern. These sections should map directly to the variant
+table in the Overview.
+
+This section describes the pattern variant in detail, and highlights content
+that is _unique_ to the pattern variant. Use a combination of written
+explanations and visuals to tell the story.
+
+The H3s headings below are suggested that be included and adapted to suit the
+requirements and complexity of the variant.
+
+Include an introductory paragraph about the pattern variant to set context.
+
+### [Pattern variant] anatomy
+
+Include an image with callouts explaining each part of the pattern variant. See
+the
+[Forms pattern](https://www.carbondesignsystem.com/patterns/forms-pattern#anatomy-of-a-form)
+for an example.
+
+### When to use
+
+Provide use cases and situations for when this pattern should be used.
+
+### When not to use
+
+If required, also include a "When not to use" section with details about when
+not to use and suggest alternatives.
+
+### Designing with [pattern variant]
+
+Describe the elements, components, and content that make up the pattern.
+
+Show the variant in context. Use visuals throughout your written commentary to
+illustrate your guidance.
+
+Different patterns require different visuals to best explain the behaviors and
+hierarchy. Choose the options that make the most sense for the story you are
+telling.
+
+- Use annotated wireframes or sketches to explain the visual hierarchy of
+  components.
+- Create high-level user flows to explain the big picture.
+- Create a functional prototype if that is the best way to illustrate the
+  pattern's behavior.
+
+Provide a Sketch file with any symbols you've created in the development of this
+pattern.
+
+### [Pattern variant] behaviors
+
+Describe behaviors specific to the pattern variant, including guidance on
+interactions, and changes in states and content.
+
+### Best practices
+
+List out best practices and include any design considerations that help with
+making choices.
+
+- Do's
+- Dont's
+
+For examples of how to lay out this kind of information, see the
+[Dropdown component](https://www.carbondesignsystem.com/components/dropdown/usage)
+and the
+[Modal component](https://www.carbondesignsystem.com/components/modal/usage#variations).
+
+### Visual guidance
+
+Cover any important topics such as alignment, image choice considerations, or
+special treatments in situations with no data or multiple instances of elements.
+See the
+[Empty states pattern](https://www.carbondesignsystem.com/patterns/empty-states-pattern#visual-guidelines-for-smaller-empty-spaces)
+and the
+[Forms pattern](https://www.carbondesignsystem.com/patterns/forms-pattern#designing-a-form)
+for examples.
+
 ### Other use cases
 
-If there are use cases that require a different solution, include those here
-with corresponding explanations and visuals. Be sure to explain the reasons for
-using one solution over another.
+If there are similar use cases that may require a different solution, include
+details here and explain the reasons for using one solution over another.
+
+Repeat the H2 heading `Pattern variant` with the necessary H3 headings for each
+variant within the pattern.
 
 ## Accessibility
 
@@ -143,3 +398,28 @@ Help us improve this pattern by providing feedback, asking questions, and
 leaving any other comments on
 [GitHub](https://github.com/carbon-design-system/carbon-website/issues/new?assignees=&labels=feedback&template=feedback.md).
 ```
+
+<Caption>Template for patterns with multiple variants</Caption>
+
+## First steps to contributing
+
+If you’ve designed a pattern that is not currently in Carbon, contributing it
+back allows others in the community to refine and use your pattern in their
+projects.
+
+Start by opening a
+[Github issue](https://github.com/carbon-design-system/carbon-website/issues/new).
+Include a detailed description in which you:
+
+- Define your pattern and explain the rationale
+- Include mockups and/or prototypes of any fidelity
+- Clarify whether it uses existing components, new components, or both
+- Include competitive and comparative analysis, and any inspirations from other
+  products
+
+This issue will be the staging ground for the pattern contribution, and you
+should expect the Carbon core team and the community to weigh in with
+suggestions.
+
+We encourage you to surface work in progress. If you’re not able to complete all
+of the parts yourself, someone in the community may be able to help.


### PR DESCRIPTION
This PR updates the existing single pattern template with two types of pattern templates--one for single variant, and one for multiple variants. 

The pattern templates themselves have undergone significant revision to capture what we learned through both the pattern development process and the component usage guidance development process. 