### PR TITLE
1946 component live demo bug

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -74,7 +74,4 @@ module.exports = {
       },
     },
   ],
-  flags: {
-    PRESERVE_WEBPACK_CACHE: true,
-  },
 };

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -74,4 +74,7 @@ module.exports = {
       },
     },
   ],
+  flags: {
+    PRESERVE_WEBPACK_CACHE: true,
+  },
 };

--- a/src/components/ComponentDemo/ComponentDemo.module.scss
+++ b/src/components/ComponentDemo/ComponentDemo.module.scss
@@ -407,7 +407,7 @@ body[data-live-preview-theme='Gray 100'] ul[class^='bx--overflow-menu-options'],
   }
 
   [class*='--content-switcher-btn'] {
-    height: 2.5rem;
+    height: 100%;
   }
 
   [class*='--overflow-menu__icon'] {

--- a/src/data/docgen/react-docgen.json
+++ b/src/data/docgen/react-docgen.json
@@ -916,7 +916,8 @@
           "name": "enum",
           "value": [
             { "value": "'sm'", "computed": false },
-            { "value": "'xl'", "computed": false }
+            { "value": "'md'", "computed": false },
+            { "value": "'lg'", "computed": false }
           ]
         },
         "required": false,

--- a/src/pages/components/content-switcher/code.mdx
+++ b/src/pages/components/content-switcher/code.mdx
@@ -62,6 +62,7 @@ code usage documentation, see the Storybooks for each framework below.
     id="content-switcher"
     knobs={{
       Switch: ['disabled'],
+      ContentSwitcher: ['size'],
     }}
     links={{
       React:

--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -75,6 +75,7 @@ binary decision.
     id="content-switcher"
     knobs={{
       Switch: ['disabled'],
+      ContentSwitcher: ['size'],
     }}
     links={{
       React:


### PR DESCRIPTION
Closes #1946 

Updates the Component Live Demo for `ContentSwitcher` to include the size variant props as seen below:

<img width="1176" alt="Screen Shot 2021-05-06 at 11 42 14 AM" src="https://user-images.githubusercontent.com/32720851/117342292-4b65fa80-ae60-11eb-81dc-12a9daf8d572.png">


#### Testing

- [ ] Make sure size variants for `ContentSwitcher` change appropriately to `sm, md, lg`
- [ ] Make sure size variants for `ContentSwitcher` change in both the `usage` and `code` tabs