### PR TITLE
docs(typography): fix font family for quotation-02 style

### DIFF
--- a/src/components/TypesetStyle/TypesetStyle.js
+++ b/src/components/TypesetStyle/TypesetStyle.js
@@ -458,7 +458,7 @@ const typeScale = {
   'quotation-02': {
     sm: {
       step: 8,
-      font: 'IBM Plex Sans',
+      font: 'IBM Plex Serif',
       'font-weight': '300',
       'font-size': 2,
       'line-height': 2.5,
@@ -466,7 +466,7 @@ const typeScale = {
     },
     md: {
       step: 9,
-      font: 'IBM Plex Sans',
+      font: 'IBM Plex Serif',
       'font-weight': '300',
       'font-size': 2.25,
       'line-height': 2.75,


### PR DESCRIPTION
Even though the `quotation-02` type style uses IBM Plex Serif on all breakpoints, the documentation currently states that IBM Plex Sans is used for the breakpoints `sm` and `md`.

#### Changelog

**Changed**

- Updated font family property in documentation to reflect the actual implementation.
