### PR TITLE
fix(demo link list): make scrollable only if there's overflow

### DIFF
--- a/src/components/ComponentDemo/Code/Code.module.scss
+++ b/src/components/ComponentDemo/Code/Code.module.scss
@@ -46,7 +46,7 @@
 
 .link-list {
   display: flex;
-  overflow-x: scroll;
+  overflow-x: auto;
   @include carbon--breakpoint('md') {
     overflow-x: visible;
   }


### PR DESCRIPTION
This is the issue the 1-liner fix here is trying to address

![image](https://user-images.githubusercontent.com/14989804/127058695-c7765ae9-4833-483e-bc1c-8aca717e6e86.png)
