### PR TITLE
update the timing of the weekly dataviz playbacks

### DIFF
--- a/src/pages/whats-happening/meetups/index.mdx
+++ b/src/pages/whats-happening/meetups/index.mdx
@@ -55,7 +55,7 @@ along to see other work in progress and learn that way.
 
 <h2>
   Data visualization weekly playback
-  <span>Wednesdays, 11am–12pm Central</span>
+  <span>Wednesdays, 10am–11am Central</span>
 </h2>
 
 _For IBMers only:_ Are you designing a product with data visualization needs?


### PR DESCRIPTION
starting next week the meetings are happening an hour earlier, which I've reflected in this PR