### PR TITLE
Fix a small typo in documentation

### DIFF
--- a/src/pages/components/inline-loading/code.mdx
+++ b/src/pages/components/inline-loading/code.mdx
@@ -7,7 +7,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 <PageDescription>
 
-Preview the accordion component with the React live demo. For detailed code
+Preview the inline loading component with the React live demo. For detailed code
 usage documentation, see the Storybooks for each framework below.
 
 </PageDescription>


### PR DESCRIPTION
Closes # NA

Fix the typo in documentation by updating with correct component name.

#### Changelog

**New**

- NA

**Changed**

- updated the component name from accordion to inline loading

**Removed**

- NA
