### PR TITLE
Update resource card link

### DIFF
--- a/src/pages/community/patterns/chatbot/overview.mdx
+++ b/src/pages/community/patterns/chatbot/overview.mdx
@@ -132,8 +132,8 @@ guidance related to your use case.
     subTitle="Sketch library"
     title="Chatbot Design Kit"
     aspectRatio="2:1"
-    actionIcon="download"
-    href="sketch://add-library/cloud/d6986eb8-bf0d-4695-abe8-9e79909d4518">
+    actionIcon="launch"
+    href="https://www.sketch.com/s/d6986eb8-bf0d-4695-abe8-9e79909d4518"
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>

--- a/src/pages/community/patterns/chatbot/overview.mdx
+++ b/src/pages/community/patterns/chatbot/overview.mdx
@@ -133,7 +133,7 @@ guidance related to your use case.
     title="Chatbot Design Kit"
     aspectRatio="2:1"
     actionIcon="launch"
-    href="https://www.sketch.com/s/d6986eb8-bf0d-4695-abe8-9e79909d4518"
+    href="https://www.sketch.com/s/d6986eb8-bf0d-4695-abe8-9e79909d4518">
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>


### PR DESCRIPTION
Resource was not downloading but had correct link. Just linking to the Sketch Cloud page for now.
