### PR TITLE
docs: fix tile wording

### DIFF
--- a/src/pages/designing/kits/axure.mdx
+++ b/src/pages/designing/kits/axure.mdx
@@ -48,7 +48,7 @@ Library `+` icon at the top of the Libraries pane. Locate and select the
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
-    subTitle="Get the Axure widget library"
+    subTitle="Axure widget library"
     href="https://github.com/IBM/design-kit/blob/master/Axure/IBM%20Carbon%2010.rplib?raw=true"
     actionIcon="download">
 
@@ -68,7 +68,7 @@ elements.
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
-    subTitle="Get the Axure template"
+    subTitle="Axure template"
     href="https://github.com/IBM/design-kit/blob/master/Axure/ibm-carbon-template.rp?raw=true"
     actionIcon="download">
 

--- a/src/pages/designing/kits/sketch.mdx
+++ b/src/pages/designing/kits/sketch.mdx
@@ -39,7 +39,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       onClick={() => fathom.trackGoal('P0OEN9TS', 0)}
-      subTitle="Get the White theme"
+      subTitle="White theme"
       href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -47,7 +47,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       onClick={() => fathom.trackGoal('T7D1HJ3L', 0)}
-      subTitle="Get the Gray 10 theme"
+      subTitle="Gray 10 theme"
       href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -55,7 +55,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       onClick={() => fathom.trackGoal('LYFJTPDE', 0)}
-      subTitle="Get the Gray 90 theme"
+      subTitle="Gray 90 theme"
       href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -63,7 +63,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       onClick={() => fathom.trackGoal('3XH0SIBJ', 0)}
-      subTitle="Get the Gray 100 theme"
+      subTitle="Gray 100 theme"
       href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -81,21 +81,21 @@ in two different libraries separated by size.
 <Row className="resource-card-group">
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Get the IBM Design Language"
+      subTitle="IBM Design Language"
       href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Get the IBM Icons (16px, 20px)"
+      subTitle="IBM Icons (16px, 20px) library"
       href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
-      subTitle="Get the IBM Icons (24px, 32px)"
+      subTitle="IBM Icons (24px, 32px) library"
       href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -117,14 +117,14 @@ access the saved grid template at `File → New file from Template`.
 <Row className="resource-card-group">
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
-      subTitle="Download the IBM Grid template"
+      subTitle="IBM Grid template"
       href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
-      subTitle="Download the UI Shell template"
+      subTitle="UI Shell template"
       href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
       <MdxIcon name="sketch" />
     </ResourceCard>
@@ -165,63 +165,92 @@ Sketch to begin designing.
 
 ### Grid
 
-The [IBM 2x Grid](/guidelines/2x-grid/overview/) is fundamental to everything we design. It is the geometric foundation of all the visual elements in the IBM Design Language, from typography to columns, boxes, icons, and illustrations. The grid provides structure and guidance for all creative decision-making.
+The [IBM 2x Grid](/guidelines/2x-grid/overview/) is fundamental to everything we
+design. It is the geometric foundation of all the visual elements in the IBM
+Design Language, from typography to columns, boxes, icons, and illustrations.
+The grid provides structure and guidance for all creative decision-making.
 
 ![2x Grid overview](/images/grid-2.gif)
 
 <Caption>2x Grid overview</Caption>
 
 #### Getting started
