### PR TITLE
chore: bump theme to 2.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gatsby": "^3.14.3",
     "gatsby-image": "^3.7.1",
     "gatsby-plugin-image": "^1.14.1",
-    "gatsby-theme-carbon": "^2.1.5",
+    "gatsby-theme-carbon": "^2.1.6",
     "lodash-es": "^4.17.15",
     "markdown-it": "^9.0.1",
     "nanoid": "^2.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8570,10 +8570,10 @@ gatsby-telemetry@^2.14.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
-gatsby-theme-carbon@^2.1.5:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-2.1.5.tgz#92a5855d3fbabf8a420f72eea4830e3350c06dbc"
-  integrity sha512-8KRHvmEcIJTE9r5pmVUbp7na5mjNA5z6KaqD0ndQDSId3mZxXDP2VW2a6Dg+OYaGX7nLuf0pr5CcYnblIgMPQg==
+gatsby-theme-carbon@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-2.1.6.tgz#6394a5502929e10b745dfc963938e4f8cd11dbb7"
+  integrity sha512-HmsASuhayNyvU0isBxO4EZdnC1FfPJTjPcq/dxCxX8Szz7YD/sh2yp4HoLKiHV5cEXoyr807V2UB1PI09X1dOw==
   dependencies:
     "@babel/core" "^7.14.6"
     "@carbon/elements" "^10.38.0"


### PR DESCRIPTION
(updated switcher links)