### PR TITLE
Docs: v11 color token updates for Content switcher component

### DIFF
--- a/src/pages/components/content-switcher/style.mdx
+++ b/src/pages/components/content-switcher/style.mdx
@@ -13,27 +13,27 @@ Content switchers have two main states: `selected` and `unselected`. By default,
 content switcher buttons are unselected with the selected state using a high
 contrast color.
 
-| Class                       | Property         | Color token          |
-| --------------------------- | ---------------- | -------------        | 
+| Class                       | Property         | Color token               |
+| --------------------------- | ---------------- | ------------------------- |
 | `.bx--content-switcher-btn` | background-color | `transparent`             |
-| `.bx--content-switcher-btn` | text color       | `$text-secondary`    |
-| `.bx--content-switcher-btn` | border           | `$border-inverse`    |
-| `--selected`                | background-color | `$layer-selected-inverse`    |
-| `--selected`                | text color       | `$text-inverse`      |
-| `:after`                    | divider          | `$border-subtle`     |
+| `.bx--content-switcher-btn` | text color       | `$text-secondary`         |
+| `.bx--content-switcher-btn` | border           | `$border-inverse`         |
+| `--selected`                | background-color | `$layer-selected-inverse` |
+| `--selected`                | text color       | `$text-inverse`           |
+| `:after`                    | divider          | `$border-subtle`          |
 
 ### Interactive states
 
 Hover states only apply to `unselected` buttons.
 
-| State       | Property         | Color token            |
-| ----------- | ---------------- | --------------         |
-| `:hover`    | background-color | `$background-hover`    |
-| `:hover`    | text color       | `$text-primary`        |
-| `:focus`    | border           | `$focus`               |
-| `:disabled` | background-color | `transparent`      |
-| `:disabled` | text color       | `$text-disabled`       |
-| `:disabled` | border           | `$border-disabled`       |
+| State       | Property         | Color token         |
+| ----------- | ---------------- | ------------------- |
+| `:hover`    | background-color | `$background-hover` |
+| `:hover`    | text color       | `$text-primary`     |
+| `:focus`    | border           | `$focus`            |
+| `:disabled` | background-color | `transparent`       |
+| `:disabled` | text color       | `$text-disabled`    |
+| `:disabled` | border           | `$border-disabled`  |
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/content-switcher/style.mdx
+++ b/src/pages/components/content-switcher/style.mdx
@@ -13,25 +13,25 @@ Content switchers have two main states: `selected` and `unselected`. By default,
 content switcher buttons are unselected with the selected state using a high
 contrast color.
 
-| Class                       | Property         | Color token   |
-| --------------------------- | ---------------- | ------------- |
-| `.bx--content-switcher-btn` | background-color | `$ui-01`      |
-| `.bx--content-switcher-btn` | text color       | `$text-02`    |
-| `--selected`                | background-color | `$ui-05`      |
-| `--selected`                | text color       | `$inverse-01` |
-| `:after`                    | divider          | `$ui-03`      |
+| Class                       | Property         | Color token          |
+| --------------------------- | ---------------- | -------------        | 
+| `.bx--content-switcher-btn` | background-color | `$layer`             |
+| `.bx--content-switcher-btn` | text color       | `$text-secondary`    |
+| `--selected`                | background-color | `$border-inverse`    |
+| `--selected`                | text color       | `$text-inverse`      |
+| `:after`                    | divider          | `$border-subtle`     |
 
 ### Interactive states
 
 Hover states only apply to `unselected` buttons.
 
-| State       | Property         | Color token    |
-| ----------- | ---------------- | -------------- |
-| `:hover`    | background-color | `$hover-ui`    |
-| `:hover`    | text color       | `$text-01`     |
-| `:focus`    | border           | `$focus`       |
-| `:disabled` | background-color | `$disabled-01` |
-| `:disabled` | text color       | `$disabled-02` |
+| State       | Property         | Color token            |
+| ----------- | ---------------- | --------------         |
+| `:hover`    | background-color | `$background-hover`    |
+| `:hover`    | text color       | `$text-primary`        |
+| `:focus`    | border           | `$focus`               |
+| `:disabled` | background-color | `$layer-disabled`      |
+| `:disabled` | text color       | `$text-disabled`       |
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/content-switcher/style.mdx
+++ b/src/pages/components/content-switcher/style.mdx
@@ -15,9 +15,10 @@ contrast color.
 
 | Class                       | Property         | Color token          |
 | --------------------------- | ---------------- | -------------        | 
-| `.bx--content-switcher-btn` | background-color | `$layer`             |
+| `.bx--content-switcher-btn` | background-color | `transparent`             |
 | `.bx--content-switcher-btn` | text color       | `$text-secondary`    |
-| `--selected`                | background-color | `$border-inverse`    |
+| `.bx--content-switcher-btn` | border           | `$border-inverse`    |
+| `--selected`                | background-color | `$layer-selected-inverse`    |
 | `--selected`                | text color       | `$text-inverse`      |
 | `:after`                    | divider          | `$border-subtle`     |
 
@@ -30,8 +31,9 @@ Hover states only apply to `unselected` buttons.
 | `:hover`    | background-color | `$background-hover`    |
 | `:hover`    | text color       | `$text-primary`        |
 | `:focus`    | border           | `$focus`               |
-| `:disabled` | background-color | `$layer-disabled`      |
+| `:disabled` | background-color | `transparent`      |
 | `:disabled` | text color       | `$text-disabled`       |
+| `:disabled` | border           | `$border-disabled`       |
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION
This PR updates the color tokens on the Style tab for the content switcher component.