### PR TITLE
fix(IconLibrary): fix issue with glyph only icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "gatsby develop -H 0.0.0.0",
     "dev:clean": "gatsby clean && yarn dev",
     "clean": "gatsby clean",
-    "build": "node --max-old-space-size=4096 ./node_modules/.bin/gatsby build",
+    "build": "node --max-old-space-size=8192 ./node_modules/.bin/gatsby build",
     "build:clean": "gatsby clean && yarn build",
     "build:analyze": "yarn install --force && yarn clean && ANALYZE=true yarn build",
     "serve": "gatsby serve",

--- a/src/components/SVGLibraries/IconLibrary/IconLibrary.js
+++ b/src/components/SVGLibraries/IconLibrary/IconLibrary.js
@@ -32,12 +32,16 @@ const IconLibrary = () => {
 
       const path = [...icon.namespace, icon.name].join('/');
 
+      const glyphOnly = icon.sizes.length === 1 && icon.sizes[0] === 'glyph';
+
       return [
         ...accumulator,
         {
           ...icon,
           Component: loadable(() =>
-            import(`@carbon/icons-react/lib/${path}/32`)
+            import(
+              `@carbon/icons-react/lib/${path}/${glyphOnly ? 'index' : '32'}`
+            )
           ),
         },
       ];

--- a/src/components/SVGLibraries/IconLibrary/IconLibrary.js
+++ b/src/components/SVGLibraries/IconLibrary/IconLibrary.js
@@ -32,16 +32,23 @@ const IconLibrary = () => {
 
       const path = [...icon.namespace, icon.name].join('/');
 
-      const glyphOnly = icon.sizes.length === 1 && icon.sizes[0] === 'glyph';
-
+      if (icon.sizes.length === 1 && icon.sizes[0] === 'glyph') {
+        return [
+          ...accumulator,
+          {
+            ...icon,
+            Component: loadable(() =>
+              import(`@carbon/icons-react/lib/${path}/index`)
+            ),
+          },
+        ];
+      }
       return [
         ...accumulator,
         {
           ...icon,
           Component: loadable(() =>
-            import(
-              `@carbon/icons-react/lib/${path}/${glyphOnly ? 'index' : '32'}`
-            )
+            import(`@carbon/icons-react/lib/${path}/32`)
           ),
         },
       ];


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/2448

Fixes an issue where we were importing all icons at the `32px` size, even if it was a glyph-only variant. This was causing the `guidelines/iconography` page to crash when one of these icons were loaded

#### Changelog

**Changed**

- If there is only 1 icon size, and the icon size is `glyph`, sets a flag that will load from the `index` file rather than `32` 

**Testing**

Go to `guidelines/iconography` and search for `caution` and ensure the page does not crash 
