### PR TITLE
fix: add IconService import to Angular tutorial

### DIFF
--- a/src/pages/developing/angular-tutorial/step-1.mdx
+++ b/src/pages/developing/angular-tutorial/step-1.mdx
@@ -257,7 +257,7 @@ import { AppComponent } from './app.component';
 import { HeaderComponent } from './header/header.component';
 
 // carbon-components-angular default imports
-import { UIShellModule, IconModule } from 'carbon-components-angular';
+import { UIShellModule, IconModule, IconService } from 'carbon-components-angular';
 
 @NgModule({
   declarations: [


### PR DESCRIPTION
Angular tutorial step 1 instructions was missing an import: IconService.
