### PR TITLE
chore(ci): add ci workflow action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: ci
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Check formatting of project files
+        run: yarn format:check
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v2.4.1
+        with:
+          node-version: '14.x'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Lint JavaScript files
+        run: yarn lint:js

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "serve": "gatsby serve",
     "lint:js": "eslint . --fix",
     "format": "prettier --write 'src/**/*.{css,scss,json,html,yaml,md,mdx}'",
+    "format:check": "prettier --check 'src/**/*.{css,scss,json,html,yaml,md,mdx}'",
     "update-browserslist": "npx browserslist-ga"
   },
   "engines": {

--- a/src/pages/community/patterns/chatbot/content.mdx
+++ b/src/pages/community/patterns/chatbot/content.mdx
@@ -88,7 +88,8 @@ Ensure the success of your bot by following these principles:
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design for AI: Conversation"
-      href="http://ai-design.eu-de.mybluemix.net/design/ai/conversation/planning">
+      href="http://ai-design.eu-de.mybluemix.net/design/ai/conversation/planning"
+    >
       <MdxIcon name="bee" />
     </ResourceCard>
   </Column>

--- a/src/pages/community/patterns/chatbot/overview.mdx
+++ b/src/pages/community/patterns/chatbot/overview.mdx
@@ -133,7 +133,8 @@ guidance related to your use case.
     title="Chatbot Design Kit"
     aspectRatio="2:1"
     actionIcon="launch"
-    href="https://www.sketch.com/s/d6986eb8-bf0d-4695-abe8-9e79909d4518">
+    href="https://www.sketch.com/s/d6986eb8-bf0d-4695-abe8-9e79909d4518"
+  >
     <MdxIcon name="sketch" />
   </ResourceCard>
 </Column>

--- a/src/pages/community/patterns/remove-pattern/index.mdx
+++ b/src/pages/community/patterns/remove-pattern/index.mdx
@@ -191,8 +191,7 @@ the user through the optional passive modal.
 
 <Caption>
   {' '}
-  Use a success modal to show that a delete request has been made / is in
-  progress.
+  Use a success modal to show that a delete request has been made / is in progress.
 </Caption>
 
 ![Example of a remove successful modal](images/DoneMedium.png)
@@ -214,8 +213,8 @@ completed. This is useful when the action takes more than a few moments.
 
 <Caption>
   {' '}
-  An optional notification can be used to confirm the delete or remove action
-  with medium or high impact actions.
+  An optional notification can be used to confirm the delete or remove action with
+  medium or high impact actions.
 </Caption>
 
 </Column>

--- a/src/pages/components/UI-shell-left-panel/usage.mdx
+++ b/src/pages/components/UI-shell-left-panel/usage.mdx
@@ -28,7 +28,8 @@ interaction patterns that persist between and across products.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://sketch.cloud/s/EjVmA">
+      href="https://sketch.cloud/s/EjVmA"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -28,7 +28,8 @@ interaction patterns that persist between and across products.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://sketch.cloud/s/EjVmA">
+      href="https://sketch.cloud/s/EjVmA"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/components/breadcrumb/style.mdx
+++ b/src/pages/components/breadcrumb/style.mdx
@@ -59,12 +59,14 @@ recommended for the overflow breadcrumb list.
 
 <h3
   class="AutolinkHeader-module--header--1G1tm Markdown-module--h3--Gwbvh"
-  id="truncated breadcrumbs color">
+  id="truncated breadcrumbs color"
+>
   Color
   <a
     class="AutolinkHeader-module--anchor--36UpA AutolinkHeader-module--left-anchor--1SDoO"
     href="#color"
-    aria-label="Color permalink">
+    aria-label="Color permalink"
+  >
     <svg
       focusable="false"
       preserveAspectRatio="xMidYMid meet"
@@ -73,7 +75,8 @@ recommended for the overflow breadcrumb list.
       width="20"
       height="20"
       viewBox="0 0 32 32"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <path d="M29.25,6.76a6,6,0,0,0-8.5,0l1.42,1.42a4,4,0,1,1,5.67,5.67l-8,8a4,4,0,1,1-5.67-5.66l1.41-1.42-1.41-1.42-1.42,1.42a6,6,0,0,0,0,8.5A6,6,0,0,0,17,25a6,6,0,0,0,4.27-1.76l8-8A6,6,0,0,0,29.25,6.76Z"></path>
       <path d="M4.19,24.82a4,4,0,0,1,0-5.67l8-8a4,4,0,0,1,5.67,0A3.94,3.94,0,0,1,19,14a4,4,0,0,1-1.17,2.85L15.71,19l1.42,1.42,2.12-2.12a6,6,0,0,0-8.51-8.51l-8,8a6,6,0,0,0,0,8.51A6,6,0,0,0,7,28a6.07,6.07,0,0,0,4.28-1.76L9.86,24.82A4,4,0,0,1,4.19,24.82Z"></path>
     </svg>
@@ -87,12 +90,14 @@ recommended for the overflow breadcrumb list.
 
 <h3
   class="AutolinkHeader-module--header--1G1tm Markdown-module--h3--Gwbvh"
-  id="truncated breadcrumbs typography">
+  id="truncated breadcrumbs typography"
+>
   Typography
   <a
     class="AutolinkHeader-module--anchor--36UpA AutolinkHeader-module--left-anchor--1SDoO"
     href="#typography"
-    aria-label="Typography permalink">
+    aria-label="Typography permalink"
+  >
     <svg
       focusable="false"
       preserveAspectRatio="xMidYMid meet"
@@ -101,7 +106,8 @@ recommended for the overflow breadcrumb list.
       width="20"
       height="20"
       viewBox="0 0 32 32"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <path d="M29.25,6.76a6,6,0,0,0-8.5,0l1.42,1.42a4,4,0,1,1,5.67,5.67l-8,8a4,4,0,1,1-5.67-5.66l1.41-1.42-1.41-1.42-1.42,1.42a6,6,0,0,0,0,8.5A6,6,0,0,0,17,25a6,6,0,0,0,4.27-1.76l8-8A6,6,0,0,0,29.25,6.76Z"></path>
       <path d="M4.19,24.82a4,4,0,0,1,0-5.67l8-8a4,4,0,0,1,5.67,0A3.94,3.94,0,0,1,19,14a4,4,0,0,1-1.17,2.85L15.71,19l1.42,1.42,2.12-2.12a6,6,0,0,0-8.51-8.51l-8,8a6,6,0,0,0,0,8.51A6,6,0,0,0,7,28a6.07,6.07,0,0,0,4.28-1.76L9.86,24.82A4,4,0,0,1,4.19,24.82Z"></path>
     </svg>
@@ -114,12 +120,14 @@ recommended for the overflow breadcrumb list.
 
 <h3
   class="AutolinkHeader-module--header--1G1tm Markdown-module--h3--Gwbvh"
-  id="truncated breadcrumbs structure">
+  id="truncated breadcrumbs structure"
+>
   Structure
   <a
     class="AutolinkHeader-module--anchor--36UpA AutolinkHeader-module--left-anchor--1SDoO"
     href="#structure"
-    aria-label="Structure permalink">
+    aria-label="Structure permalink"
+  >
     <svg
       focusable="false"
       preserveAspectRatio="xMidYMid meet"
@@ -128,7 +136,8 @@ recommended for the overflow breadcrumb list.
       width="20"
       height="20"
       viewBox="0 0 32 32"
-      aria-hidden="true">
+      aria-hidden="true"
+    >
       <path d="M29.25,6.76a6,6,0,0,0-8.5,0l1.42,1.42a4,4,0,1,1,5.67,5.67l-8,8a4,4,0,1,1-5.67-5.66l1.41-1.42-1.41-1.42-1.42,1.42a6,6,0,0,0,0,8.5A6,6,0,0,0,17,25a6,6,0,0,0,4.27-1.76l8-8A6,6,0,0,0,29.25,6.76Z"></path>
       <path d="M4.19,24.82a4,4,0,0,1,0-5.67l8-8a4,4,0,0,1,5.67,0A3.94,3.94,0,0,1,19,14a4,4,0,0,1-1.17,2.85L15.71,19l1.42,1.42,2.12-2.12a6,6,0,0,0-8.51-8.51l-8,8a6,6,0,0,0,0,8.51A6,6,0,0,0,7,28a6.07,6.07,0,0,0,4.28-1.76L9.86,24.82A4,4,0,0,1,4.19,24.82Z"></path>
     </svg>

--- a/src/pages/data-visualization/simple-charts/index.mdx
+++ b/src/pages/data-visualization/simple-charts/index.mdx
@@ -30,7 +30,8 @@ import ChartDemoGroup from '../../../components/data-visualization/ChartDemoGrou
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Carbon Charts demo site"
-      href="https://carbon-design-system.github.io/carbon-charts/">
+      href="https://carbon-design-system.github.io/carbon-charts/"
+    >
       <MdxIcon name="storybook" />
     </ResourceCard>
   </Column>

--- a/src/pages/designing/kits/sketch.mdx
+++ b/src/pages/designing/kits/sketch.mdx
@@ -40,7 +40,8 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('P0OEN9TS', 0)}
       subTitle="White theme"
