### PR TITLE
chore(gatsby): remove v3.0 `FAST_REFRESH` flag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,7 +12,6 @@ module.exports = {
   flags: {
     PRESERVE_WEBPACK_CACHE: true,
     FAST_DEV: true,
-    FAST_REFRESH: true,
   },
   plugins: [
     {


### PR DESCRIPTION
related #2324

hot reloading appears to be broken based on user reports. It seems that the `FAST_REFRESH` flag is not supported in the version of Gatsby we're currently using (ref https://github.com/gatsbyjs/gatsby/discussions/28390), and removing the flag restores hot reloading

not sure if we're ready to upgrade Gatsby to 3.0+ but in the meantime it seems that we can't use this flag yet