### PR TITLE
docs: component index reference

### DIFF
--- a/src/pages/components/overview/index.mdx
+++ b/src/pages/components/overview/index.mdx
@@ -23,6 +23,6 @@ feedback to the user, and so on. All of the components in Carbon have been
 designed to work harmoniously together, as parts of a greater whole.
 
 Additional components, maintained by the Carbon community, are available in
-[Community assets](https://www.carbondesignsystem.com/community/component-index).
+[Community assets](/community/component-index).
 
 <ComponentOverview />

--- a/src/pages/components/overview/index.mdx
+++ b/src/pages/components/overview/index.mdx
@@ -22,10 +22,7 @@ as presenting a list of options, enabling submission of a form, providing
 feedback to the user, and so on. All of the components in Carbon have been
 designed to work harmoniously together, as parts of a greater whole.
 
-<ComponentOverview />
-
-## Community components
-
-Additional components, maintained by members of the Carbon community, are
-available in
+Additional components, maintained by the Carbon community, are available in
 [Community assets](https://www.carbondesignsystem.com/community/component-index).
+
+<ComponentOverview />


### PR DESCRIPTION
This PR moves the link to the community component index to the top of the component overview page. One step to increase visibility of the index. 