### PR TITLE
[button] update icon-only guidance

### DIFF
--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -632,9 +632,7 @@ a text label, but use icon buttons cautiously.
 
 ### Icon-only buttons
 
-Icon buttons allow users to take actions, and make choices, with a single tap.
-Icon buttons can take the form of any of the five variants above but most
-commonly will be styled as primary or ghost buttons.
+Icon buttons allow users to take actions, and make choices, with a single tap. Icon buttons can take the form of a primary, secondary, tertiary or ghost variant but most commonly will be styled as primary or ghost buttons.
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -632,7 +632,7 @@ a text label, but use icon buttons cautiously.
 
 ### Icon-only buttons
 
-Icon buttons allow users to take actions, and make choices, with a single tap. Icon buttons can take the form of a primary, secondary, tertiary or ghost variant but most commonly will be styled as primary or ghost buttons.
+Icon buttons allow users to take actions, and make choices, with a single tap. Icon buttons can take the form of a primary, secondary, tertiary, or ghost variant but most commonly will be styled as primary or ghost buttons.
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION
We do not support a danger icon-only button. It only is available in the primary, secondary, tertiary and ghost variants.

**Changed**

- Icon-only buttons: Edited out that we support danger icon-only buttons.
