### PR TITLE
fix(overlay): remove overlay on mobile

### DIFF
--- a/src/styles/_homepage.scss
+++ b/src/styles/_homepage.scss
@@ -81,3 +81,7 @@
 .resource-card-group .bx--col-lg-4:nth-child(even) .bx--resource-card--dark {
   border-left-color: #000;
 }
+
+.bx--side-nav__overlay-active {
+  width: 100%;
+}


### PR DESCRIPTION
Rel https://github.com/carbon-design-system/carbon/pull/7891

Prevents overlay from showing on mobile by default, unless it is expanded




