### PR TITLE
Remove Mike Abbink from Carbon team page

### DIFF
--- a/src/pages/all-about-carbon/the-team.mdx
+++ b/src/pages/all-about-carbon/the-team.mdx
@@ -17,9 +17,6 @@ design and build with them.
 ## Design system
 
 <Row>
-
-
-</Profile>
 <Profile name="John Bister" title="Motion Designer">
 
 ![John Bister headshot](/images/team/bister_john.png)

--- a/src/pages/all-about-carbon/the-team.mdx
+++ b/src/pages/all-about-carbon/the-team.mdx
@@ -18,9 +18,6 @@ design and build with them.
 
 <Row>
 
-<Profile name="Mike Abbink" title="IBM Distinguished Designer">
-
-![Mike Abbink headshot](/images/team/abbink_mike.png)
 
 </Profile>
 <Profile name="John Bister" title="Motion Designer">


### PR DESCRIPTION
Remove Mike Abbink from Carbon team page as his role fits more into the steering committee and the Advisory board and does not need to be in three places.