### PR TITLE
Fixes $hover-primary-text hex for blue 70

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -907,11 +907,11 @@ const colorTokens = {
       value: {
         white: {
           name: 'Blue 70',
-          hex: '#054ada',
+          hex: '#0043ce',
         },
         g10: {
           name: 'Blue 70',
-          hex: '#054ada',
+          hex: '#0043ce',
         },
         g90: {
           name: 'Blue 30',


### PR DESCRIPTION
Blue 70 should be #0043ce

![image](https://user-images.githubusercontent.com/2853295/122254545-1d46f200-cec5-11eb-9d68-9d81ebeebcf1.png)

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- Fixes the documented hex value of $hover-primary-text

**Removed**

- {{removed thing}}
