### PR TITLE
docs: button variant guidance refinements

### DIFF
--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -76,7 +76,7 @@ actions.
 | _Secondary_ | For secondary actions on each page. Secondary buttons can only be used  in conjunction with a primary button. As part of a pair, the secondary button's function is to perform the negative action of the set, such as Cancel or Back. Do not use a secondary button in isolation and do not use a button for a positive action. |
 | _Tertiary_  | For less prominent, and sometimes independent, actions. Tertiary buttons can be used in isolation  or paired with a primary button when there are multiple calls to action. Tertiary buttons can also be used for sub-tasks on a page where a primary button for the main and final action is present.                           |
 | _Danger_    | For actions that could have destructive effects on the user’s data  (for example, delete or remove). Danger button has three styles: primary, tertiary, and ghost.                                                                                                                                                               |
-| _Ghost_     | For the least pronounced actions. Ghost buttons are often used in conjunction with a primary button, or with a primary and secondary button pair.                                                                                                                                                                                |
+| _Ghost_     | For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for forward action, the secondary button is for "Back", and the ghost button is for "Cancel".       |
 
 ## Live demo
 

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -57,6 +57,11 @@ desired action is to take the user to a new page.
 
 ### Button variants
 
+Each button variant has a particular function and its design signals that
+function to the user. It is therefore very important that the different variants
+are implemented consistently across products, so that they message the correct
+actions.
+
 <Row>
 <Column colLg={12}>
 
@@ -65,13 +70,13 @@ desired action is to take the user to a new page.
 </Column>
 </Row>
 
-| Variant     | Purpose                                                                                                                                                       |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _Primary_   | For the principal call to action on the page. Primary buttons should only appear once per screen (not including the application header or in a modal dialog). |
-| _Secondary_ | For secondary actions on each page; these can only be used  in conjunction with a primary button.                                                             |
-| _Tertiary_  | For less prominent actions; tertiary buttons can be used in isolation  or paired with a primary button when there are multiple calls to action.               |
-| _Danger_    | For actions that could have destructive effects on the user’s data  (for example, delete or remove). Danger button has three styles: primary, tertiary, and ghost.     |
-| _Ghost_     | For the least pronounced actions; often used in conjunction with a primary button.                                                                            |
+| Variant     | Purpose                                                                                                                                                                                                                                                                                                                          |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Primary_   | For the principal call to action on the page. Primary buttons should only appear once per screen (not including the application header or in a modal dialog).                                                                                                                                                                    |
+| _Secondary_ | For secondary actions on each page. Secondary buttons can only be used  in conjunction with a primary button. As part of a pair, the secondary button's function is to perform the negative action of the set, such as Cancel or Back. Do not use a secondary button in isolation and do not use a button for a positive action. |
+| _Tertiary_  | For less prominent, and sometimes independent, actions. Tertiary buttons can be used in isolation  or paired with a primary button when there are multiple calls to action. Tertiary buttons can also be used for sub-tasks on a page where a primary button for the main and final action is present.                           |
+| _Danger_    | For actions that could have destructive effects on the user’s data  (for example, delete or remove). Danger button has three styles: primary, tertiary, and ghost.                                                                                                                                                               |
+| _Ghost_     | For the least pronounced actions. Ghost buttons are often used in conjunction with a primary button, or with a primary and secondary button pair.                                                                                                                                                                                |
 
 ## Live demo
 
@@ -648,8 +653,8 @@ Determining which danger button style to use will depend on the level of
 emphasis you want to give to the danger action. Destructive actions that are
 considered a required or primary step in a workflow should use the primary
 danger button style. However, if a destructive action is just one of several
-actions a user could choose from, then a lower emphasis style like the tertiary danger
-button or the ghost danger button may be more appropriate.
+actions a user could choose from, then a lower emphasis style like the tertiary
+danger button or the ghost danger button may be more appropriate.
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION
This PR is to add clarity around the use of button variants. In particular, the correct use of a secondary button as the negative option for a primary button, and being clear that it cannot be used in isolation or for a positive action. 

This came out of discussions in the January 21. Design Crit. 