### PR TITLE
Fix mismatching anchor linked title

### DIFF
--- a/src/pages/guidelines/2x-grid/overview.mdx
+++ b/src/pages/guidelines/2x-grid/overview.mdx
@@ -215,7 +215,7 @@ item, scale boxes and use fixed column counts.
 
 </AnchorLinks>
 
-### Fluid grid
+### Fluid columns
 
 Fluid column structures are ideal for editorial content, dashboards, images,
 video, data visualizations, etc. In each case, scaling the size of things is


### PR DESCRIPTION
Link in documentation was not working because the title didn't match with the anchor link text.