### PR TITLE
docs: update storybook links

### DIFF
--- a/src/pages/components/accordion/code.mdx
+++ b/src/pages/components/accordion/code.mdx
@@ -20,7 +20,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/accordion--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-accordion--accordion"
     >
 
 <MdxIcon name="react" />
@@ -66,7 +66,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/accordion--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-accordion--accordion',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-accordion--basic',
       Vue:

--- a/src/pages/components/accordion/usage.mdx
+++ b/src/pages/components/accordion/usage.mdx
@@ -63,7 +63,7 @@ extra click; instead use a full scrolling page with normal headers.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/accordion--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-accordion--accordion',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-accordion--basic',
       Vue:

--- a/src/pages/components/breadcrumb/code.mdx
+++ b/src/pages/components/breadcrumb/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/breadcrumb--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-breadcrumb--breadcrumb"
     >
 
 <MdxIcon name="react" />
@@ -62,7 +62,7 @@ usage documentation, see the Storybooks for each framework below.
     id="currentPage"
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/breadcrumb--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-breadcrumb--breadcrumb',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-breadcrumb--basic',
       Vue:
@@ -79,7 +79,7 @@ usage documentation, see the Storybooks for each framework below.
     id="breadcrumb"
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/breadcrumb--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-breadcrumb--breadcrumb',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-breadcrumb--basic',
       Vue:

--- a/src/pages/components/breadcrumb/usage.mdx
+++ b/src/pages/components/breadcrumb/usage.mdx
@@ -73,7 +73,7 @@ type used should be consistent across a product.
     id="currentPage"
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/breadcrumb--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-breadcrumb--breadcrumb',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-breadcrumb--basic',
       Vue:
@@ -90,7 +90,7 @@ type used should be consistent across a product.
     id="breadcrumb"
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/breadcrumb--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-breadcrumb--breadcrumb',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-breadcrumb--basic',
       Vue:

--- a/src/pages/components/button/code.mdx
+++ b/src/pages/components/button/code.mdx
@@ -21,7 +21,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/button--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-button--default"
     >
 
 <MdxIcon name="react" />
@@ -75,7 +75,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/buttons--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:
@@ -91,7 +91,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/buttons--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:
@@ -107,7 +107,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/buttons--icon-only-buttons',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--icon-button',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -105,7 +105,7 @@ import { Add16 } from '@carbon/icons-react';
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/buttons--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:
@@ -121,7 +121,7 @@ import { Add16 } from '@carbon/icons-react';
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/buttons--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:
@@ -137,7 +137,7 @@ import { Add16 } from '@carbon/icons-react';
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/buttons--icon-only-buttons',
+        'https://react.carbondesignsystem.com/?path=/story/components-button--icon-button',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-button--basic',
       Vue:

--- a/src/pages/components/checkbox/code.mdx
+++ b/src/pages/components/checkbox/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/checkbox--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-checkbox--checkbox"
     >
 
 <MdxIcon name="react" />
