### PR TITLE
fix: carbon-overrides path in Angular Tutorial

### DIFF
--- a/src/pages/developing/angular-tutorial/step-2.mdx
+++ b/src/pages/developing/angular-tutorial/step-2.mdx
@@ -324,7 +324,7 @@ Next, we'll need to add a styling override to move the tabs to the right on
 large viewports, and tidy up the alignment of the grid. Create a file
 `carbon-overrides.scss` in `src/assets/scss` with this declaration block.
 
-```scss path=src/assets/carbon-overrides.scss
+```scss path=src/assets/scss/carbon-overrides.scss
 // makes the grid fit the entire width of the page
 .bx--grid--full-width {
   padding-left: 1rem;


### PR DESCRIPTION
In Carbon Angular Tutorial, step 2, it was pointing to a wrong path for carbon-overrides.scss file.