### PR TITLE
add link to Carbon Svelte components on home page

### DIFF
--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -103,6 +103,15 @@ building websites and user interfaces.
 
   </ResourceCard>
 </Column>
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    color="dark"
+    subTitle="Carbon Svelte components"
+    href="https://github.com/IBM/carbon-components-svelte"
+    >
+    <MdxIcon name="github" color="inverse" />
+  </ResourceCard>
+</Column>
 </Row>
 
 ### Latest news and articles


### PR DESCRIPTION
This PR adds a link under "Other Resources" on the home page that links to the [Carbon Svelte GitHub repository](https://github.com/IBM/carbon-components-svelte).

**Changed**

- add resource card linking to Carbon Svelte components on the home page

![ccs-home](https://user-images.githubusercontent.com/10718366/113343087-2d96fa00-92e4-11eb-9106-7b58dc89ab0b.png)

