### PR TITLE
v11[bugs]: assorted color token bugs on style tabs

### DIFF
--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -33,7 +33,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Class                                                  | Property         | Color token     |
 | ------------------------------------------------------ | ---------------- | --------------- |
-| `.bx--snippet`                                         | background       | `$field`        |
+| `.bx--snippet`                                         | background       | `$layer`        |
 | `.bx--snippet`                                         | text color       | `$text-primary` |
 | `.bx--snippet__icon`                                   | svg              | `$icon-primary` |
 | `.bx--copy-btn:hover` <br/> `.bx--snippet-btn:hover`   | background-color | `$layer-hover`  |
@@ -66,9 +66,9 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Class                         | Property         | Color token     |
 | ----------------------------- | ---------------- | --------------- |
-| `.bx--snippet--inline`        | background-color | `$field`        |
+| `.bx--snippet--inline`        | background-color | `$layer`        |
 | `.bx--snippet--inline`        | color            | `$text-primary` |
-| `.bx--snippet--inline:hover`  | background-color | `$field-hover`  |
+| `.bx--snippet--inline:hover`  | background-color | `$layer-hover`  |
 | `.bx--snippet--inline:focus`  | focus            | `$focus`        |
 | `.bx--snippet--inline:active` | background-color | `$layer-active` |
 

--- a/src/pages/components/content-switcher/style.mdx
+++ b/src/pages/components/content-switcher/style.mdx
@@ -13,13 +13,13 @@ Content switchers have two main states: `selected` and `unselected`. By default,
 content switcher buttons are unselected with the selected state using a high
 contrast color.
 
-| Class                       | Property         | Color token      |
-| --------------------------- | ---------------- | ---------------- |
-| `.bx--content-switcher-btn` | background-color | `$ui-background` |
-| `.bx--content-switcher-btn` | text color       | `$text-02`       |
-| `--selected`                | background-color | `$ui-05`         |
-| `--selected`                | text color       | `$inverse-01`    |
-| `:after`                    | divider          | `$ui-03`         |
+| Class                       | Property         | Color token               |
+| --------------------------- | ---------------- | ------------------------- |
+| `.bx--content-switcher-btn` | background-color | `$background`             |
+| `.bx--content-switcher-btn` | text color       | `$text-secondary`         |
+| `--selected`                | background-color | `$layer-selected-inverse` |
+| `--selected`                | text color       | `$text-inverse`           |
+| `:after`                    | divider          | `$border-subtle`          |
 
 ### Interactive states
 

--- a/src/pages/components/date-picker/style.mdx
+++ b/src/pages/components/date-picker/style.mdx
@@ -34,7 +34,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Warning  | Warning message | text-color       | `$text-primary`    |
 |          | Warning icon    | svg              | `$support-warning` |
 | Disabled | Label           | text-color       | `$text-disabled`   |
-|          | Field           | background-color | `$field-disabled`  |
+|          | Field           | background-color | `$field`           |
+|          | Field           | border-bottom    | transparent        |
 |          | Field text      | text-color       | `$text-disabled`   |
 |          | Calendar icon   | svg              | `$icon-disabled`   |
 

--- a/src/pages/components/dropdown/style.mdx
+++ b/src/pages/components/dropdown/style.mdx
@@ -55,7 +55,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 |                | Menu option     | checkmark        | `$icon-primary`       |
 | Multi-selected | Tag             | background-color | `$background-inverse` |
 |                | Tag             | text-color       | `$text-inverse`       |
-| Disabled       | Field           | background-color | `$field-disabled`     |
+| Disabled       | Field           | background-color | `$field`              |
+|                | Field           | border-bottom    | transparent           |
 |                | Field           | text-color       | `$text-disabled`      |
 |                | Label           | text-color       | `$text-disabled`      |
 |                | Chevron icon    | svg              | `$icon-disabled`      |

