### PR TITLE
Who uses carbon page copyedits

### DIFF
--- a/src/pages/all-about-carbon/who-uses-carbon.mdx
+++ b/src/pages/all-about-carbon/who-uses-carbon.mdx
@@ -27,12 +27,6 @@ comes in.
 
 </AnchorLinks>
 
-## Overview
-
-Carbon provides the building blocks that allow product teams to build
-consistent, branded solutions to complex problems. Let's look at how different
-team members use Carbon, what the benefits are, and how you can get started.
-
 ## Designers
 
 Designers are passionate advocates for users, and Carbon helps them provide
@@ -51,8 +45,6 @@ In addition, Carbon enables product and .com designers across the organization
 to explore and deliver the full potential of a design, leveraging the work of
 other teams where possible, avoiding redesign and duplication of efforts,
 keeping the focus on the distinct client use cases.
-
-### How designers can engage with Carbon
 
 Here are some ways designers can begin engaging with Carbon.
 
@@ -130,8 +122,6 @@ elevates the user experience for our clients.
 Developers can create products that are cohesive with other business
 units—high-quality, consistent, and robust front-end experiences that share the
 IBM brand.
-
-### How developers can engage with Carbon
 
 Here are some ways developers can begin engaging with Carbon.
 


### PR DESCRIPTION
This PR smooths out the brand new `Who uses Carbon?` page, removing some headings. 