### PR TITLE
(fix) broken link on icon contribution tab

### DIFF
--- a/src/pages/guidelines/icons/contribute.mdx
+++ b/src/pages/guidelines/icons/contribute.mdx
@@ -30,7 +30,7 @@ guidelines to ensure visual consistency and proper formatting.
   associated with your proposed new icon to ensure that it is not already
   represented.
 - All icons should adhere to the
-  [IBM Design Language visual style](https://w3.ibm.com/design/language/elements/icons/).
+  [IBM Design Language visual style](https://www.ibm.com/design/language/iconography/ui-icons/design).
 - All icons should comply with IBM
   [accessibility standards](/guidelines/accessibility/overview).
 - All icons should be usable across all supported platforms and devices.


### PR DESCRIPTION
**Changed**
- Fixed a broken link on the Icon Contribution tab. It now directs to the correct guidance on the IDL site.

---

**Testing**
- Go to Guidelines -> Icons -> Contribute tab. Ensure the `IBM Design Language visual style` link points to the UI icon design tab on IDL.