--- a/src/pages/components/file-uploader/style.mdx
+++ b/src/pages/components/file-uploader/style.mdx
@@ -45,7 +45,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Disabled | Label          | text-color                                                                                     | `$text-disabled`   |
 |          | Description    | text-color                                                                                     | `$text-disabled`   |
 |          | Drop text      | text-color                                                                                     | `$text-disabled`   |
-|          | Drop container | border                                                                                         | `$button-disabled` |
+|          | Drop container | border                                                                                         | `$border-disabled` |
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/inline-loading/style.mdx
+++ b/src/pages/components/inline-loading/style.mdx
@@ -7,13 +7,13 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                       | Property | Color token       |
-| --------------------------- | -------- | ----------------- |
-| `.bx--loading__background`  | stroke   | `$ui-03`          |
-| `.bx--loading__stroke`      | stroke   | `$interactive-04` |
-| `.bx--inline-loading__text` | color    | `$text-02`        |
-| `status: finished`          | svg      | `$support-02`     |
-| `status: finished`          | svg      | `$support-01`     |
+| Class                       | Property | Color token           |
+| --------------------------- | -------- | --------------------- |
+| `.bx--loading__background`  | stroke   | `$border-subtle`      |
+| `.bx--loading__stroke`      | stroke   | `$border-interactive` |
+| `.bx--inline-loading__text` | color    | `$text-secondary`     |
+| `status: finished`          | svg      | `$support-success`    |
+| `status: finished`          | svg      | `$support-error`      |
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/number-input/style.mdx
+++ b/src/pages/components/number-input/style.mdx
@@ -29,16 +29,17 @@ used on `$background` and `$overlay` page backgrounds.
 
 ### Interactive states
 
-| Class                                       | Property         | Color token       |
-| ------------------------------------------- | ---------------- | ----------------- |
-| `.bx--number:focus`                         | border           | `$focus`          |
-| `.bx--number__controls:focus`               | border           | `$focus`          |
-| `[data-invalid]`                            | border           | `$support-error`  |
-| `[data-invalid]:focus`                      | color            | `$support-error`  |
-| `.bx--form-requirement`                     | text color       | `$support-error`  |
-| `.bx--label:disabled`                       | text color       | `$text-disabled`  |
-| `.bx--number:disabled`                      | background-color | `$field-disabled` |
-| `.bx--number input[type='number']:disabled` | text color       | `$text-disabled`  |
+| Class                                       | Property         | Color token      |
+| ------------------------------------------- | ---------------- | ---------------- |
+| `.bx--number:focus`                         | border           | `$focus`         |
+| `.bx--number__controls:focus`               | border           | `$focus`         |
+| `[data-invalid]`                            | border           | `$support-error` |
+| `[data-invalid]:focus`                      | color            | `$support-error` |
+| `.bx--form-requirement`                     | text color       | `$support-error` |
+| `.bx--label:disabled`                       | text color       | `$text-disabled` |
+| `.bx--number:disabled`                      | background-color | `$field`         |
+| `.bx--number:disabled`                      | border-bottom    | transparent      |
+| `.bx--number input[type='number']:disabled` | text color       | `$text-disabled` |
 
 **Active:** Number input should have a default number to start. The input should
 never be empty.

--- a/src/pages/components/search/style.mdx
+++ b/src/pages/components/search/style.mdx
@@ -30,12 +30,13 @@ input color is `$field-02` and is used on `$ui-01` page backgrounds.
 
 ### Interactive colors
 
-| Class                            | Property         | Color token       |
-| -------------------------------- | ---------------- | ----------------- |
-| `.bx--search-input:focus`        | border           | `$focus`          |
-| `.bx--search-input:disabled`     | background-color | `$field-disabled` |
-| `.bx--search-input:disabled`     | text color       | `$text-disabled`  |
-| `.bx--search-magnifier:disabled` | fill             | `$icon-disabled`  |
+| Class                            | Property         | Color token      |
+| -------------------------------- | ---------------- | ---------------- |
+| `.bx--search-input:focus`        | border           | `$focus`         |
+| `.bx--search-input:disabled`     | background-color | `$field`         |
+| `.bx--search-input:disabled`     | border-bottom    | transparent      |
+| `.bx--search-input:disabled`     | text color       | `$text-disabled` |
+| `.bx--search-magnifier:disabled` | fill             | `$icon-disabled` |
 
 <div className="image--fixed">
 

