### PR TITLE
IA: add divider, move What's happening

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -16,6 +16,19 @@
       path: /case-studies/consistency-in-the-cloud
     - title: IBM Commerce Platform
       path: /case-studies/ibm-commerce-platform
+- title: What’s happening
+  pages:
+    - title: Releases
+      path: /whats-happening/releases/
+    - title: The v11 release
+      path: /whats-happening/v11-release/
+    - title: News and articles
+      path: /whats-happening/news-and-articles/
+    - title: Meetups
+      path: /whats-happening/meetups/
+    - title: Work in progress
+      path: /whats-happening/work-in-progress/
+  hasDivider: true
 - title: Designing
   pages:
     - title: Get started
@@ -58,18 +71,6 @@
       path: /contributing/contribute-pictograms/
     - title: Add ons
       path: /contributing/add-ons/
-- title: What’s happening
-  pages:
-    - title: Releases
-      path: /whats-happening/releases/
-    - title: The v11 release
-      path: /whats-happening/v11-release/
-    - title: News and articles
-      path: /whats-happening/news-and-articles/
-    - title: Meetups
-      path: /whats-happening/meetups/
-    - title: Work in progress
-      path: /whats-happening/work-in-progress/
   hasDivider: true
 - title: Guidelines
   pages:


### PR DESCRIPTION
This PR moves `What's happening` to the third position on the left nav, grouping it with `All about Carbon` and `Case studies` and adding a divider line to create a new section. 

This is the final piece of the intended plan when we changed the IA last year. We wanted to wait until we had `Case studies` so that we had a group of three.   