### PR TITLE
docs: adding resources for mobile, reorganizing Other resources

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -20,6 +20,8 @@ templates, color palettes, GitHub repos, and design tools.
   <AnchorLink>Fonts</AnchorLink>
   <AnchorLink>Gatsby theme Sketch kit</AnchorLink>
   <AnchorLink>GitHub repos</AnchorLink>
+  <AnchorLink>Mobile Sketch resources</AnchorLink>
+
 </AnchorLinks>
 
 ## Introduction
@@ -192,6 +194,48 @@ for PAL sites or any other sites using the Gatsby theme.
 
 <MdxIcon name="github" />
 
+  </ResourceCard>
+</Column>
+</Row>
+
+## Mobile Sketch resources
+
+These Carbon mobile Sketch resources include everything you need to get your iOS
+or Android project underway. Install the grid template, be inspired by the
+patterns and examples, and get started with either the Light or Dark theme.
+
+<Row className="resource-card-group">
+
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Light theme for mobile"
+    href="sketch://add-library/cloud/s/a3343128-adb6-489c-9e62-709d89ba76e9"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Dark theme for mobile"
+    href="sketch://add-library/cloud/s/1f59f590-6915-47b0-bf06-6fd66209b3b3"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="IBM Grid template for mobile"
+    href="https://www.sketch.com/s/42e694ee-4b37-41c9-8c8f-480e2415d9de"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Mobile patterns and examples"
+    href="https://www.sketch.com/s/f13d67b9-3116-4b50-a2e9-56148f1976b0"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>
 </Row>

--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -210,7 +210,7 @@ patterns and examples, and get started with either the Light or Dark theme.
   <ResourceCard
     subTitle="Light theme for mobile"
     href="sketch://add-library/cloud/s/a3343128-adb6-489c-9e62-709d89ba76e9"
-    actionIcon="launch">
+    actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>

--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -121,15 +121,6 @@ You'll find even more guidance and assets in this file than on the site.
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="Carbon mobile Sketch kit"
-    href="https://www.sketch.com/s/a3343128-adb6-489c-9e62-709d89ba76e9"
-    actionIcon="launch">
-    <MdxIcon name="sketch" />
-  </ResourceCard>
-</Column>
-
-<Column colLg={4} colMd={4} noGutterSm>
-  <ResourceCard
     subTitle="UI Shell template"
     href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
     actionIcon="launch">
@@ -167,7 +158,7 @@ for PAL sites or any other sites using the Gatsby theme.
   <ResourceCard
     subTitle="Gatsby theme Sketch kit"
     href="sketch://add-library/cloud/304313c1-29a8-4946-a6f0-51dbec953bc2"
-    actionIcon="launch">
+    actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>

--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -218,7 +218,7 @@ patterns and examples, and get started with either the Light or Dark theme.
   <ResourceCard
     subTitle="Dark theme for mobile"
     href="sketch://add-library/cloud/s/1f59f590-6915-47b0-bf06-6fd66209b3b3"
-    actionIcon="launch">
+    actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>


### PR DESCRIPTION
This PR updates the **Designing > Other resources** page by: 

- Creating a new section for mobile Sketch resources, and
- Adding the Dark theme, the grid template for mobile, and patterns and examples  
