### PR TITLE
fix(Tabs): set `scrollIntoView` to `false`

### DIFF
--- a/src/pages/components/tabs/code.mdx
+++ b/src/pages/components/tabs/code.mdx
@@ -68,7 +68,7 @@ documentation, see the Storybooks for each framework below.
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=tabs',
     }}>{`
 <div style={{ width: '50%' }}>
-  <Tabs>
+  <Tabs scrollIntoView={false}>
     <Tab
       href="#"
       id="tab-1"

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -56,7 +56,7 @@ Tabs are used to quickly navigate between views within the same context.
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=tabs',
     }}>{`
 <div style={{ width: '50%' }}>
-  <Tabs>
+  <Tabs scrollIntoView={false}>
     <Tab
       href="#"
       id="tab-1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,25 +1105,6 @@
   resolved "https://registry.yarnpkg.com/@carbon/pictograms/-/pictograms-11.2.0.tgz#3ad3842fe82e03a560af2838ca0a47b73a641734"
   integrity sha512-FYWNlMCXC6CXTyZBQCGTJGX/LKmRhc7XIUKTT5pwi7IALnhwol6WjZkVEiOb4ef1N8PhqcLQ//Uc3gEtpAQIpQ==
 
-"@carbon/layout@^10.17.0-rc.0":
-  version "10.17.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/layout/-/layout-10.17.0-rc.0.tgz#bdd4272ce40ed08e554f4650af2c8252fccd4f4e"
-  integrity sha512-IdPSasYLvjAs4D98FUPMDJZa8/TLD7M+M5hCb3kRIscjQEKua9to7ti26yNusszpf5F9ZJJ9porogGqEdTPAcA==
-
-"@carbon/motion@^10.12.0-rc.0":
-  version "10.12.0-rc.0"
-  resolved "https://registry.yarnpkg.com/@carbon/motion/-/motion-10.12.0-rc.0.tgz#3bc9d6ef71ca6c26ed8fa87e4b1e4b5df3addc61"
-  integrity sha512-LXBee8oiPXsfIuvLFyzZO1hDIeOwQOLPAo0HTK3DlYNne/ikPR9pwaj/F3pSyShn4prafdpN3P+NpY4GZOR1Fw==
-
-"@carbon/pictograms-react@^11.2.0-rc.1":
-  version "11.2.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@carbon/pictograms-react/-/pictograms-react-11.2.0-rc.1.tgz#c10a1b1d33513aebeac35cb22c936317f35272ea"
-  integrity sha512-0iFH4F5w0LeWAv2EJ5ii2pVrjq4WsMjFyMOFuK/89zmQsJj/D36ha5k1FWgy9Ka2A8kyCNvPR3W+T8s6XRFsuQ==
-  dependencies:
-    "@carbon/icon-helpers" "^10.12.0-rc.0"
-    "@carbon/telemetry" "0.0.0-alpha.6"
-    prop-types "^15.7.2"
-
 "@carbon/telemetry@0.0.0-alpha.6":
   version "0.0.0-alpha.6"
   resolved "https://registry.yarnpkg.com/@carbon/telemetry/-/telemetry-0.0.0-alpha.6.tgz#1d11e64f310e98f32c3db0c55f02e047f2398087"


### PR DESCRIPTION
Closes #2051

This PR sets the new Tabs `scrollIntoView` prop to `false` to prevent pages from auto scrolling on load when they contain the Tabs component