### PR TITLE
docs(Button): update fluid button border docs

### DIFF
--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -70,13 +70,13 @@ actions.
 </Column>
 </Row>
 
-| Variant     | Purpose                                                                                                                                                                                                                                                                                                                                        |
-| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _Primary_   | For the principal call to action on the page. Primary buttons should only appear once per screen (not including the application header, modal dialog, or side panel).                                                                                                                                                                          |
-| _Secondary_ | For secondary actions on each page. Secondary buttons can only be used  in conjunction with a primary button. As part of a pair, the secondary button's function is to perform the negative action of the set, such as "Cancel" or "Back". Do not use a secondary button in isolation and do not use a secondary button for a positive action. |
-| _Tertiary_  | For less prominent, and sometimes independent, actions. Tertiary buttons can be used in isolation  or paired with a primary button when there are multiple calls to action. Tertiary buttons can also be used for sub-tasks on a page where a primary button for the main and final action is present.                                         |
-| _Danger_    | For actions that could have destructive effects on the user’s data  (for example, delete or remove). Danger button has three styles: primary, tertiary, and ghost.                                                                                                                                                                             |
-| _Ghost_     | For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for forward action, the secondary button is for "Back", and the ghost button is for "Cancel".                     |
+| Variant     | Purpose                                                                                                                                                                                                                                                                                                                                       |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| _Primary_   | For the principal call to action on the page. Primary buttons should only appear once per screen (not including the application header, modal dialog, or side panel).                                                                                                                                                                         |
+| _Secondary_ | For secondary actions on each page. Secondary buttons can only be used in conjunction with a primary button. As part of a pair, the secondary button's function is to perform the negative action of the set, such as "Cancel" or "Back". Do not use a secondary button in isolation and do not use a secondary button for a positive action. |
+| _Tertiary_  | For less prominent, and sometimes independent, actions. Tertiary buttons can be used in isolation or paired with a primary button when there are multiple calls to action. Tertiary buttons can also be used for sub-tasks on a page where a primary button for the main and final action is present.                                         |
+| _Danger_    | For actions that could have destructive effects on the user’s data (for example, delete or remove). Danger button has three styles: primary, tertiary, and ghost.                                                                                                                                                                             |
+| _Ghost_     | For the least pronounced actions; often used in conjunction with a primary button. In a situation such as a progress flow, a ghost button may be paired with a primary and secondary button set, where the primary button is for forward action, the secondary button is for "Back", and the ghost button is for "Cancel".                    |
 
 ## Live demo
 
@@ -315,7 +315,7 @@ button locations include:
 | Alignment         | Use case                                                                                                                                                        |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | _Left-justified_  | Banner call to actions, in-page forms, and nested buttons in components like tiles                                                                              |
-| _Right-justified_ | Inline notifications, inline field buttons and  data tables, progressive forms, wizards, and single-button dialogs                                              |
+| _Right-justified_ | Inline notifications, inline field buttons and data tables, progressive forms, wizards, and single-button dialogs                                               |
 | _Full-span_       | Dialogs, side panels, and small tiles; currently Carbon does not offer a way to implement full-span buttons in code, without an override, they max out at 320px |
 
 #### Fluid versus fixed buttons
@@ -362,12 +362,12 @@ Other fluid components include tiles and most recently,
 #### Fluid button border
 
 Many product designers have approached us looking for more guidance around
-borders between all fluid buttons. Although we haven’t made
-[this update](https://github.com/carbon-design-system/carbon/issues/5638) yet,
-we plan to add a 1px border between all fluid buttons that calls the `$ui-03`
-token for subtle borders. This feature will add a 3:1 distinction between the
-two interactive UI elements. The border is a recommended feature to improve
-accessibility in data visualizations and the same logic should apply here.
+borders between all fluid buttons. In a
+[recent update](https://github.com/carbon-design-system/carbon/issues/5638), we
+added a 1px border between all fluid buttons that call the `$ui-03` token for
+subtle borders. This feature adds a 3:1 distinction between the two interactive
+UI elements. The border is a recommended feature to improve accessibility in
+data visualizations, and the same logic should apply here.
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION
Noticed in a [comment](https://github.com/carbon-design-system/carbon/issues/5638#issuecomment-819484700) in https://github.com/carbon-design-system/carbon/issues/5638

Updates the wordage around fluid button borders now that the associated PR has been merged.

#### Changelog

**Changed**

- Updated wordage from planned to implemented 