--- a/src/pages/components/select/style.mdx
+++ b/src/pages/components/select/style.mdx
@@ -8,14 +8,15 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                 | Property   | Color token     |
-| --------------------- | ---------- | --------------- |
-| `.bx--select-input`   | background | `$field`        |
-| `.bx--select--inline` | background | transparent     |
-| `.bx--label`          | text color | `$text-primary` |
-| `.bx--select-input`   | text color | `$text-primary` |
-| `.bx--select--inline` | text color | `$icon-primary` |
-| `.bx--select__arrow`  | fill       | `$icon-primary` |
+| Class                 | Property      | Color token      |
+| --------------------- | ------------- | ---------------- |
+| `.bx--select-input`   | background    | `$field`         |
+| `.bx--select-input`   | border-bottom | `$border-strong` |
+| `.bx--select--inline` | background    | transparent      |
+| `.bx--label`          | text color    | `$text-primary`  |
+| `.bx--select-input`   | text color    | `$text-primary`  |
+| `.bx--select--inline` | text color    | `$icon-primary`  |
+| `.bx--select__arrow`  | fill          | `$icon-primary`  |
 
 <div className="image--fixed">
 
@@ -27,13 +28,14 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Interaction states
 
-| Class                             | Property   | Color token       |
-| --------------------------------- | ---------- | ----------------- |
-| `.bx--select-input:focus`         | border     | `$focus`          |
-| `.bx--select-input[data-invalid]` | border     | `$support-error`  |
-| `.bx--form-requirement`           | text color | `$support-error`  |
-| `.bx--select-input:disabled`      | background | `$field-disabled` |
-| `.bx--select-input:disabled`      | text color | `$text-disabled`  |
+| Class                             | Property      | Color token      |
+| --------------------------------- | ------------- | ---------------- |
+| `.bx--select-input:focus`         | border        | `$focus`         |
+| `.bx--select-input[data-invalid]` | border        | `$support-error` |
+| `.bx--form-requirement`           | text color    | `$support-error` |
+| `.bx--select-input:disabled`      | background    | `$field`         |
+| `.bx--select-input:disabled`      | border-bottom | transparent      |
+| `.bx--select-input:disabled`      | text color    | `$text-disabled` |
 
 <div className="image--fixed">
 

--- a/src/pages/components/tabs/style.mdx
+++ b/src/pages/components/tabs/style.mdx
@@ -17,18 +17,18 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Line tabs
 
-| State    | Element               | Property         | Color token                                    |
-| -------- | --------------------- | ---------------- | ---------------------------------------------- |
-| Enabled  | Background            | background-color | transparent                                    |
-|          | Label                 | text-color       | `$text-secondary`                              |
-|          | Icon                  | svg              | `$icon-secondary`                              |
-|          | Background            | border-bottom    | `$border-subtle`                               |
-|          | Scrollable icon       | svg              | `$icon-primary`                                |
-|          | Scrollable fade       | background-color | 8px, linear-gradient white to 100% transparent |
-|          | Scrollable background | background-color | `$background`                                  |
-| Selected | Label                 | text-color       | `$text-primary`                                |
-|          | Icon                  | svg              | `$icon-primary`                                |
-|          | Background            | border-bottom    | `$interactive`                                 |
+| State    | Element               | Property         | Color token                                            |
+| -------- | --------------------- | ---------------- | ------------------------------------------------------ |
+| Enabled  | Background            | background-color | transparent                                            |
+|          | Label                 | text-color       | `$text-secondary`                                      |
+|          | Icon                  | svg              | `$icon-secondary`                                      |
+|          | Background            | border-bottom    | `$border-subtle`                                       |
+|          | Scrollable icon       | svg              | `$icon-primary`                                        |
+|          | Scrollable fade       | background-color | 8px, linear-gradient `$background` to 100% transparent |
+|          | Scrollable background | background-color | `$background`                                          |
+| Selected | Label                 | text-color       | `$text-primary`                                        |
+|          | Icon                  | svg              | `$icon-primary`                                        |
+|          | Background            | border-bottom    | `$interactive`                                         |
 
 <div className="image--fixed">
 
