### PR TITLE
fix: remove robin from team

### DIFF
--- a/src/pages/all-about-carbon/the-team.mdx
+++ b/src/pages/all-about-carbon/the-team.mdx
@@ -33,11 +33,6 @@ and successful in designing digital experiences and products.
 ![Josh Black headshot](/images/team/black_josh.png)
 
 </Profile>
-<Profile name="Robin Cannon" title="Program Director">
-
-![Robin Cannon headshot](/images/team/cannon_robin.png)
-
-</Profile>
 <Profile name="Andrea Cardona" title="Front-end Developer">
 
 ![Andrea Cardona headshot](/images/team/cardona_andrea.png)


### PR DESCRIPTION
Keeps Robin's image around for use in the Partners page.