### PR TITLE
fix(overview-page): update image import

### DIFF
--- a/src/components/ComponentOverview/ComponentOverview.js
+++ b/src/components/ComponentOverview/ComponentOverview.js
@@ -19,10 +19,10 @@ class ComponentOverview extends React.Component {
 
     let componentImg;
     try {
-      componentImg = require(`./images/${component}.svg`);
+      componentImg = require(`./images/${component}.svg`).default;
     } catch (e) {
       // eslint-disable-next-line global-require
-      componentImg = require('./images/NoImage.svg');
+      componentImg = require('./images/NoImage.svg').default;
     }
 
     return (


### PR DESCRIPTION
Closes #2540 
Closes #2514 

Update the image imports in the overview page so that the image URL is valid.

#### Changelog

**New**

**Changed**

- Fix component overview page where URL was being resolved to `[object Module]`

**Removed**
