### PR TITLE
step-2.mdx Fix library adresses

### DIFF
--- a/src/pages/developing/react-tutorial/step-2.mdx
+++ b/src/pages/developing/react-tutorial/step-2.mdx
@@ -449,10 +449,10 @@ In `app.scss`, add these imports at the **top** of the file so we can use Carbon
 breakpoints, tokens, and typography Sass mixins and functions:
 
 ```scss path=src/app.scss
-@import 'carbon-components/scss/globals/scss/vendor/@carbon/type/scss/font-family.scss';
-@import 'carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/breakpoint.scss';
-@import 'carbon-components/scss/globals/scss/typography.scss';
-@import 'carbon-components/scss/globals/scss/vars.scss';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/type/scss/_font-family.scss';
+@import 'carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/_breakpoint.scss';
+@import 'carbon-components/scss/globals/scss/_typography.scss';
+@import 'carbon-components/scss/globals/scss/_vars.scss';
 ```
 
 ### Banner


### PR DESCRIPTION
In the "Style landing page" section, there are a few libraries to import that must be copied to a file named app.scss. 
All these libraries are written with an underscore "_".

#### Changelog

**New**

@import 'carbon-components/scss/globals/scss/vendor/@carbon/type/scss/_font-family.scss';
@import 'carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/_breakpoint.scss';
@import 'carbon-components/scss/globals/scss/_typography.scss';
@import 'carbon-components/scss/globals/scss/_vars.scss';

**Removed**
import 'carbon-components/scss/globals/scss/vendor/@carbon/type/scss/font-family.scss';
@import 'carbon-components/scss/globals/scss/vendor/@carbon/layout/scss/breakpoint.scss';
@import 'carbon-components/scss/globals/scss/typography.scss';
@import 'carbon-components/scss/globals/scss/vars.scss';