### PR TITLE
docs: v11 size updates for content switcher usage

### DIFF
--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -116,7 +116,7 @@ binary decision.
 
 #### Height
 
-There are three height sizes for the content switcher: small (32px), default
+There are three height sizes for the content switcher: small (32px), medium
 (40px), and large (48px). Choose a size that best fits the density of your
 layout or the prominence of the switcher.
 


### PR DESCRIPTION
This PR gives the correct size variants (small, medium, large) for the content switcher in the usage tab.

