### PR TITLE
chore(release): v10.37.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "resolutions": {
     "carbon-components": "^10.37.0",
-    "carbon-components-react": "^7.37.0",
+    "carbon-components-react": "^7.37.1",
     "@carbon/elements": "^10.36.0",
     "@carbon/icons": "^10.33.0",
     "@carbon/icons-react": "^10.33.0",
@@ -54,7 +54,7 @@
     "@loadable/component": "^5.12.0",
     "@slack/web-api": "^5.11.0",
     "carbon-components": "^10.37.0",
-    "carbon-components-react": "^7.37.0",
+    "carbon-components-react": "^7.37.1",
     "change-case": "^4.1.1",
     "classnames": "^2.2.6",
     "codesandbox": "^2.1.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4250,10 +4250,10 @@ capture-stack-trace@^1.0.0:
   resolved "https://registry.yarnpkg.com/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz#a6c0bbe1f38f3aa0b92238ecb6ff42c344d4135d"
   integrity sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==
 
-carbon-components-react@^7.33.0, carbon-components-react@^7.37.0:
-  version "7.37.0"
-  resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.37.0.tgz#ee2893e61cdc49b97f0dec68168a81e0ad12a028"
-  integrity sha512-iTiWYW2rdRM34uwJMYImo/t3itViVSR1In8e69i8sL+kxXWXXNtBVCsg2HKO3KXKVM9CzWe9JL4P51x2RDZ+IQ==
+carbon-components-react@^7.33.0, carbon-components-react@^7.37.1:
+  version "7.37.1"
+  resolved "https://registry.yarnpkg.com/carbon-components-react/-/carbon-components-react-7.37.1.tgz#7a2c2164e7115ebee7364cba6f0f97796490009e"
+  integrity sha512-ZA6vYsAjMpJuxGtc1dU+GVpyoAGyBfxgX0xqWYr3dftiQqfJJzmZF/tZFJQMxUlIOY1rmu1AtZz02ra6PPoS9g==
   dependencies:
     "@carbon/feature-flags" "^0.5.0"
     "@carbon/icons-react" "^10.33.0"


### PR DESCRIPTION
hot fix for broken Searches

**testing**
Check pages `Icons` and `Pictograms` to make sure search is no longer broken. 