### PR TITLE
docs: v11 color token updates for overflow menu component

### DIFF
--- a/src/pages/components/overflow-menu/style.mdx
+++ b/src/pages/components/overflow-menu/style.mdx
@@ -10,23 +10,23 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Class                                        | Property         | Color token                      |
 | -------------------------------------------- | ---------------- | -------------------------------- |
-| `.bx--overflow-menu__icon`                   | fill             | `$icon-01`                       |
-| `.bx--overflow-menu-options`                 | background-color | `$ui-01`                         |
-| `.bx--overflow-menu-options__btn`            | color            | `$text-02`                       |
-| `.bx--overflow-menu-options__option--danger` | background-color | `$support-01`                    |
+| `.bx--overflow-menu__icon`                   | fill             | `$icon-primary`                  |
+| `.bx--overflow-menu-options`                 | background-color | `$layer`                         |
+| `.bx--overflow-menu-options__btn`            | color            | `$text-secondary`                |
+| `.bx--overflow-menu-options__option--danger` | background-color | `$support-error`                 |
 | `.bx--overflow-menu-options`                 | box-shadow       | `0 2px 6px 0 rgba(0, 0, 0, 0.3)` |
 
 ### Interactive states
 
-| Class                      | Property         | Color token     |
-| -------------------------- | ---------------- | --------------- |
-| `.bx--overflow-menu:focus` | border           | `$focus`        |
-| `option:focus`             | border           | `$focus`        |
-| `.bx--overflow-menu:hover` | background-color | `$hover-ui`     |
-| `option:hover`             | background-color | `$hover-row`    |
-| `option:hover`             | text color       | `$text-01`      |
-| `option--danger:hover`     | background-color | `$hover-danger` |
-| `option:disabled`          | text color       | `$disabled-02`  |
+| Class                      | Property         | Color token            |
+| -------------------------- | ---------------- | ---------------------- |
+| `.bx--overflow-menu:focus` | border           | `$focus`               |
+| `option:focus`             | border           | `$focus`               |
+| `.bx--overflow-menu:hover` | background-color | `$background-hover`    |
+| `option:hover`             | background-color | `$background-hover`    |
+| `option:hover`             | text color       | `$text-primary`        |
+| `option--danger:hover`     | background-color | `$button-danger-hover` |
+| `option:disabled`          | text color       | `$text-disabled`       |
 
 <div className="image--fixed">
 

--- a/src/pages/components/overflow-menu/style.mdx
+++ b/src/pages/components/overflow-menu/style.mdx
@@ -13,7 +13,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | `.bx--overflow-menu__icon`                   | fill             | `$icon-primary`                  |
 | `.bx--overflow-menu-options`                 | background-color | `$layer`                         |
 | `.bx--overflow-menu-options__btn`            | color            | `$text-secondary`                |
-| `.bx--overflow-menu-options__option--danger` | background-color | `$support-error`                 |
+| `.bx--overflow-menu-options__option--danger` | background-color | `$layer`                         |
 | `.bx--overflow-menu-options`                 | box-shadow       | `0 2px 6px 0 rgba(0, 0, 0, 0.3)` |
 
 ### Interactive states
@@ -23,7 +23,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | `.bx--overflow-menu:focus` | border           | `$focus`               |
 | `option:focus`             | border           | `$focus`               |
 | `.bx--overflow-menu:hover` | background-color | `$background-hover`    |
-| `option:hover`             | background-color | `$background-hover`    |
+| `option:hover`             | background-color | `$layer-hover`         |
 | `option:hover`             | text color       | `$text-primary`        |
 | `option--danger:hover`     | background-color | `$button-danger-hover` |
 | `option:disabled`          | text color       | `$text-disabled`       |


### PR DESCRIPTION
This PR updates the color tokens on the style tab for the overflow menu component.