### PR TITLE
add Gatsby theme library resource card

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -137,6 +137,15 @@ design kit, visit the [Design kits](/designing/kits/sketch) page.
   </ResourceCard>
 </Column>
 
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Gatsby theme library"
+    href="sketch://add-library/cloud/304313c1-29a8-4946-a6f0-51dbec953bc2"
+    actionIcon="download">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+
 </Row>
 
 ## Fonts


### PR DESCRIPTION
**New**
- Added the Gatsby theme sketch library resource card link to our design resources.

----

**Testing**
- Navigate to `Designing` -> `Other resources` page -> `Extensions` section
- Make sure the resource card shows up correctly and links out to the library to download