### PR TITLE
docs: update WIP page

### DIFF
--- a/src/pages/whats-happening/work-in-progress/index.mdx
+++ b/src/pages/whats-happening/work-in-progress/index.mdx
@@ -31,31 +31,6 @@ Not everything here may make it into production, while other pieces might become
 central pieces of the design system. It's an early opportunity for you to
 provide feedback and have a say in Carbon's direction.
 
-### Tools and resources
-
-**React Native Sketch kits for mobile**
-
-<CardGroup>
-  <MiniCard
-    title="Light theme"
-    href="sketch://add-library/cloud/a3343128-adb6-489c-9e62-709d89ba76e9"
-    actionIcon="launch"
-    onClick={() => fathom.trackGoal('GZNMLWPV', 0)}
-  />
-  <MiniCard
-    title="Dark theme"
-    href="sketch://add-library/cloud/1f59f590-6915-47b0-bf06-6fd66209b3b3"
-    actionIcon="launch"
-    onClick={() => fathom.trackGoal('BHFADJ59', 0)}
-  />
-  <MiniCard
-    title="IBM Grid template"
-    href="https://www.sketch.com/s/42e694ee-4b37-41c9-8c8f-480e2415d9de"
-    actionIcon="launch"
-    onClick={() => fathom.trackGoal('TWMSHNQP', 0)}
-  />
-</CardGroup>
-
 ### Components and patterns
 
 <CardGroup>


### PR DESCRIPTION
Removes Mobile Sketch kits from WIP page as these are now available in Designing > Other Resources 