### PR TITLE
docs(data table) fix content guidance links

### DIFF
--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -474,7 +474,7 @@ other.
 - A description can be added under the title to provide more information about
   the data or its source.
 - A data table's title and description should use
-  [sentence-case capitalization.](/guidelines/content/guidance#use-sentence-case-capitalization)
+  [sentence-case capitalization.](/guidelines/content/writing-style#use-sentence-case-capitalization)
 
 #### Column titles
 
@@ -484,7 +484,7 @@ other.
   truncate the rest of the text. The full text should be shown in a tooltip on
   hover.
 - Column titles should use
-  [sentence-case capitalization.](/guidelines/content/guidance#use-sentence-case-capitalization)
+  [sentence-case capitalization.](/guidelines/content/writing-style#use-sentence-case-capitalization)
 
 #### Primary button
 


### PR DESCRIPTION
Fixes two instance of broken links to content guidance on the data table component usage documentation.

**Changed**

- Sentence case links under the Content section.
