### PR TITLE
fix(component-demo): update to emit component tokens

### DIFF
--- a/src/components/ComponentDemo/ComponentDemo.module.scss
+++ b/src/components/ComponentDemo/ComponentDemo.module.scss
@@ -1,3 +1,7 @@
+@import '~carbon-components/scss/globals/scss/component-tokens';
+@import '~carbon-components/scss/components/notification/tokens';
+@import '~carbon-components/scss/components/tag/tokens';
+
 .fullscreen {
   @include carbon--breakpoint('md') {
     position: fixed;
@@ -313,28 +317,40 @@ fieldset.form-group:last-of-type {
   @include carbon--theme(
     $theme: $carbon--theme--white,
     $emit-custom-properties: true
-  );
+  ) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
 }
 
 .g10 {
   @include carbon--theme(
     $theme: $carbon--theme--g10,
     $emit-custom-properties: true
-  );
+  ) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
 }
 
 .g90 {
   @include carbon--theme(
     $theme: $carbon--theme--g90,
     $emit-custom-properties: true
-  );
+  ) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
 }
 
 .g100 {
   @include carbon--theme(
     $theme: $carbon--theme--g100,
     $emit-custom-properties: true
-  );
+  ) {
+    @include emit-component-tokens($tag-colors);
+    @include emit-component-tokens($notification-colors);
+  }
 }
 
 //---------------------------------------


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/2263

Update our component demo to use component tokens for Notification and Tag. You can test out the changes by visiting the component demo pages for Tag and Notification, change the theme, and see the colors become updated.

#### Changelog

**New**

**Changed**

- Update component demo switcher to emit component tokens for notification and tag

**Removed**
