### PR TITLE
fix: resolve syntax error in npm call

### DIFF
--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -69,7 +69,7 @@ installing or updating one package.
 1. Install the new package
 
 ```
-npm -i @carbon/react
+npm i @carbon/react
 ```
 
 ```


### PR DESCRIPTION
In the [Carbon 11 migration guide](https://v11.carbondesignsystem.com/migrating/guide/develop/#how-to-migrate), the documented command `npm -i` gives an error:

```
>npm -i @carbon/react
Unknown command: "@carbon/react"

To see a list of supported npm commands, run:
  npm help
```

#### Changelog

**Changed**

- Replaced the wrong command with the corrected syntax