-All designs should start with the 2x Grid. Once you have [saved the grid](/designing/kits/sketch/#get-the-kit) as a template, in Sketch navigate to **File → New file from Template** and select the `IBM Grid template` to open a new document with preset grid artboards. Either begin working in the new file or copy/paste an artboard into your working file. 
+
+All designs should start with the 2x Grid. Once you
+have [saved the grid](/designing/kits/sketch/#get-the-kit) as a template, in
+Sketch navigate to **File → New file from Template** and select the
+`IBM Grid template` to open a new document with preset grid artboards. Either
+begin working in the new file or copy/paste an artboard into your working file.
 
 #### Layout
 
-The grid layout feature controls and shows the 2x grid columns, gutters, and page margins. To create or edit the layout go to **View → Canvas → Layout Settings...**. 
+The grid layout feature controls and shows the 2x grid columns, gutters, and
+page margins. To create or edit the layout go to **View → Canvas → Layout
+Settings...**.
 
-To toggle seeing the 2x grid columns on an artboard go to **View → Show layout** or use the keyboard shortcut  `Control+L`.
+To toggle seeing the 2x grid columns on an artboard go to **View → Show layout**
+or use the keyboard shortcut  `Control+L`.
 
 #### Grid
 
-To toggle seeing the mini unit grid go to **View → Show grid** or use the keyboard shortcut `Control+G`.
+To toggle seeing the mini unit grid go to **View → Show grid** or use the
+keyboard shortcut `Control+G`.
 
 #### Breakpoints
 
-The layout settings change depending on which size screen you are designing for. See [breakpoints](https://www.carbondesignsystem.com/guidelines/2x-grid/overview/#breakpoints).
-
+The layout settings change depending on which size screen you are designing for.
+See
+[breakpoints](https://www.carbondesignsystem.com/guidelines/2x-grid/overview/#breakpoints).
 
 ### Basic grid
 
-This basic grid is not affected by any influencers and would simply react to the product's breakpoints. Every layout and break points are included in the grid template on the page labeled "Basic grid".
+This basic grid is not affected by any influencers and would simply react to the
+product's breakpoints. Every layout and break points are included in the grid
+template on the page labeled "Basic grid".
 
 ### Grids with an influencer
 
-An influencer is a component that affects the content on the page. It can either appears on a page as the result of a user action or be part of your product's page. These [influencers](/guidelines/2x-grid/overview/#grid-influencers) effect the layout grid by scaling and resizing the columns and its content. You can find an assortment of examples of grids with an influences in the grid template file on the page labeled "Grid influencers". 
+An influencer is a component that affects the content on the page. It can either
+appears on a page as the result of a user action or be part of your product's
+page. These [influencers](/guidelines/2x-grid/overview/#grid-influencers) effect
+the layout grid by scaling and resizing the columns and its content. You can
+find an assortment of examples of grids with an influences in the grid template
+file on the page labeled "Grid influencers".
 
 ### Calculating the Sketch grid
 
 #### Sketch layout settings
 
-Slide-in panels influence the page layout grid; below are some of the specifications for panel combinations and how they impact the grid at all sizes.
+Slide-in panels influence the page layout grid; below are some of the
+specifications for panel combinations and how they impact the grid at all sizes.
 
-- Breakpoint width* = **Artboard width**
-- Breakpoint gutter* = **Left and right outside margins**
-- Total panel width (“sidebar nav”) + Left outside margin + Right outside margin = **Total margins**
+- Breakpoint width\* = **Artboard width**
+- Breakpoint gutter\* = **Left and right outside margins**
+- Total panel width (“sidebar nav”) + Left outside margin + Right outside margin
+  = **Total margins**
 - Artboard width - Total margins = **Total width**
 - Total panel width + Left margin = **Offset**
 
-*Since we are following the Carbon Design responsive guidelines, we referenced [this table](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation#responsive-options) to determine our common breakpoint widths and respective gutter specs.
+\*Since we are following the Carbon Design responsive guidelines, we referenced
+[this table](https://www.carbondesignsystem.com/guidelines/2x-grid/implementation#responsive-options)
+to determine our common breakpoint widths and respective gutter specs.
 
 #### Example
 
-Let’s say we want to create a custom grid for a new design that uses the extra small panel (256px wide) on our x-large 1312px breakpoint. Applying the formula above, your calculations would look like this:
+Let’s say we want to create a custom grid for a new design that uses the extra
+small panel (256px wide) on our x-large 1312px breakpoint. Applying the formula
+above, your calculations would look like this:
 
 - Breakpoint width (1312px) = 1312px wide artboard
-- Breakpoint gutter (32px) = 32px Left outside margin and 32px Right outside margin
+- Breakpoint gutter (32px) = 32px Left outside margin and 32px Right outside
+  margin
 - Total panel width (256px) + 16px Left + 16px Right = 288px Total margins
 - Artboard width (1312px) - Total margins (272px) = **1,056px Total width**
 - Total panel width (256px) + 16px Left = **272px Offset**
 
-*If the grid influencer would cause the content view size to be smaller than 1056, then it would follow the next grid breakpoint setting the columns to 8. Which also avoids columns that are smaller than 32.
+\*If the grid influencer would cause the content view size to be smaller than
+1056, then it would follow the next grid breakpoint setting the columns to 8.
+Which also avoids columns that are smaller than 32.
 
 ### Symbols
 
@@ -236,7 +265,8 @@ There are two kinds of symbols — library symbols and document symbols. Library
 symbols are available in any Sketch document, while document symbols are
 specific to the document in which they are found.
 
-From the main menu select **Insert → Symbols → Carbon Design System** then select the desired symbol to add onto your page.
+From the main menu select **Insert → Symbols → Carbon Design System** then
+select the desired symbol to add onto your page.
 
 Carbon symbols are built to be flexible, and designers should not detach symbols
 from the library. Once a symbol is detached, you will no longer receive updates


### PR DESCRIPTION
This PR fixes the wording on tiles in the Designing section. Tiles don't need to include verbs. 