### PR TITLE
chore: remove gatsby service worker and bump minimum node version to 14 (LTS)

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -46,7 +46,7 @@ module.exports = {
       resolve: 'gatsby-theme-carbon',
       options: {
         mdxExtensions: ['.mdx'],
-        isServiceWorkerEnabled: true,
+        isServiceWorkerEnabled: false,
         iconPath: './src/images/favicon.svg',
         titleType: 'prepend',
         repository: {
@@ -76,5 +76,6 @@ module.exports = {
         directory: path.resolve(__dirname, './src/data/chart-index'),
       },
     },
+    'gatsby-plugin-remove-serviceworker',
   ],
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "update-browserslist": "npx browserslist-ga"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "browserslist": [
     "last 1 edge version",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8261,7 +8261,7 @@ gatsby-plugin-react-helmet@^3.2.1:
 
 gatsby-plugin-remove-serviceworker@^1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
+  resolved "https://registry.npmjs.org/gatsby-plugin-remove-serviceworker/-/gatsby-plugin-remove-serviceworker-1.0.0.tgz#9fb433bc8bd766e14e1d3711c4ac6f051e1dff7c"
   integrity sha1-n7QzvIvXZuFOHTcRxKxvBR4d/3w=
 
 gatsby-plugin-sass-resources@^2.0.0:


### PR DESCRIPTION
We're getting some weird workbox related issues,  this disables the serviceworker. 

Considering the caching we're getting through cloudflare, the serviceworker's file serving complexity might be doing more harm than good.

After merging, in addition to ensuring the errors disappear, we can compare performance metrics to test that hypothesis.