@@ -60,7 +60,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 |                | Icon                  | svg              | `$icon-primary`     |
 | Disabled       | Label                 | text-color       | `$text-disabled`    |
 |                | Icon                  | svg              | `$icon-disabled`    |
-|                | Background            | background-color | `$icon-disabled`    |
+|                | Background            | background-color | transparent         |
 
 <div className="image--fixed">
 
@@ -128,7 +128,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 |                | Icon                  | svg              | `$icon-primary`        |
 | Disabled       | Label                 | text-color       | `$text-disabled`       |
 |                | Icon                  | svg              | `$icon-disabled`       |
-|                | Background            | background-color | `$icon-disabled`       |
+|                | Background            | background-color | `$button-disabled`     |
 |                | Border                | border-right     | `$border-disabled`     |
 
 <div className="image--fixed">

--- a/src/pages/components/text-input/style.mdx
+++ b/src/pages/components/text-input/style.mdx
@@ -27,14 +27,15 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Interactive states
 
-| State    | Element       | Property   | Color token       |
-| -------- | ------------- | ---------- | ----------------- |
-| Focus    | Field         | outline    | `$focus`          |
-| Invalid  | Field         | outline    | `$support-error`  |
-|          | Error message | text color | `$text-error`     |
-|          | Warning icon  | svg        | `$support-error`  |
-| Disabled | Field         | background | `$field-disabled` |
-|          | Field text    | text color | `$disabled-02`    |
+| State    | Element       | Property      | Color token      |
+| -------- | ------------- | ------------- | ---------------- |
+| Focus    | Field         | outline       | `$focus`         |
+| Invalid  | Field         | outline       | `$support-error` |
+|          | Error message | text color    | `$text-error`    |
+|          | Warning icon  | svg           | `$support-error` |
+| Disabled | Field         | background    | `$field`         |
+|          | Field         | border-bottom | transparent      |
+|          | Field text    | text color    | `$text-disabled` |
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/tile/style.mdx
+++ b/src/pages/components/tile/style.mdx
@@ -8,15 +8,14 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class            | Property         | Color token       |
-| ---------------- | ---------------- | ----------------- |
-| Tile             | background-color | `$layer`          |
-| Tile: focus      | border           | `$focus`          |
-| Tile: hover      | background-color | `$layer-hover`    |
-| Tile: selected   | border           | `$border-inverse` |
-| Chevron icon     | svg              | `$icon-primary`   |
-| Checkmark icon   | svg              | `$icon-primary`   |
-| Checkmark: hover | svg              | `$icon-secondary` |
+| Class          | Property         | Color token       |
+| -------------- | ---------------- | ----------------- |
+| Tile           | background-color | `$layer`          |
+| Tile: focus    | border           | `$focus`          |
+| Tile: hover    | background-color | `$layer-hover`    |
+| Tile: selected | border           | `$border-inverse` |
+| Chevron icon   | svg              | `$icon-primary`   |
+| Checkmark icon | svg              | `$icon-primary`   |
 
 ## Structure
 


### PR DESCRIPTION
- updated `$field-disabled` instances to be just `$field`
- updated content switcher and inline loading v10 tokens
- updated/added border-bottom to disabled inputs as transparent