### PR TITLE
docs: adding new Gatsby kit, page reorg

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -1,37 +1,53 @@
 ---
 title: Other resources
 description:
-  Everything you need to learn about and work with Carbon, including Sketch
-  libraries and templates, color palettes, fonts, GitHub repos, and design
-  tools.
+  Everything you need to work with Carbon, including Sketch libraries and
+  templates, color palettes, fonts, GitHub repos, and design tools.
 ---
 
 <PageDescription>
 
-Everything you need to learn about and work with Carbon, Sketch libraries and
+Everything you need to work with Carbon, including Sketch libraries and
 templates, color palettes, GitHub repos, and design tools.
 
 </PageDescription>
 
 <AnchorLinks>
   <AnchorLink>Introduction</AnchorLink>
+  <AnchorLink>Data visualization Sketch file</AnchorLink>
   <AnchorLink>Elements</AnchorLink>
   <AnchorLink>Extensions</AnchorLink>
   <AnchorLink>Fonts</AnchorLink>
+  <AnchorLink>Gatsby theme Sketch kit</AnchorLink>
   <AnchorLink>GitHub repos</AnchorLink>
 </AnchorLinks>
 
 ## Introduction
 
-Carbon expresses the [IBM Design Language](https://www.ibm.com/design/language/)
-in product and delivers it through tools for designers and developers including
-guidance, tooling, components, and support. Take the time to read the design
-language site so that you fully understand what drives IBM's design philosophy
-and principles, and can make informed decisions in your product design work.
+This page includes Sketch kits, tools, templates, and various extensions that
+have been created to help you get up and running.
 
 To use the Sketch libraries you'll find here, you need the **most recent
 version** of [Sketch](https://www.sketch.com/) installed. If you’re new to the
 design kit, visit the [Design kits](/designing/kits/sketch) page.
+
+## Data visualization Sketch file
+
+The Data visualization Sketch file includes basic and complex chart assets,
+along with usage guidance, theming guidance, palettes, and sample layouts.
+You'll find even more guidance and assets in this file than on the site.
+
+<Row className="resource-card-group">
+
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Data visualization Sketch file"
+    href="https://www.sketch.com/s/1a36060a-7a5d-4ddb-aab1-639caa1f74d4"
+    actionIcon="download">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+</Row>
 
 ## Elements
 
@@ -103,15 +119,6 @@ design kit, visit the [Design kits](/designing/kits/sketch) page.
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="Data visualization master Sketch file"
-    href="https://www.sketch.com/s/1a36060a-7a5d-4ddb-aab1-639caa1f74d4"
-    actionIcon="download">
-    <MdxIcon name="sketch" />
-  </ResourceCard>
-</Column>
-
-<Column colLg={4} colMd={4} noGutterSm>
-  <ResourceCard
     subTitle="Carbon mobile Sketch kit"
     href="https://www.sketch.com/s/a3343128-adb6-489c-9e62-709d89ba76e9"
     actionIcon="launch">
@@ -144,6 +151,25 @@ design kit, visit the [Design kits](/designing/kits/sketch) page.
 Carbon uses the open-source typeface [IBM Plex](https://github.com/ibm/plex) –
 carefully designed to meet IBM's needs as a global technology company and
 reflect IBM's spirit, beliefs, and design principles.
+
+## Gatsby theme Sketch kit
+
+For anyone working on a Gatsby-themed site, this updated Sketch kit has all the
+components, patterns, and sample layouts that have been developed by teams
+within the IBM ecosystem. A great resource for designers working on new pages
+for PAL sites or any other sites using the Gatsby theme.
+
+<Row className="resource-card-group">
+
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Gatsby theme Sketch kit"
+    href="sketch://add-library/cloud/304313c1-29a8-4946-a6f0-51dbec953bc2"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+</Row>
 
 ## GitHub repos
 


### PR DESCRIPTION
This PR adds the new and improved Gatsby kit to the Other resources page. Also did a bit of a page re-org. 

To view go to **Designing > Other resources**.