### PR TITLE
Update index.mdx

### DIFF
--- a/src/pages/patterns/dialog-pattern/index.mdx
+++ b/src/pages/patterns/dialog-pattern/index.mdx
@@ -57,7 +57,7 @@ immediately apparent to the user, with a clear and obvious path to completion.
 2. **Body:** Contains the information and/or controls needed to complete the
    dialog’s task. It can include message text and components.
 3. **Actions:** The main actions needed to complete or cancel the dialog task.
-   [Button groupings](/patterns/dialog-pattern#buttons-groups) change based on
+   [Button groupings](/patterns/dialog-pattern#button-groups) change based on
    modal variant. Use descriptive words for the actions like Add, Delete, Save
    and avoid vague words like Done or OK.
 4. **x:** The close `x` icon will close the dialog without submitting any data.


### PR DESCRIPTION
typo to fix broken anchor link from "Actions: The main actions needed to complete or cancel the dialog task. Button groupings change based on modal variant. Use descriptive words for the actions like Add, Delete, Save and avoid vague words like Done or OK."

original line 60: `"[Button groupings](/patterns/dialog-pattern#buttons-groups) change based on"`
fixed line 60: `"[Button groupings](/patterns/dialog-pattern#button-groups) change based on"`

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
