### PR TITLE
docs: add Image production guidelines Sketch kit

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -177,7 +177,7 @@ For anyone interested in contributing to the Carbon Design System website, or ma
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Image production guidelines Sketch kit"
-    href="sketch://add-library/cloud/304313c1-29a8-4946-a6f0-51dbec953bc2"
+    href="sketch://add-library/cloud/240226b0-f455-484d-b412-cfd13fb1bb39"
     actionIcon="download">
     <MdxIcon name="sketch" />
   </ResourceCard>

--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -147,10 +147,10 @@ reflect IBM's spirit, beliefs, and design principles.
 
 ## Gatsby theme resources
 
-The Gatsby Sketch kit has all the components, patterns, and sample layouts that
-have been developed by teams within the IBM ecosystem. The Gatsby theme site
-includes the components, guidelines, and everything you need to create and
-contribute to Carbon sites.
+The Gatsby Sketch kit has all the components, patterns, and sample layouts that have been developed by teams within the IBM ecosystem. The Gatsby theme site includes the components, guidelines, and everything you need to create and contribute to Carbon sites.
+
+### Image production guidelines
+For anyone interested in contributing to the Carbon Design System website, or making images for their own Pattern Asset Library (PAL), we follow a set of guidelines to ensure consistency across the content in the Gatsby ecosystem. The image production guidelines Sketch kit includes guidance, symbols and templates to help designers with every aspect of image creation and component specs.
 
 <Row className="resource-card-group">
 
@@ -162,6 +162,7 @@ contribute to Carbon sites.
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>
+  
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Gatsby theme Carbon site"
@@ -172,6 +173,16 @@ contribute to Carbon sites.
 
   </ResourceCard>
 </Column>
+  
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="Image production guidelines Sketch kit"
+    href="sketch://add-library/cloud/304313c1-29a8-4946-a6f0-51dbec953bc2"
+    actionIcon="download">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+  
 </Row>
 
 ## GitHub repos


### PR DESCRIPTION
#### Changelog

**New**

- Added the Image production guidelines Sketch kit to the Other Resources page under "Designing".
- Added a heading and description for the kit under the Gatsby theme resources section.

----

**Testing**
- Go to `Designing` --> `Other resources` --> `Gatsby theme resources` --> Image production guidelines

