### PR TITLE
Removed space between paragraphs

### DIFF
--- a/src/pages/all-about-carbon/what-is-carbon.mdx
+++ b/src/pages/all-about-carbon/what-is-carbon.mdx
@@ -28,9 +28,7 @@ community of contributors.
 
 A design system is a collection of pre-built, reusable assets—components,
 patterns, guidance, and code—that allows its users to build consistent digital
-experiences faster.
-
-By using the pre-built and universal assets of Carbon, the time teams spend
+experiences faster. By using the pre-built and universal assets of Carbon, the time teams spend
 designing and building is minimized. Instead of building and re-building basic
 elements, they can spend that time customizing their products to address
 specific client use cases.
@@ -39,9 +37,7 @@ specific client use cases.
 
 Carbon is funded and built by IBM, which means we build for the company’s
 business needs, but we’ve made it open source for anyone to use and contribute
-back to.
-
-While being primarily open source, Carbon also serves various parts of the IBM
+back to. While being primarily open source, Carbon also serves various parts of the IBM
 business that follow an inner source model.
 
 ## How Carbon works


### PR DESCRIPTION
Removed space between paragraphs in “Overview” and “Carbon is open source” so the copy reads continuously without paragraph breaks. Not needed and disrupting the one thought.

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