-      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1">
+      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -48,7 +49,8 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('T7D1HJ3L', 0)}
       subTitle="Gray 10 theme"
-      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f">
+      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -56,7 +58,8 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('LYFJTPDE', 0)}
       subTitle="Gray 90 theme"
-      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc">
+      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -64,7 +67,8 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('3XH0SIBJ', 0)}
       subTitle="Gray 100 theme"
-      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477">
+      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -82,21 +86,24 @@ in two different libraries separated by size.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language"
-      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba">
+      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Icons (16px, 20px) library"
-      href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7">
+      href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Icons (24px, 32px) library"
-      href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3">
+      href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -118,14 +125,16 @@ access the saved grid template at `File → New file from Template`.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Grid template"
-      href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e">
+      href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
+      href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
+    >
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/developing/dev-resources/index.mdx
+++ b/src/pages/developing/dev-resources/index.mdx
@@ -75,7 +75,8 @@ your framework of choice.
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
     subTitle="Carbon Svelte"
-    href="https://github.com/IBM/carbon-components-svelte">
+    href="https://github.com/IBM/carbon-components-svelte"
+  >
     <MdxIcon name="github" />
   </ResourceCard>
 </Column>

--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -301,7 +301,8 @@ const TutorialHeader = () => (
         <SideNav
           aria-label="Side navigation"
           expanded={isSideNavExpanded}
-          isPersistent={false}>
+          isPersistent={false}
+        >
           <SideNavItems>
             <HeaderSideNavItems>
               <HeaderMenuItem href="/repos">Repositories</HeaderMenuItem>

--- a/src/pages/guidelines/themes/overview.mdx
+++ b/src/pages/guidelines/themes/overview.mdx
@@ -875,4 +875,3 @@ changing for each individual theme.
 
   </ResourceCard>
 </Column>
-

--- a/src/pages/guidelines/typography/code.mdx
+++ b/src/pages/guidelines/typography/code.mdx
@@ -1,6 +1,8 @@
 ---
 label:
-  Type is a core part of any offering and critical to how brands express and communicate throughout any experience. Use the Carbon type package to leverage IBM Plex and create effective typography across your products more easily.
+  Type is a core part of any offering and critical to how brands express and
+  communicate throughout any experience. Use the Carbon type package to leverage
+  IBM Plex and create effective typography across your products more easily.
 title: Typography
 description:
   Typography can help create clear hierarchies, organize information, and guide
@@ -10,7 +12,9 @@ tabs: ['Overview', 'Styling strategies', 'Type sets', 'Code']
 
 <PageDescription>
 
-Type is a core part of any offering and critical to how brands express and communicate throughout any experience. Use the Carbon type package to leverage IBM Plex and create effective typography across your products more easily.
+Type is a core part of any offering and critical to how brands express and
+communicate throughout any experience. Use the Carbon type package to leverage
+IBM Plex and create effective typography across your products more easily.
 
 </PageDescription>
 

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -1,6 +1,9 @@
 ---
 label:
-  Our approach to the typographic system uses IBM Plex as its typeface. It has been carefully engineered with suitable scales, styles, and weights to help create clear hierarchies and organize information that guides users through IBM products or experiences.
+  Our approach to the typographic system uses IBM Plex as its typeface. It has
+  been carefully engineered with suitable scales, styles, and weights to help
+  create clear hierarchies and organize information that guides users through
+  IBM products or experiences.
 title: Typography
 description:
   Typography can help create clear hierarchies, organize information, and guide
@@ -13,7 +16,10 @@ import TypeWeight from '../../../../src/components/TypeWeight';
 
 <PageDescription>
 
-Our approach to the typographic system uses IBM Plex as its typeface. It has been carefully engineered with suitable scales, styles, and weights to help create clear hierarchies and organize information that guides users through IBM products or experiences.
+Our approach to the typographic system uses IBM Plex as its typeface. It has
+been carefully engineered with suitable scales, styles, and weights to help
+create clear hierarchies and organize information that guides users through IBM
+products or experiences.
 
 </PageDescription>
 
@@ -56,7 +62,8 @@ are implemented in code. The productive type set uses fixed headings. Expressive
 headings are responsive and the type styles change size at different
 breakpoints.
 
-For more detail, see [Styling strategies](/guidelines/typography/styling-strategies/) and
+For more detail, see
+[Styling strategies](/guidelines/typography/styling-strategies/) and
 [Type sets](/guidelines/typography/type-sets/).
 
 ## Typeface: IBM Plex
@@ -93,7 +100,7 @@ The IBM type scale is built on a single equation. The formula for our scale was
 created to provide hierarchy for all types of experiences. The formula assumes
 that y₀=12 px.
 
-<br/>
+<br />
 
 <TypeScaleTable />
 

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -1,6 +1,9 @@
 ---
 label:
-  Carbon uses clear naming approach and type tokens to manage typography across complex and layered layouts and patterns, and these tokens sit within two type sets: expressive and productive.
+  ? Carbon uses clear naming approach and type tokens to manage typography
+    across complex and layered layouts and patterns, and these tokens sit within
+    two type sets
+  : expressive and productive.
 title: Typography
 description:
   The productive and expressive type sets support designers creating for a full
@@ -12,7 +15,9 @@ import TypesetStyle from 'components/TypesetStyle';
 
 <PageDescription>
 
-Carbon uses a clear naming approach and type tokens to manage typography across complex and layered layouts and patterns, and these tokens sit within two type sets: expressive and productive.
+Carbon uses a clear naming approach and type tokens to manage typography across
+complex and layered layouts and patterns, and these tokens sit within two type
+sets: expressive and productive.
 
 </PageDescription>
 

--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -114,7 +114,8 @@ function MyComponent() {
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="@carbon/react docs"
-      href="https://github.com/carbon-design-system/carbon/tree/main/packages/carbon-react">
+      href="https://github.com/carbon-design-system/carbon/tree/main/packages/carbon-react"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
@@ -203,28 +204,32 @@ of mixins and design tokens using the Carbon tutorial.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="@carbon/styles docs"
-      href="https://github.com/carbon-design-system/carbon/tree/main/packages/styles">
+      href="https://github.com/carbon-design-system/carbon/tree/main/packages/styles"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Migrating from node-sass to dart-sass"
-      href="https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate">
+      href="https://sass-lang.com/blog/libsass-is-deprecated#how-do-i-migrate"
+    >
       <MdxIcon name="sass" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="One quick way to get ready for Carbon v11"
-      href="https://medium.com/carbondesign/migrating-from-node-sass-to-sass-eba9db004a3a">
+      href="https://medium.com/carbondesign/migrating-from-node-sass-to-sass-eba9db004a3a"
+    >
       <MdxIcon name="medium" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Discover mixins using the Carbon tutorial"
-      href="https://github.com/carbon-design-system/carbon-tutorial/blob/v11-react-step-5/src/content/LandingPage/_landing-page.scss">
+      href="https://github.com/carbon-design-system/carbon-tutorial/blob/v11-react-step-5/src/content/LandingPage/_landing-page.scss"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
@@ -260,7 +265,8 @@ To view a full table of v10 color tokens and their v11 equivalent, check out our
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Color tokens migration table"
-      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-color.md">
+      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-color.md"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
@@ -395,14 +401,16 @@ Some usage guidelines to keep in mind when migrating are:
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="CSS Grid docs"
-      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-grid.md">
+      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-grid.md"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="CSS Grid storybook"
-      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-grid.md">
+      href="https://github.com/carbon-design-system/carbon/blob/main/docs/migration/11.x-grid.md"
+    >
       <MdxIcon name="react" />
     </ResourceCard>
   </Column>
@@ -489,21 +497,24 @@ of the Carbon Tutorial to see theming in action.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Theme usage example"
-      href="https://github.com/carbon-design-system/carbon-tutorial/blob/v11-react-step-5/src/App.js">
+      href="https://github.com/carbon-design-system/carbon-tutorial/blob/v11-react-step-5/src/App.js"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Theme component docs"
-      href="https://github.com/carbon-design-system/carbon/blob/main/packages/carbon-react/src/components/Theme/Theme.mdx">
+      href="https://github.com/carbon-design-system/carbon/blob/main/packages/carbon-react/src/components/Theme/Theme.mdx"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Layer component docs"
-      href="https://github.com/carbon-design-system/carbon/blob/main/packages/carbon-react/src/components/Layer/Layer.mdx">
+      href="https://github.com/carbon-design-system/carbon/blob/main/packages/carbon-react/src/components/Layer/Layer.mdx"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
@@ -656,7 +667,8 @@ Learn more about our Popover component and it's API below:
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Popover"
-      href="https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Popover">
+      href="https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/Popover"
+    >
       <MdxIcon name="github" />
     </ResourceCard>
   </Column>
@@ -725,14 +737,16 @@ notifications to closed by pressing the `escape` key. For more details, see the
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Notification usage examples"
-      href="https://carbon-react-next.netlify.app/?path=/story/components-notifications--toast">
+      href="https://carbon-react-next.netlify.app/?path=/story/components-notifications--toast"
+    >
       <MdxIcon name="storybook" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Notification accessibility page"
-      href="https://v11.carbondesignsystem.com/components/notification/accessibility">
+      href="https://v11.carbondesignsystem.com/components/notification/accessibility"
+    >
       <MdxIcon name="bee" />
     </ResourceCard>
   </Column>

--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -160,7 +160,8 @@ example in CodePen shows how it is implemented.
       frameborder="no"
       allowtransparency="true"
       allowfullscreen="true"
-      style="width: 100%;">
+      style="width: 100%;"
+    >
       See the Pen{' '}
       <a href="https://codepen.io/team/carbon/pen/KRoBQe/">Middle Truncation</a>{' '}
       by Carbon Design System (<a href="https://codepen.io/carbon">@carbon</a>)


### PR DESCRIPTION
In #2613 we found that some formatting errors had slipped into the v11 branch. Formatting and linting is only being checked via `lint-staged` in the git hook. There's a few ways this can be bypassed and invalid formatting can get into the build.

This PR adds a GitHub Action/workflow to explicitly check formatting and linting for every PR moving forward on `main` and `v11`, though it will only apply to ` v11` for now since we need to add this file to the `main` branch as well at a later time.

I can mark these status checks as required once merged in if preferred

#### Changelog

**New**

- add ci workflow for formatting check and linting