### PR TITLE
docs: v11 size token updates for Tag component

### DIFF
--- a/src/pages/components/tag/style.mdx
+++ b/src/pages/components/tag/style.mdx
@@ -56,7 +56,6 @@ amount of content. All four corners of a tag are rounded with a 24px radius.
 
 | Element | Property                    | px / rem | Spacing token |
 | ------- | --------------------------- | -------- | ------------- |
-| Tag     | height                      | 24 / 1.5 | –             |
 |         | radius                      | 24px     | –             |
 |         | margin                      | 8 / 0.5  | `$spacing-03` |
 |         | padding-left, padding-right | 8 / 0.5  | `$spacing-03` |
@@ -68,3 +67,8 @@ amount of content. All four corners of a tag are rounded with a 24px radius.
 </div>
 
 <Caption>Structure and spacing measurements for a tag | px / rem</Caption>
+
+## Size
+| Size              | Height (px/rem)    | 
+| ----------------- | ------------------ | 
+| Extra small (xs)  | 24 / 1.5           | 


### PR DESCRIPTION
This PR updates the size tokens on the Style tab for the Tag component.
