### PR TITLE
feat: add on demand and scheduled image processing

### DIFF
--- a/.github/workflows/process-images.yml
+++ b/.github/workflows/process-images.yml
@@ -1,18 +1,28 @@
-name: Compress images
+# Compress images on demand (workflow_dispatch), and at 11pm every Sunday (schedule).
+# Open a Pull Request if any images can be compressed.
+name: Compress Images
 on:
-  pull_request:
-    paths:
-      - '**.jpg'
-      - '**.png'
-      - '**.webp'
+  workflow_dispatch:
+  schedule:
+    - cron: '00 23 * * 0'
 jobs:
   build:
     name: calibreapp/image-actions
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Compress Images
-        uses: calibreapp/image-actions@master
+        id: calibre
+        uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          compressOnly: true
+      - name: Create New Pull Request If Needed
+        if: steps.calibre.outputs.markdown != ''
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Compressed Images Nightly
+          branch-suffix: timestamp
+          commit-message: Compressed Images
+          body: ${{ steps.calibre.outputs.markdown }}


### PR DESCRIPTION
This updates the image processing to allow for running on-demand and scheduled (once a week on Sunday). This prevents the bot from cluttering (sometimes unrelated) pull requests, which has been a source of confusion during code reviews.

After manually triggering the action in a fork, the bot[ successfully opened a PR shaving off 10mb](https://github.com/vpicone/carbon-website/pull/2) from the images.

**Changed**
- update image processing action configuration

