### PR TITLE
fix(modal): correct the 'max-width' sizing to 'width' property

### DIFF
--- a/src/pages/components/modal/style.mdx
+++ b/src/pages/components/modal/style.mdx
@@ -154,12 +154,12 @@ browser but will still align to columns on the 2x grid.
 Each modal size has a max height and width in order to maintain a proper window
 ratio.
 
-| Modal size  | Max-height | Max-width |
-| ----------- | ---------- | --------- |
-| **XS**      | 48%        | 420px     |
-| **Small**   | 72%        | 576px     |
-| **Default** | 84%        | 768px     |
-| **Large**   | 96%        | –         |
+| Modal size  | Max-height | Width |
+| ----------- | ---------- | ----- |
+| **XS**      | 48%        | 420px |
+| **Small**   | 72%        | 576px |
+| **Default** | 84%        | 768px |
+| **Large**   | 96%        | –     |
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION
Minor update to the modal style docs to match the actual properties used for sizing. `max-width` is not applied to the modal, it's just a `width`. [Example](https://github.com/carbon-design-system/carbon/blob/647ec1e752bc004f39743e5b6e2d45061a6ab843/packages/components/src/components/modal/_modal.scss#L167)

#### Changelog

**Changed**

- fix(modal): correct the 'max-width' sizing to 'width' property
