### PR TITLE
feat(design-resources): added a11y kit

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -21,6 +21,7 @@ templates, color palettes, GitHub repos, and design tools.
   <AnchorLink>Gatsby theme</AnchorLink>
   <AnchorLink>GitHub repos</AnchorLink>
   <AnchorLink>Native mobile</AnchorLink>
+  <AnchorLink>Accessibility</AnchorLink>
   <AnchorLink>Prototyping tools</AnchorLink>
 
 </AnchorLinks>
@@ -255,6 +256,23 @@ the patterns and examples, and get started with either the Light or Dark theme.
   <ResourceCard
     subTitle="Mobile patterns and examples"
     href="https://www.sketch.com/s/f13d67b9-3116-4b50-a2e9-56148f1976b0"
+    actionIcon="launch">
+    <MdxIcon name="sketch" />
+  </ResourceCard>
+</Column>
+</Row>
+
+## Accessibility
+
+The IBM Accessibility Sketch kit includes checklists, bite-sized guidance, and
+handoff assets to make sure your designs are accessible for implementation.
+
+<Row className="resource-card-group">
+
+<Column colLg={4} colMd={4} noGutterSm>
+  <ResourceCard
+    subTitle="IBM Accessibility Sketch kit"
+    href="https://www.sketch.com/s/f0a04c0d-fb62-4d71-92c6-07c402f8cae7"
     actionIcon="launch">
     <MdxIcon name="sketch" />
   </ResourceCard>


### PR DESCRIPTION
**New**

- Added the IBM Accessibility Sketch kit to the website
  - Added a new section and description
  - Added anchor link
  - Added a resource card

-----
**Testing**
- Go to `Designing`  --> `Other resources` --> `Accessibility` section
  - Make sure resource card link works and links out to Sketch Cloud for the option to add library or download file for guidance.

author @laurenmrice 