### PR TITLE
fix(partners): 2028-aat-all-about-carbon-partners-h3-element

### DIFF
--- a/src/pages/all-about-carbon/partners.mdx
+++ b/src/pages/all-about-carbon/partners.mdx
@@ -33,7 +33,28 @@ practitioners to ensure Carbon stays true to the community we're serving.
   collaborators and resources.
 - Provide a quarterly update to the advisory board.
 
-### The people
+<h3
+  class="AutolinkHeader-module--header--1G1tm Markdown-module--h3--Gwbvh"
+  id="the-committee">
+  The people
+  <a
+    class="AutolinkHeader-module--anchor--36UpA AutolinkHeader-module--left-anchor--1SDoO"
+    href="#the-people"
+    aria-label="The people permalink">
+    <svg
+      focusable="false"
+      preserveAspectRatio="xMidYMid meet"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="currentColor"
+      width="20"
+      height="20"
+      viewBox="0 0 32 32"
+      aria-hidden="true">
+      <path d="M29.25,6.76a6,6,0,0,0-8.5,0l1.42,1.42a4,4,0,1,1,5.67,5.67l-8,8a4,4,0,1,1-5.67-5.66l1.41-1.42-1.41-1.42-1.42,1.42a6,6,0,0,0,0,8.5A6,6,0,0,0,17,25a6,6,0,0,0,4.27-1.76l8-8A6,6,0,0,0,29.25,6.76Z"></path>
+      <path d="M4.19,24.82a4,4,0,0,1,0-5.67l8-8a4,4,0,0,1,5.67,0A3.94,3.94,0,0,1,19,14a4,4,0,0,1-1.17,2.85L15.71,19l1.42,1.42,2.12-2.12a6,6,0,0,0-8.51-8.51l-8,8a6,6,0,0,0,0,8.51A6,6,0,0,0,7,28a6.07,6.07,0,0,0,4.28-1.76L9.86,24.82A4,4,0,0,1,4.19,24.82Z"></path>
+    </svg>
+  </a>
+</h3>
 
 <Row>
 


### PR DESCRIPTION
Closes #2028 


- Multiple `The people` titles / id's was causing an accessibility issue. 

## Removed

- Extracted markdown title `The people` into an `h3` element to provide a different id

## Testing 

- [ ] Run Accessibility Checker on the following page `All about Carbon --> Partners` & make sure you do not see the error shown in issue #2028 