### PR TITLE
fix(Carbon-Website): update component accessibility links

### DIFF
--- a/src/pages/components/accordion/accessibility.mdx
+++ b/src/pages/components/accordion/accessibility.mdx
@@ -103,7 +103,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+accordion%22+).
 
 ### Automated test
 

--- a/src/pages/components/breadcrumb/accessibility.mdx
+++ b/src/pages/components/breadcrumb/accessibility.mdx
@@ -69,7 +69,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Design System GitHub repository](https://github.com/carbon-design-system/carbon/labels/type%3A%20a11y%20%E2%99%BF).
+[Carbon Design System GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+breadcrumb%22+).
 
 ### Automated test
 

--- a/src/pages/components/button/accessibility.mdx
+++ b/src/pages/components/button/accessibility.mdx
@@ -77,7 +77,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Design System GitHub repository](https://github.com/carbon-design-system/carbon/labels/type%3A%20a11y%20%E2%99%BF).
+[Carbon Design System GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+button%22+).
 
 ### Automated test
 

--- a/src/pages/components/checkbox/accessibility.mdx
+++ b/src/pages/components/checkbox/accessibility.mdx
@@ -79,7 +79,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+checkbox%22+).
 
 ### Automated test
 

--- a/src/pages/components/form/accessibility.mdx
+++ b/src/pages/components/form/accessibility.mdx
@@ -79,7 +79,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+form%22+).
 For screen reader test results refer to the Accessibility guidance for each
 Carbon Component form control used.
 

--- a/src/pages/components/inline-loading/accessibility.mdx
+++ b/src/pages/components/inline-loading/accessibility.mdx
@@ -47,7 +47,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestone/57).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+loading%22+).
 
 ### Automated test
 

--- a/src/pages/components/link/accessibility.mdx
+++ b/src/pages/components/link/accessibility.mdx
@@ -65,7 +65,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones)
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+link%22+)
 
 ### Automated test
 

--- a/src/pages/components/list/accessibility.mdx
+++ b/src/pages/components/list/accessibility.mdx
@@ -58,7 +58,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+list%22+).
 
 ### Automated test
 

--- a/src/pages/components/loading/accessibility.mdx
+++ b/src/pages/components/loading/accessibility.mdx
@@ -52,7 +52,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+loading%22+).
 
 ### Automated test
 

--- a/src/pages/components/modal/accessibility.mdx
+++ b/src/pages/components/modal/accessibility.mdx
@@ -85,7 +85,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+modal%22+).
 
 ### Automated test
 

--- a/src/pages/components/notification/accessibility.mdx
+++ b/src/pages/components/notification/accessibility.mdx
@@ -77,7 +77,7 @@ key is used to move focus to the close button within the notification and the
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+notification%22+).
 
 ### Automated test
 

--- a/src/pages/components/overflow-menu/accessibility.mdx
+++ b/src/pages/components/overflow-menu/accessibility.mdx
@@ -91,7 +91,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+overflow-menu%22+).
 
 ### Automated test
 

--- a/src/pages/components/radio-button/accessibility.mdx
+++ b/src/pages/components/radio-button/accessibility.mdx
@@ -55,7 +55,7 @@ keyboard focus placing the element in the logical navigation flow.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+radio-button%22+).
 
 ### Automated test
 

--- a/src/pages/components/search/accessibility.mdx
+++ b/src/pages/components/search/accessibility.mdx
@@ -53,7 +53,7 @@ understand the purpose of the button.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestone/).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+search%22+).
 
 ### Automated test
 

--- a/src/pages/components/select/accessibility.mdx
+++ b/src/pages/components/select/accessibility.mdx
@@ -71,7 +71,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+select%22+).
 
 ### Automated test
 

--- a/src/pages/components/slider/accessibility.mdx
+++ b/src/pages/components/slider/accessibility.mdx
@@ -67,7 +67,7 @@ be updated when these accessibility issues are resolved.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestone/57).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+slider%22+).
 
 ### Automated test
 

--- a/src/pages/components/tag/accessibility.mdx
+++ b/src/pages/components/tag/accessibility.mdx
@@ -61,7 +61,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones)
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+tag%22+)
 
 ### Automated test
 

--- a/src/pages/components/text-input/accessibility.mdx
+++ b/src/pages/components/text-input/accessibility.mdx
@@ -68,7 +68,7 @@ optional input, data formats, and other relevant information.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+text-input%22+).
 
 ### Automated test
 

--- a/src/pages/components/toggle/accessibility.mdx
+++ b/src/pages/components/toggle/accessibility.mdx
@@ -76,7 +76,7 @@ content to this component.
 ## Accessibility testing
 
 Accessibility issues are tracked in the
-[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/milestones).
+[Carbon Component GitHub repository](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+label%3A%22type%3A+a11y+%E2%99%BF%22+label%3A%22component%3A+toggle%22+).
 
 ### Automated test
 


### PR DESCRIPTION
Some of our accessibility links pointed to a milestone issue we don't use to track a11y issues anymore. This updates those links with relevant issue searches 👍🏾 