@@ -62,7 +62,7 @@ documentation, see the Storybooks for each framework below.
     knobs={{ Checkbox: ['indeterminate', 'disabled', 'hideLabel'] }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/checkbox--checked',
+        'https://react.carbondesignsystem.com/?path=/story/components-checkbox--checkbox',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-checkbox--basic',
       Vue:

--- a/src/pages/components/checkbox/usage.mdx
+++ b/src/pages/components/checkbox/usage.mdx
@@ -101,7 +101,7 @@ set whereas radio buttons allow the user to select only one option.
     knobs={{ Checkbox: ['indeterminate', 'disabled', 'hideLabel'] }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/checkbox--checked',
+        'https://react.carbondesignsystem.com/?path=/story/components-checkbox--checkbox',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-checkbox--basic',
       Vue:

--- a/src/pages/components/code-snippet/code.mdx
+++ b/src/pages/components/code-snippet/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/codesnippet--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-codesnippet--inline"
     >
 
 <MdxIcon name="react" />
@@ -76,7 +76,7 @@ import {
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/codesnippet--singleline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--singleline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:
@@ -92,7 +92,7 @@ import {
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/codesnippet--inline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--multiline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:
@@ -108,7 +108,7 @@ import {
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/codesnippet--inline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--inline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:

--- a/src/pages/components/code-snippet/usage.mdx
+++ b/src/pages/components/code-snippet/usage.mdx
@@ -81,7 +81,7 @@ length use cases—inline, single line, and multi-line.
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/codesnippet--singleline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--singleline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:
@@ -95,7 +95,7 @@ length use cases—inline, single line, and multi-line.
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/codesnippet--multiline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--multiline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:
@@ -111,7 +111,7 @@ length use cases—inline, single line, and multi-line.
     knobs={{ CodeSnippet: ['light'] }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/codesnippet--inline',
+        'https://react.carbondesignsystem.com/?path=/story/components-codesnippet--inline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-code-snippet--basic',
       Vue:

--- a/src/pages/components/content-switcher/code.mdx
+++ b/src/pages/components/content-switcher/code.mdx
@@ -20,7 +20,7 @@ code usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/contentswitcher--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-contentswitcher--default"
     >
 
 <MdxIcon name="react" />
@@ -65,7 +65,7 @@ code usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/contentswitcher--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-contentswitcher--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-content-switcher--basic',
       Vue:

--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -78,7 +78,7 @@ binary decision.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/contentswitcher--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-contentswitcher--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-content-switcher--basic',
       Vue:

--- a/src/pages/components/data-table/code.mdx
+++ b/src/pages/components/data-table/code.mdx
@@ -26,7 +26,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/datatable--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-datatable--usage"
     >
 
 <MdxIcon name="react" />
@@ -82,7 +82,7 @@ usage documentation, see the Storybooks for each framework below.
     knobs={{ DataTable: ['isSortable'], Table: ['size', 'useZebraStyles'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--basic',
       Vue:
@@ -121,7 +121,7 @@ usage documentation, see the Storybooks for each framework below.
     knobs={{ DataTable: ['isSortable'], Table: ['size', 'useZebraStyles'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-selection--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-selection--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--basic',
       Vue:
@@ -169,7 +169,7 @@ usage documentation, see the Storybooks for each framework below.
     knobs={{ DataTable: ['isSortable'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-expansion--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-expansion--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--with-expansion',
       Vue:
@@ -217,7 +217,7 @@ usage documentation, see the Storybooks for each framework below.
     id="with-batch-actions"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-batch-actions--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-batch-actions--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--with-toolbar',
       Vue:

--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -90,7 +90,7 @@ import {
     knobs={{ DataTable: ['isSortable'], Table: ['size', 'useZebraStyles'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--basic',
       Vue:
@@ -129,7 +129,7 @@ import {
     knobs={{ DataTable: ['isSortable'], Table: ['size', 'useZebraStyles'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-selection--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-selection--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--basic',
       Vue:
@@ -177,7 +177,7 @@ import {
     knobs={{ DataTable: ['isSortable'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-expansion--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-expansion--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--with-expansion',
       Vue:
@@ -225,7 +225,7 @@ import {
     id="with-batch-actions"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datatable-batch-actions--usage',
+        'https://react.carbondesignsystem.com/?path=/story/components-datatable-batch-actions--usage',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-table--with-toolbar',
       Vue:

--- a/src/pages/components/date-picker/code.mdx
+++ b/src/pages/components/date-picker/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/datepicker--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-datepicker--simple"
     >
 
 <MdxIcon name="react" />
@@ -77,7 +77,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--simple',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--simple',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--simple',
       Vue:
@@ -100,7 +100,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--single-with-calendar',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--single',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--single',
       Vue:
@@ -123,7 +123,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--range-with-calendar',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--range',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--range',
       Vue:
@@ -152,7 +152,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/timepicker--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-timepicker--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-time-picker--simple',
       Vue:

--- a/src/pages/components/date-picker/usage.mdx
+++ b/src/pages/components/date-picker/usage.mdx
@@ -77,7 +77,7 @@ for scheduling tasks.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--simple',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--simple',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--simple',
       Vue:
@@ -100,7 +100,7 @@ for scheduling tasks.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--single-with-calendar',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--single',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--single',
       Vue:
@@ -123,7 +123,7 @@ for scheduling tasks.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/datepicker--range-with-calendar',
+        'https://react.carbondesignsystem.com/?path=/story/components-datepicker--range',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-date-picker--range',
       Vue:
@@ -152,7 +152,7 @@ for scheduling tasks.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/timepicker--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-timepicker--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-time-picker--simple',
       Vue:

--- a/src/pages/components/dropdown/code.mdx
+++ b/src/pages/components/dropdown/code.mdx
@@ -21,7 +21,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/dropdown--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-dropdown--default"
     >
 
 <MdxIcon name="react" />
@@ -79,7 +79,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/dropdown--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-dropdown--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -101,7 +101,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/combobox--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-combobox--combobox',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -123,7 +123,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/multiselect--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-multiselect--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -142,7 +142,7 @@ documentation, see the Storybooks for each framework below.
     id="filter-multiselect"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/multiselect--filterable',
+        'https://react.carbondesignsystem.com/?path=/story/components-multiselect--filterable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:

--- a/src/pages/components/dropdown/usage.mdx
+++ b/src/pages/components/dropdown/usage.mdx
@@ -96,7 +96,7 @@ functionality—dropdown, multiselect, and combo box.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/dropdown--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-dropdown--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -118,7 +118,7 @@ functionality—dropdown, multiselect, and combo box.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/combobox--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-combobox--combobox',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -140,7 +140,7 @@ functionality—dropdown, multiselect, and combo box.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/multiselect--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-multiselect--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:
@@ -159,7 +159,7 @@ functionality—dropdown, multiselect, and combo box.
     id="filter-multiselect"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/multiselect--filterable',
+        'https://react.carbondesignsystem.com/?path=/story/components-multiselect--filterable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-dropdown--basic',
       Vue:

--- a/src/pages/components/file-uploader/code.mdx
+++ b/src/pages/components/file-uploader/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/fileuploader--fileuploader"
+    href="https://react.carbondesignsystem.com/?path=/story/components-fileuploader--file-uploader"
     >
 
 <MdxIcon name="react" />
@@ -72,7 +72,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--fileuploader',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--file-uploader',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--basic',
       Vue:
@@ -101,7 +101,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--drag-and-drop-upload-container-example-application',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--drag-and-drop-upload-container-example-application',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--drag-and-drop',
       Vue:
@@ -130,7 +130,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--fileuploaderitem',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--file-uploader-item',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--basic',
       Vue:

--- a/src/pages/components/file-uploader/usage.mdx
+++ b/src/pages/components/file-uploader/usage.mdx
@@ -76,7 +76,7 @@ file uploader.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--fileuploader',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--file-uploader',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--basic',
       Vue:
@@ -105,7 +105,7 @@ file uploader.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--drag-and-drop-upload-container-example-application',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--drag-and-drop-upload-container-example-application',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--drag-and-drop',
       Vue:
@@ -134,7 +134,7 @@ file uploader.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/fileuploader--fileuploaderitem',
+        'https://react.carbondesignsystem.com/?path=/story/components-fileuploader--file-uploader-item',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-file-uploader--basic',
       Vue:

--- a/src/pages/components/form/code.mdx
+++ b/src/pages/components/form/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/form--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-form--default"
     >
 
 <MdxIcon name="react" />
@@ -66,7 +66,8 @@ documentation, see the Storybooks for each framework below.
       SelectItem: ['disabled', 'hidden'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/form--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-form--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:

--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -54,7 +54,8 @@ do you gain by collecting this information?
       SelectItem: ['disabled', 'hidden'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/form--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-form--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:

--- a/src/pages/components/inline-loading/code.mdx
+++ b/src/pages/components/inline-loading/code.mdx
@@ -18,7 +18,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/inlineloading--inline-loading"
+    href="https://react.carbondesignsystem.com/?path=/story/components-inlineloading--inline-loading"
     >
 
 <MdxIcon name="react" />
@@ -63,7 +63,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/inlineloading--inline-loading',
+        'https://react.carbondesignsystem.com/?path=/story/components-inlineloading--inline-loading',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-inline-loading--basic',
       Vue:

--- a/src/pages/components/inline-loading/usage.mdx
+++ b/src/pages/components/inline-loading/usage.mdx
@@ -64,7 +64,7 @@ table, after a primary or secondary button click, or even in a modal.
     }}
     links={{
       React:
-        'http://react.carbondesignsystem.com/?path=/story/inlineloading--inline-loading',
+        'https://react.carbondesignsystem.com/?path=/story/components-inlineloading--inline-loading',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-inline-loading--basic',
       Vue:

--- a/src/pages/components/link/code.mdx
+++ b/src/pages/components/link/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/link--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-link--default"
     >
 
 <MdxIcon name="react" />
@@ -61,7 +61,8 @@ documentation, see the Storybooks for each framework below.
     id="link"
     knobs={{ Link: ['disabled', 'inline'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/link--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-link--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-link--basic',
       Vue:

--- a/src/pages/components/link/usage.mdx
+++ b/src/pages/components/link/usage.mdx
@@ -70,7 +70,8 @@ be used for navigational actions.
     id="link"
     knobs={{ Link: ['disabled', 'inline'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/link--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-link--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-link--basic',
       Vue:

--- a/src/pages/components/list/code.mdx
+++ b/src/pages/components/list/code.mdx
@@ -18,7 +18,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/orderedlist--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-orderedlist--default"
     >
 
 <MdxIcon name="react" />
@@ -64,7 +64,7 @@ documentation, see the Storybooks for each framework below.
     id="ordered"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/orderedlist--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-orderedlist--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-list--basic',
       Vue:
@@ -98,7 +98,7 @@ documentation, see the Storybooks for each framework below.
     id="unordered"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/unorderedlist--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-unorderedlist--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-list--basic',
       Vue:

--- a/src/pages/components/list/usage.mdx
+++ b/src/pages/components/list/usage.mdx
@@ -50,7 +50,7 @@ between list items.
     id="ordered"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/orderedlist--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-orderedlist--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-list--basic',
       Vue:
@@ -84,7 +84,7 @@ between list items.
     id="unordered"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/unorderedlist--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-unorderedlist--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-list--basic',
       Vue:

--- a/src/pages/components/loading/code.mdx
+++ b/src/pages/components/loading/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/loading--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-loading--default"
     >
 
 <MdxIcon name="react" />
@@ -62,7 +62,7 @@ documentation, see the Storybooks for each framework below.
     knobs={{ Loading: ['small'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/loading--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-loading--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-loading--basic',
       Vue:

--- a/src/pages/components/loading/usage.mdx
+++ b/src/pages/components/loading/usage.mdx
@@ -46,7 +46,7 @@ three seconds.
     knobs={{ Loading: ['small'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/loading--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-loading--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-loading--basic',
       Vue:

--- a/src/pages/components/modal/code.mdx
+++ b/src/pages/components/modal/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/modal--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-modal--default"
     >
 
 <MdxIcon name="react" />
@@ -67,7 +67,8 @@ documentation, see the Storybooks for each framework below.
       ModalWrapper: ['passiveModal', 'danger', 'disabled', 'size'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/modal--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-modal--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-modal--basic',
       Vue:
@@ -85,7 +86,8 @@ documentation, see the Storybooks for each framework below.
   <ComponentVariant
     id="scrolling-content"
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/modal--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-modal--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-modal--basic',
       Vue:

--- a/src/pages/components/modal/usage.mdx
+++ b/src/pages/components/modal/usage.mdx
@@ -88,7 +88,8 @@ destructive or irreversible then use a transactional danger modal.
       ModalWrapper: ['passiveModal', 'danger', 'disabled', 'size'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/modal--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-modal--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-modal--basic',
       Vue:
@@ -106,7 +107,8 @@ destructive or irreversible then use a transactional danger modal.
   <ComponentVariant
     id="scrolling-content"
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/modal--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-modal--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-modal--basic',
       Vue:

--- a/src/pages/components/notification/code.mdx
+++ b/src/pages/components/notification/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/notifications--toast"
+    href="https://react.carbondesignsystem.com/?path=/story/components-notifications--toast"
     >
 
 <MdxIcon name="react" />
@@ -49,3 +49,64 @@ usage documentation, see the Storybooks for each framework below.
 </Row>
 
 ## Live demo
+
+<ComponentDemo
+  components={[
+    {
+      id: 'toast',
+      label: 'Toast notification',
+    },
+    {
+      id: 'inline',
+      label: 'Inline notification',
+    },
+  ]}>
+  <ComponentVariant
+    id="toast"
+    knobs={{
+      ToastNotification: ['hideCloseButton', 'kind', 'lowContrast'],
+    }}
+    links={{
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-notifications--toast',
+      Angular:
+        'https://angular.carbondesignsystem.com/?path=/story/components-notification--toast',
+      Vue:
+        'http://vue.carbondesignsystem.com/?path=/story/components-cvtoastnotification--default',
+      Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
+    }}>{`
+    <div>
+      <ToastNotification
+        caption="00:00:00 AM"
+        iconDescription="describes the close button"
+        subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+        timeout={0}
+        title="Notification title"
+      />
+    </div>
+`}</ComponentVariant>
+  <ComponentVariant
+    id="inline"
+    knobs={{
+      InlineNotification: ['hideCloseButton', 'lowContrast'],
+    }}
+    links={{
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-notifications--inline',
+      Angular:
+        'https://angular.carbondesignsystem.com/?path=/story/components-notification--basic',
+      Vue:
+        'http://vue.carbondesignsystem.com/?path=/story/components-cvinlinenotification--default',
+      Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
+    }}>{`
+  <div>
+    <InlineNotification
+      kind="info"
+      actions={<NotificationActionButton>Action</NotificationActionButton>}
+      iconDescription="describes the close button"
+      subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+      title="Notification title"
+    />
+  </div>
+`}</ComponentVariant>
+</ComponentDemo>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -69,7 +69,7 @@ product teams also support banners and notification centers.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/notifications--toast',
+        'https://react.carbondesignsystem.com/?path=/story/components-notifications--toast',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-notification--toast',
       Vue:
@@ -93,7 +93,7 @@ product teams also support banners and notification centers.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/notifications--inline',
+        'https://react.carbondesignsystem.com/?path=/story/components-notifications--inline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-notification--basic',
       Vue:

--- a/src/pages/components/number-input/code.mdx
+++ b/src/pages/components/number-input/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/numberinput--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-numberinput--default"
     >
 
 <MdxIcon name="react" />
@@ -65,7 +65,7 @@ usage documentation, see the Storybooks for each framework below.
     id="number-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/numberinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-numberinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-number--basic',
       Vue:
@@ -87,7 +87,7 @@ usage documentation, see the Storybooks for each framework below.
     id="mobile-number-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/numberinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-numberinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-number--basic',
       Vue:

--- a/src/pages/components/number-input/usage.mdx
+++ b/src/pages/components/number-input/usage.mdx
@@ -44,7 +44,7 @@ or decrease an incremental value.
     id="number-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/numberinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-numberinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-number--basic',
       Vue:
@@ -66,7 +66,7 @@ or decrease an incremental value.
     id="mobile-number-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/numberinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-numberinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-number--basic',
       Vue:

--- a/src/pages/components/overflow-menu/code.mdx
+++ b/src/pages/components/overflow-menu/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/overflowmenu--basic"
+    href="https://react.carbondesignsystem.com/?path=/story/components-overflowmenu--default"
     >
 
 <MdxIcon name="react" />
@@ -64,7 +64,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/overflowmenu--basic',
+        'https://react.carbondesignsystem.com/?path=/story/components-overflowmenu--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-overflow-menu--basic',
       Vue:

--- a/src/pages/components/overflow-menu/usage.mdx
+++ b/src/pages/components/overflow-menu/usage.mdx
@@ -43,7 +43,7 @@ there is a space constraint.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/overflowmenu--basic',
+        'https://react.carbondesignsystem.com/?path=/story/components-overflowmenu--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-overflow-menu--basic',
       Vue:

--- a/src/pages/components/pagination/code.mdx
+++ b/src/pages/components/pagination/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/pagination--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-pagination--pagination"
     >
 
 <MdxIcon name="react" />
@@ -69,7 +69,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/pagination--pagination',
+        'https://react.carbondesignsystem.com/?path=/story/components-pagination--pagination',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-pagination--basic',
       Vue:

--- a/src/pages/components/pagination/usage.mdx
+++ b/src/pages/components/pagination/usage.mdx
@@ -50,7 +50,7 @@ The default number displayed will vary depending on the context.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/pagination--pagination',
+        'https://react.carbondesignsystem.com/?path=/story/components-pagination--pagination',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-pagination--basic',
       Vue:

--- a/src/pages/components/progress-indicator/code.mdx
+++ b/src/pages/components/progress-indicator/code.mdx
@@ -20,7 +20,7 @@ code usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/progressindicator--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-progressindicator--default"
     >
 
 <MdxIcon name="react" />
@@ -66,7 +66,7 @@ code usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/progressindicator--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-progressindicator--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-progress-indicator--basic',
       Vue:

--- a/src/pages/components/progress-indicator/usage.mdx
+++ b/src/pages/components/progress-indicator/usage.mdx
@@ -45,7 +45,7 @@ percentage of completeness as each task is completed.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/progressindicator--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-progressindicator--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-progress-indicator--basic',
       Vue:

--- a/src/pages/components/radio-button/code.mdx
+++ b/src/pages/components/radio-button/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/radiobuttongroup--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-radiobutton--default"
     >
 
 <MdxIcon name="react" />
@@ -64,7 +64,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/radiobuttongroup--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-radiobutton--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-radio--basic',
       Vue:

--- a/src/pages/components/radio-button/usage.mdx
+++ b/src/pages/components/radio-button/usage.mdx
@@ -89,7 +89,7 @@ checkboxes allow the user to select multiple options.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/radiobuttongroup--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-radiobutton--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-radio--basic',
       Vue:

--- a/src/pages/components/search/code.mdx
+++ b/src/pages/components/search/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/search--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-search--default"
     >
 
 <MdxIcon name="react" />
@@ -62,7 +62,7 @@ documentation, see the Storybooks for each framework below.
     knobs={{ Search: ['size', 'light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/search--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-search--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-search--basic',
       Vue:

--- a/src/pages/components/search/usage.mdx
+++ b/src/pages/components/search/usage.mdx
@@ -43,7 +43,7 @@ to aid the user in finding content.
     knobs={{ Search: ['size', 'light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/search--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-search--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-search--basic',
       Vue:

--- a/src/pages/components/select/code.mdx
+++ b/src/pages/components/select/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/select--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-select--default"
     >
 
 <MdxIcon name="react" />
@@ -66,7 +66,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/select--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-select--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-select--basic',
       Vue:

--- a/src/pages/components/select/usage.mdx
+++ b/src/pages/components/select/usage.mdx
@@ -60,7 +60,7 @@ while the dropdown component can be styled as needed.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/select--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-select--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-select--basic',
       Vue:

--- a/src/pages/components/slider/code.mdx
+++ b/src/pages/components/slider/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/slider--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-slider--default"
     >
 
 <MdxIcon name="react" />
@@ -62,7 +62,7 @@ documentation, see the Storybooks for each framework below.
     knobs={{ Slider: ['disabled', 'hideTextInput', 'light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/slider--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-slider--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-slider--basic',
       Vue:

--- a/src/pages/components/slider/usage.mdx
+++ b/src/pages/components/slider/usage.mdx
@@ -67,7 +67,7 @@ value range.
     knobs={{ Slider: ['disabled', 'hideTextInput', 'light'] }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/slider--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-slider--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-slider--basic',
       Vue:

--- a/src/pages/components/structured-list/code.mdx
+++ b/src/pages/components/structured-list/code.mdx
@@ -21,7 +21,7 @@ code usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/structuredlist--simple"
+    href="https://react.carbondesignsystem.com/?path=/story/components-structuredlist--simple"
     >
 
 <MdxIcon name="react" />
@@ -68,7 +68,7 @@ code usage documentation, see the Storybooks for each framework below.
     id="default-structured-list"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/structuredlist--simple',
+        'https://react.carbondesignsystem.com/?path=/story/components-structuredlist--simple',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-structured-list--basic',
       Vue:
@@ -122,7 +122,7 @@ code usage documentation, see the Storybooks for each framework below.
     id="select-structured-list"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/structuredlist--selection',
+        'https://react.carbondesignsystem.com/?path=/story/components-structuredlist--selection',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-structured-list--with-selection',
       Vue:

--- a/src/pages/components/structured-list/usage.mdx
+++ b/src/pages/components/structured-list/usage.mdx
@@ -39,7 +39,7 @@ import { CheckmarkFilled16 } from '@carbon/icons-react';
     id="default-structured-list"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/structuredlist--simple',
+        'https://react.carbondesignsystem.com/?path=/story/components-structuredlist--simple',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-structured-list--basic',
       Vue:
@@ -93,7 +93,7 @@ import { CheckmarkFilled16 } from '@carbon/icons-react';
     id="select-structured-list"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/structuredlist--selection',
+        'https://react.carbondesignsystem.com/?path=/story/components-structuredlist--selection',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-structured-list--with-selection',
       Vue:

--- a/src/pages/components/tabs/code.mdx
+++ b/src/pages/components/tabs/code.mdx
@@ -18,7 +18,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/tabs--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-tabs--default"
     >
 
 <MdxIcon name="react" />
@@ -60,7 +60,8 @@ documentation, see the Storybooks for each framework below.
     id="tabs"
     knobs={{ Tabs: ['type'], Tab: ['disabled', 'selected'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tabs--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tabs--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tabs--basic',
       Vue:

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -48,7 +48,8 @@ Tabs are used to quickly navigate between views within the same context.
     id="tabs"
     knobs={{ Tabs: ['type'], Tab: ['disabled', 'selected'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tabs--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tabs--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tabs--basic',
       Vue:

--- a/src/pages/components/tag/code.mdx
+++ b/src/pages/components/tag/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/tag--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-tag--default"
     >
 
 <MdxIcon name="react" />
@@ -61,7 +61,8 @@ documentation, see the Storybooks for each framework below.
     id="tag"
     knobs={{ Tag: ['filter', 'disabled'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tag--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tag--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tag--basic',
       Vue:

--- a/src/pages/components/tag/usage.mdx
+++ b/src/pages/components/tag/usage.mdx
@@ -65,7 +65,8 @@ that particular category.
     id="tag"
     knobs={{ Tag: ['filter', 'disabled'] }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tag--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tag--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tag--basic',
       Vue:

--- a/src/pages/components/text-input/code.mdx
+++ b/src/pages/components/text-input/code.mdx
@@ -19,7 +19,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/textinput--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-textinput--default"
     >
 
 <MdxIcon name="react" />
@@ -72,7 +72,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-textinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:
@@ -93,7 +93,7 @@ usage documentation, see the Storybooks for each framework below.
     id="password-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textinput--toggle-password-visibility',
+        'https://react.carbondesignsystem.com/?path=/story/components-textinput--toggle-password-visibility',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:
@@ -119,7 +119,7 @@ usage documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textarea--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-textarea--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--textarea',
       Vue:

--- a/src/pages/components/text-input/usage.mdx
+++ b/src/pages/components/text-input/usage.mdx
@@ -58,7 +58,7 @@ reflect the length of the content you expect the user to enter.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textinput--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-textinput--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:
@@ -79,7 +79,7 @@ reflect the length of the content you expect the user to enter.
     id="password-input"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textinput--toggle-password-visibility',
+        'https://react.carbondesignsystem.com/?path=/story/components-textinput--toggle-password-visibility',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--label',
       Vue:
@@ -105,7 +105,7 @@ reflect the length of the content you expect the user to enter.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/textarea--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-textarea--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-input--textarea',
       Vue:

--- a/src/pages/components/tile/code.mdx
+++ b/src/pages/components/tile/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/tile--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-tile--default"
     >
 
 <MdxIcon name="react" />
@@ -79,7 +79,8 @@ documentation, see the Storybooks for each framework below.
       Tile: ['light'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tile--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--basic',
       Vue:
@@ -96,7 +97,8 @@ documentation, see the Storybooks for each framework below.
       ClickableTile: ['light', 'clicked'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tile--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--clickable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--basic',
       Vue:
@@ -116,7 +118,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--clickable',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--radio',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--clickable',
       Vue:
@@ -161,7 +163,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--multi-select',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--multi-select',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--selectable',
       Vue:
@@ -208,7 +210,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--expandable',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--expandable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--expandable',
       Vue:

--- a/src/pages/components/tile/usage.mdx
+++ b/src/pages/components/tile/usage.mdx
@@ -63,7 +63,8 @@ for the most important action a user can take on the page.
       Tile: ['light'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tile--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--basic',
       Vue:
@@ -80,7 +81,8 @@ for the most important action a user can take on the page.
       ClickableTile: ['light', 'clicked'],
     }}
     links={{
-      React: 'https://react.carbondesignsystem.com/?path=/story/tile--default',
+      React:
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--clickable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--basic',
       Vue:
@@ -100,7 +102,7 @@ for the most important action a user can take on the page.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--clickable',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--radio',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--clickable',
       Vue:
@@ -145,7 +147,7 @@ for the most important action a user can take on the page.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--multi-select',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--multi-select',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--selectable',
       Vue:
@@ -192,7 +194,7 @@ for the most important action a user can take on the page.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tile--expandable',
+        'https://react.carbondesignsystem.com/?path=/story/components-tile--expandable',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tiles--expandable',
       Vue:

--- a/src/pages/components/toggle/code.mdx
+++ b/src/pages/components/toggle/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/toggle--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-toggle--default"
     >
 
 <MdxIcon name="react" />
@@ -65,7 +65,7 @@ documentation, see the Storybooks for each framework below.
     id="default-toggle"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/toggle--toggled',
+        'https://react.carbondesignsystem.com/?path=/story/components-toggle--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-toggle--basic',
       Vue:
@@ -83,7 +83,7 @@ documentation, see the Storybooks for each framework below.
     id="small-toggle"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/togglesmall--toggled',
+        'https://react.carbondesignsystem.com/?path=/story/components-toggle--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-toggle--basic',
       Vue:

--- a/src/pages/components/toggle/usage.mdx
+++ b/src/pages/components/toggle/usage.mdx
@@ -54,7 +54,7 @@ user “flips the switch”. They are commonly used for “on/off” switches.
     id="default-toggle"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/toggle--toggled',
+        'https://react.carbondesignsystem.com/?path=/story/components-toggle--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-toggle--basic',
       Vue:
@@ -72,7 +72,7 @@ user “flips the switch”. They are commonly used for “on/off” switches.
     id="small-toggle"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/togglesmall--toggled',
+        'https://react.carbondesignsystem.com/?path=/story/components-toggle--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-toggle--basic',
       Vue:

--- a/src/pages/components/tooltip/code.mdx
+++ b/src/pages/components/tooltip/code.mdx
@@ -21,7 +21,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="http://react.carbondesignsystem.com/?path=/story/tooltip--default"
+    href="https://react.carbondesignsystem.com/?path=/story/components-tooltip--default-bottom"
     >
 
 <MdxIcon name="react" />
@@ -72,7 +72,7 @@ documentation, see the Storybooks for each framework below.
     id="tooltip"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltip--default-bottom',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltip--default-bottom',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip--basic',
       Vue:
@@ -102,7 +102,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltipicon--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltipicon--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip-icon--basic',
       Vue:
@@ -122,7 +122,7 @@ documentation, see the Storybooks for each framework below.
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltipdefinition--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltipdefinition--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip-definition--basic',
       Vue:

--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -58,7 +58,7 @@ import { Filter16 } from '@carbon/icons-react';
     id="tooltip"
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltip--default-bottom',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltip--default-bottom',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip--basic',
       Vue:
@@ -88,7 +88,7 @@ import { Filter16 } from '@carbon/icons-react';
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltipicon--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltipicon--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip-icon--basic',
       Vue:
@@ -108,7 +108,7 @@ import { Filter16 } from '@carbon/icons-react';
     }}
     links={{
       React:
-        'https://react.carbondesignsystem.com/?path=/story/tooltipdefinition--default',
+        'https://react.carbondesignsystem.com/?path=/story/components-tooltipdefinition--default',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-tooltip-definition--basic',
       Vue:


### PR DESCRIPTION
Closes #2246

Updated the storybook links in the live demos and on the Code tab tiles to go to the correct component rather than going to the default storybook welcome screen.
