### PR TITLE
docs: inclusive language update in content guidelines

### DIFF
--- a/src/pages/guidelines/content/writing-style.mdx
+++ b/src/pages/guidelines/content/writing-style.mdx
@@ -20,7 +20,7 @@ over long impressive-sounding words. Put the thesaurus away!
 <AnchorLink>Capitalization</AnchorLink>
 <AnchorLink>Simple writing</AnchorLink>
 <AnchorLink>Conversational style</AnchorLink>
-<AnchorLink>Inclusive terminology</AnchorLink>
+<AnchorLink>Inclusive language</AnchorLink>
 <AnchorLink>Pronouns</AnchorLink>
 <AnchorLink>Active and passive voice</AnchorLink>
 
@@ -403,7 +403,7 @@ work, generally go with “might” to avoid confusion with the multiple meaning
   />
 </DoDontRow>
 
-## Inclusive terminology
+## Inclusive language
 
 IBM is committed to eliminating language that supports racial, cultural, or
 gender bias. It is critical that all words used in any capacity in product

--- a/src/pages/guidelines/content/writing-style.mdx
+++ b/src/pages/guidelines/content/writing-style.mdx
@@ -405,36 +405,11 @@ work, generally go with “might” to avoid confusion with the multiple meaning
 
 ## Inclusive terminology
 
-It is critical that all words used in any capacity in product offerings be
-inclusive in its language.
+IBM is committed to eliminating language that supports racial, cultural, or
+gender bias. It is critical that all words used in any capacity in product
+offerings be inclusive in their language.
 
-The following terms represent guidance that content designers can use to improve
-the inclusiveness of our offerings:
-
-- The terms "blacklist" and "whitelist" are prohibited for future use. Instead,
-  use the terms "blocklist" and "allowlist". To refer to the action of adding
-  items to a blocklist or allowlist, use the verbs "block" and "allow".
-- The term "slave" is prohibited in all IBM content, along with the term
-  "master" in the sense of "superior". Instead of slave, use another term such
-  as "worker", "child", "helper", "replica", or "secondary". Instead of
-  "master," use a term such as "controller", "leader", "manager", "main",
-  "coordinator", "parent", or "primary".
-- When you must refer to prohibited terms because they occur in a product from
-  another company, make it clear that these terms are not from IBM. Use the
-  verbs "block" and "allow" to refer to the action of adding items to another
-  company's "blacklist" or "whitelist".
-
-Other considerations apply for inclusive writing, including to avoid gender
-bias. As an example, do not assume that the subject of a sentence is male if the
-context might refer to any gender. Thus, instead of using "man hours", use
-"labor hours" or "person hours".
-
-Sometimes, you can rewrite a sentence to use the second person ("you"). For
-example, instead of writing "The user can now move his cursor in four
-directions", write "You can now move your cursor in four directions". It is also
-acceptable to use "they" to refer to a singular subject.
-
-IBMers who are unsure about a particular word, can search the
+IBMers who are unsure about a particular word can search the
 [IBM Terminology database](http://ibm.biz/termsearch), and can
 also [submit a term for review](http://tlwi.w3-969.ibm.com/standards/terminology/feedbackform2.html).
 


### PR DESCRIPTION
Simplified the section on Inclusive language in the Content guidelines. Less is more!   
