### PR TITLE
fix: update link to the new URL of Gatsby theme

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -174,7 +174,7 @@ to help designers with every aspect of image creation and component specs.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Gatsby theme Carbon site"
-    href="https://gatsby-theme-carbon.vercel.app/"
+    href="https://gatsby.carbondesignsystem.com/"
     actionIcon="launch">
 
 ![Gatsby icon](images/gatsby.svg)


### PR DESCRIPTION
As @vpicone recently wrote, https://gatsby.carbondesignsystem.com/ should be the new URL for the Gatsby Carbon theme. The old URL is still being used here, so I propose to use the new one instead.

#### Changelog

**Changed**

- The Carbon Gatsby theme URL link