### PR TITLE
(fix) broken link to heat maps section on advanced charts

### DIFF
--- a/src/pages/data-visualization/advanced-charts/index.mdx
+++ b/src/pages/data-visualization/advanced-charts/index.mdx
@@ -294,7 +294,7 @@ hierarchical structure of a tree map. Each rectangle has an area proportional to
 a specified dimension of the data, but the rectangles can also be colored
 independently according to an additional indicator.
 
-As with [heat maps](../data-visualization/advanced-charts#heat-maps), the
+As with [heat maps](#heat-maps), the
 diverging palette shows color progression in either direction from an inflection
 point (for example, a 0 value midway between -10 and +10). In the example below,
 the inflection point is simply an average. Tourism can be mapped by the number


### PR DESCRIPTION
On [advanced charts page](https://www.carbondesignsystem.com/data-visualization/advanced-charts) we currently use a relative path that [resolves in a 404](https://www.carbondesignsystem.com/404/#heat-maps). Since [heat maps](https://www.carbondesignsystem.com/data-visualization/advanced-charts/#heat-maps) are part of this page now, we can point straight to that section.

#### Changelog

**Changed**

- Fixed a broken link to the heat maps section on advanced charts.

----

**Testing**

- Go to Data visualization → [Advanced charts](https://carbondesignsy-git-fork-alex-ju-patch-1-carbon-design-10a1aa.vercel.app/data-visualization/advanced-charts/). Search for 'As with heat maps' or scroll down the page to reach that paragraph and check the link points to the heat maps section above.
