### PR TITLE
v11[style]: add layer annotation

### DIFF
--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -10,14 +10,19 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Single line
 
-| Class                  | Property         | Color token     |
-| ---------------------- | ---------------- | --------------- |
-| `.bx--snippet`         | background       | `$field`        |
-| `.bx--snippet`         | text color       | `$text-primary` |
-| `.bx--snippet__icon`   | svg              | `$icon-primary` |
-| `.bx--copy-btn:hover`  | background-color | `$layer-hover`  |
-| `.bx--copy-btn:focus`  | border           | `$focus`        |
-| `.bx--copy-btn:active` | background-color | `$layer-active` |
+| Element         | Property                                                              | Color token     |
+| --------------- | --------------------------------------------------------------------- | --------------- |
+| Container       | background                                                            | `$field`\*      |
+| Code            | text color                                                            | `$text-primary` |
+| Copy button     | See [ghost button - icon only](/components/button/style#ghost-button) |                 |
+| Container:focus | border                                                                | `$focus`        |
+
+<Caption>
+  * This is a contextual token and is used by default in Carbon Components to
+  implement the layering model. For its value, a contextual token will use one
+  of three nested layering tokens of the same name and will vary depending on
+  the layer a component is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -31,14 +36,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Multi-line
 
-| Class                                                  | Property         | Color token     |
-| ------------------------------------------------------ | ---------------- | --------------- |
-| `.bx--snippet`                                         | background       | `$layer`        |
-| `.bx--snippet`                                         | text color       | `$text-primary` |
-| `.bx--snippet__icon`                                   | svg              | `$icon-primary` |
-| `.bx--copy-btn:hover` <br/> `.bx--snippet-btn:hover`   | background-color | `$layer-hover`  |
-| `.bx--copy-btn:focus` <br/> `.bx--snippet-btn:focus`   | border           | `$focus`        |
-| `.bx--copy-btn:active` <br/> `.bx--snippet-btn:active` | background-color | `$layer-active` |
+| Element                          | Property                                                              | Color token     |
+| -------------------------------- | --------------------------------------------------------------------- | --------------- |
+| Container                        | background                                                            | `$layer`\*      |
+| Code                             | text color                                                            | `$text-primary` |
+| Icon                             | svg                                                                   | `$icon-primary` |
+| Copy button <br/> Snippet button | See [ghost button - icon only](/components/button/style#ghost-button) |                 |
+| Container:focus                  | border                                                                | `$focus`        |
+
+<Caption>
+  * This is a contextual token and is used by default in Carbon Components to
+  implement the layering model. For its value, a contextual token will use one
+  of three nested layering tokens of the same name and will vary depending on
+  the layer a component is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -64,13 +75,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Inline snippet
 
-| Class                         | Property         | Color token     |
-| ----------------------------- | ---------------- | --------------- |
-| `.bx--snippet--inline`        | background-color | `$layer`        |
-| `.bx--snippet--inline`        | color            | `$text-primary` |
-| `.bx--snippet--inline:hover`  | background-color | `$layer-hover`  |
-| `.bx--snippet--inline:focus`  | focus            | `$focus`        |
-| `.bx--snippet--inline:active` | background-color | `$layer-active` |
+| Element          | Property         | Color token       |
+| ---------------- | ---------------- | ----------------- |
+| Container        | background-color | `$layer`\*        |
+| Code             | text color       | `$text-primary`   |
+| Container:hover  | background-color | `$layer-hover`\*  |
+| Container:focus  | focus            | `$focus`          |
+| Container:active | background-color | `$layer-active`\* |
+
+<Caption>
+  * This is a contextual token and is used by default in Carbon Components to
+  implement the layering model. For its value, a contextual token will use one
+  of three nested layering tokens of the same name and will vary depending on
+  the layer a component is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -97,12 +115,12 @@ Carbon has defined a set of accessible syntax colors. View an incontext
 
 ### Single line
 
-| Class                  | Property      | px / rem | Spacing token |
-| ---------------------- | ------------- | -------- | ------------- |
-| `.bx--snippet--single` | height        | 40 / 3   | –             |
-| `.bx--snippet--single` | max-width     | 768 / 48 | –             |
-| `.bx--snippet--single` | padding-right | 48 / 3   | `$spacing-09` |
-| `.bx--snippet--single` | padding-left  | 16 / 1   | `$spacing-05` |
+| Element   | Property      | px / rem | Spacing token |
+| --------- | ------------- | -------- | ------------- |
+| Container | height        | 40 / 3   | –             |
+|           | max-width     | 768 / 48 | –             |
+|           | padding-right | 48 / 3   | `$spacing-09` |
+|           | padding-left  | 16 / 1   | `$spacing-05` |
 
 <div className="image--fixed">
 
@@ -116,16 +134,16 @@ Carbon has defined a set of accessible syntax colors. View an incontext
 
 ### Multi-line code snippet
 
-| Class                    | Property      | px / rem                | Spacing token |
-| ------------------------ | ------------- | ----------------------- | ------------- |
-| `.bx--snippet--multi`    | min-height    | 288 / 18                | –             |
-| `.bx--snippet--multi`    | max-height    | Varies based on content | –             |
-| `.bx--snippet--multi`    | max-width     | 768 / 48                | –             |
-| `.bx--snippet`           | padding       | 16 / 1                  | `$spacing-05` |
-| `.bx--snippet-container` | padding-right | 40 / 2.5                | `$spacing-08` |
-| `.bx--snippet__icon`     | height, width | 16px                    | –             |
-| `.bx--snippet-button`    | height, width | 40 / 2.5                | –             |
-| `.bx--copy-button`       | height, width | 32 / 2                  | –             |
+| Element        | Property      | px / rem                | Spacing token |
+| -------------- | ------------- | ----------------------- | ------------- |
+| Container      | min-height    | 288 / 18                | –             |
+|                | max-height    | Varies based on content | –             |
+|                | max-width     | 768 / 48                | –             |
+|                | padding       | 16 / 1                  | `$spacing-05` |
+|                | padding-right | 40 / 2.5                | `$spacing-08` |
+| Icon           | height, width | 16px                    | –             |
+| Snippet button | height, width | 40 / 2.5                | –             |
+| Copy button    | height, width | 32 / 2                  | –             |
 
 <div className="image--fixed">
 
@@ -139,12 +157,12 @@ Carbon has defined a set of accessible syntax colors. View an incontext
 
 ### Inline code snippet
 
-| Class                       | Property                    | px / rem                | Spacing token |
-| --------------------------- | --------------------------- | ----------------------- | ------------- |
-| `.bx--snippet--inline`      | height                      | 16 / 1                  | –             |
-| `.bx--snippet--inline`      | width                       | Varies based on content | –             |
-| `.bx--snippet--inline`      | border-radius               | 2                       | -             |
-| `.bx--snippet--inline code` | padding-right, padding-left | 8 / 0.5                 | \$spacing-03  |
+| Element   | Property                    | px / rem                | Spacing token |
+| --------- | --------------------------- | ----------------------- | ------------- |
+| Container | height                      | 16 / 1                  | –             |
+|           | width                       | Varies based on content | –             |
+|           | border-radius               | 2                       | -             |
+| Code      | padding-right, padding-left | 8 / 0.5                 | `$spacing-03` |
 
 <div className="image--fixed">
 

--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -18,10 +18,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Container:focus | border                                                                | `$focus`        |
 
 <Caption>
-  * This is a contextual token and is used by default in Carbon Components to
-  implement the layering model. For its value, a contextual token will use one
-  of three nested layering tokens of the same name and will vary depending on
-  the layer a component is placed on.
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
 </Caption>
 
 <Row>
@@ -45,9 +43,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Container:focus                  | border                                                                | `$focus`        |
 
 <Caption>
-  * Denotes a contextual token, see the [Color
-  guidance](/guidelines/color/implementation#contextual-tokens) for more
-  information.
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
 </Caption>
 
 <Row>
@@ -83,10 +80,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Container:active | background-color | `$layer-active`\* |
 
 <Caption>
-  * This is a contextual token and is used by default in Carbon Components to
-  implement the layering model. For its value, a contextual token will use one
-  of three nested layering tokens of the same name and will vary depending on
-  the layer a component is placed on.
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
 </Caption>
 
 <Row>

--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -38,17 +38,16 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Element                          | Property                                                              | Color token     |
 | -------------------------------- | --------------------------------------------------------------------- | --------------- |
-| Container                        | background                                                            | `$layer`\*      |
+| Container                        | background                                                            | `$layer` \*     |
 | Code                             | text color                                                            | `$text-primary` |
 | Icon                             | svg                                                                   | `$icon-primary` |
 | Copy button <br/> Snippet button | See [ghost button - icon only](/components/button/style#ghost-button) |                 |
 | Container:focus                  | border                                                                | `$focus`        |
 
 <Caption>
-  * This is a contextual token and is used by default in Carbon Components to
-  implement the layering model. For its value, a contextual token will use one
-  of three nested layering tokens of the same name and will vary depending on
-  the layer a component is placed on.
+  * Denotes a contextual token, see the [Color
+  guidance](/guidelines/color/implementation#contextual-tokens) for more
+  information.
 </Caption>
 
 <Row>

--- a/src/pages/components/code-snippet/style.mdx
+++ b/src/pages/components/code-snippet/style.mdx
@@ -12,7 +12,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Element         | Property                                                              | Color token     |
 | --------------- | --------------------------------------------------------------------- | --------------- |
-| Container       | background                                                            | `$field`\*      |
+| Container       | background                                                            | `$field` \*     |
 | Code            | text color                                                            | `$text-primary` |
 | Copy button     | See [ghost button - icon only](/components/button/style#ghost-button) |                 |
 | Container:focus | border                                                                | `$focus`        |
@@ -71,13 +71,13 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Inline snippet
 
-| Element          | Property         | Color token       |
-| ---------------- | ---------------- | ----------------- |
-| Container        | background-color | `$layer`\*        |
-| Code             | text color       | `$text-primary`   |
-| Container:hover  | background-color | `$layer-hover`\*  |
-| Container:focus  | focus            | `$focus`          |
-| Container:active | background-color | `$layer-active`\* |
+| Element          | Property         | Color token        |
+| ---------------- | ---------------- | ------------------ |
+| Container        | background-color | `$layer` \*        |
+| Code             | text color       | `$text-primary`    |
+| Container:hover  | background-color | `$layer-hover` \*  |
+| Container:focus  | focus            | `$focus`           |
+| Container:active | background-color | `$layer-active` \* |
 
 <Caption>
   * Denotes a contextual color token that will change values based on the layer

--- a/src/pages/components/data-table/style.mdx
+++ b/src/pages/components/data-table/style.mdx
@@ -12,9 +12,14 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Element      | Property         | Color token       |
 | ------------ | ---------------- | ----------------- |
-| Table header | background-color | `$layer`          |
+| Table header | background-color | `$layer` \*       |
 | Title        | text-color       | `$text-primary`   |
 | Description  | text-color       | `$text-secondary` |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -26,15 +31,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Column header
 
-| State   | Property         | Color token            |
-| ------- | ---------------- | ---------------------- |
-| Enabled | background-color | `$layer-accent`        |
-|         | text-color       | `$text-primary`        |
-|         | svg              | `$icon-primary`        |
-| Hover   | background-color | `$layer-accent-hover`  |
-|         | text-color       | `$text-primary`        |
-| Focus   | border           | `$focus`               |
-| Active  | background-color | `$layer-accent-active` |
+| State   | Property         | Color token               |
+| ------- | ---------------- | ------------------------- |
+| Enabled | background-color | `$layer-accent` \*        |
+|         | text-color       | `$text-primary`           |
+|         | svg              | `$icon-primary`           |
+| Hover   | background-color | `$layer-accent-hover` \*  |
+|         | text-color       | `$text-primary`           |
+| Focus   | border           | `$focus`                  |
+| Active  | background-color | `$layer-accent-active` \* |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -46,23 +56,28 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Row
 
-| State            | Property         | Color token               |
-| ---------------- | ---------------- | ------------------------- |
-| Enabled          | background-color | `$layer`                  |
-|                  | text-color       | `$text-secondary`         |
-|                  | border-bottom    | `$border-subtle`          |
-|                  | svg              | `$icon-secondary`         |
-| Hover            | background-color | `$layer-hover`            |
-|                  | text-color       | `$text-primary`           |
-| Focus            | border           | `$focus`                  |
-| Selected         | background-color | `$layer-selected`         |
-|                  | text-color       | `$text-primary`           |
-|                  | border-bottom    | `$border-subtle-selected` |
-|                  | svg              | `$icon-primary`           |
-| Selected + hover | background-color | `$layer-selected-hover`   |
-| Expanded         | background-color | `$layer`                  |
-|                  | svg              | `$icon-primary`           |
-| Zebra            | background-color | `$layer-accent`           |
+| State            | Property         | Color token                 |
+| ---------------- | ---------------- | --------------------------- |
+| Enabled          | background-color | `$layer` \*                 |
+|                  | text-color       | `$text-secondary`           |
+|                  | border-bottom    | `$border-subtle` \*         |
+|                  | svg              | `$icon-secondary`           |
+| Hover            | background-color | `$layer-hover` \*           |
+|                  | text-color       | `$text-primary`             |
+| Focus            | border           | `$focus`                    |
+| Selected         | background-color | `$layer-selected` \*        |
+|                  | text-color       | `$text-primary`             |
+|                  | border-bottom    | `$border-subtle-selected`\* |
+|                  | svg              | `$icon-primary`             |
+| Selected + hover | background-color | `$layer-selected-hover` \*  |
+| Expanded         | background-color | `$layer` \*                 |
+|                  | svg              | `$icon-primary`             |
+| Zebra            | background-color | `$layer-accent` \*          |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -76,9 +91,14 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Element     | Property                                                                                    | Color token |
 | ----------- | ------------------------------------------------------------------------------------------- | ----------- |
-| Toolbar     | background-color                                                                            | `$layer`    |
+| Toolbar     | background-color                                                                            | `$layer` \* |
 | Icon button | See [ghost button](https://carbondesignsystem.com/components/button/style#ghost-button)     |             |
 | Button      | See [primary button](https://carbondesignsystem.com/components/button/style#primary-button) |             |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/date-picker/style.mdx
+++ b/src/pages/components/date-picker/style.mdx
@@ -10,14 +10,19 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Date input
 
-| Element            | Property         | Color token       |
-| ------------------ | ---------------- | ----------------- |
-| Label              | text-color       | `$text-secondary` |
-| Field              | background-color | `$field`          |
-|                    | border-bottom    | `$border-strong`  |
-| Field text         | text-color       | `$text-primary`   |
-| Field text: prompt | text-color       | `$text-helper`    |
-| Calendar icon      | svg              | `$icon-primary`   |
+| Element            | Property         | Color token         |
+| ------------------ | ---------------- | ------------------- |
+| Label              | text-color       | `$text-secondary`   |
+| Field              | background-color | `$field` \*         |
+|                    | border-bottom    | `$border-strong` \* |
+| Field text         | text-color       | `$text-primary`     |
+| Field text: prompt | text-color       | `$text-helper`      |
+| Calendar icon      | svg              | `$icon-primary`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <br />
 
@@ -49,24 +54,15 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 <Caption>Examples of date picker input states</Caption>
 
-**Active:** Placeholder text should remain when the user clicks into the text
-input and gets a cursor. Once the user starts typing the hint text is replaced
-with the user input text.
-
-**Error:** Error messages appear below the input field and are always present
-while invalid.
-
-**Disabled:** Disabled state should have a `.not-allowed` cursor on hover.
-
 ### Calendar menu
 
 | Element             | Property         | Color token                      |
 | ------------------- | ---------------- | -------------------------------- |
-| Calendar            | background-color | `$layer`                         |
+| Calendar            | background-color | `$layer` \*                      |
 | Calendar menu       | box-shadow       | `0 2px 6px 0 rgba(0, 0, 0, 0.2)` |
 | Today               | text-color       | `$link-01`                       |
 | Day                 | text-color       | `$text-primary`                  |
-| Day: hover          | background-color | `$layer-hover`                   |
+| Day: hover          | background-color | `$layer-hover` \*                |
 | Day: focus          | border           | `$focus`                         |
 | Day: selected       | text-color       | `$text-on-color`                 |
 |                     | background-color | `$background-brand`              |
@@ -76,6 +72,11 @@ while invalid.
 | Day: end range      | text-color       | `$text-primary`                  |
 |                     | border           | `$focus`                         |
 | Day: next month day | text-color       | `$text-secondary`                |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={12}>

--- a/src/pages/components/dropdown/style.mdx
+++ b/src/pages/components/dropdown/style.mdx
@@ -14,16 +14,21 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Field text         | text-color       | `$text-primary`              |
 | Field text: prompt | text-color       | `$text-helper`               |
 | Helper text        | text-color       | `$text-helper`               |
-| Field              | background-color | `$field`                     |
-|                    | border-bottom    | `$border-strong`             |
+| Field              | background-color | `$field` \*                  |
+|                    | border-bottom    | `$border-strong` \*          |
 | Chevron icon       | svg              | `$icon-primary`              |
 | Menu option        | text-color       | `$text-secondary`            |
-|                    | background-color | `$layer`                     |
-|                    | border-top       | `$border-subtle`             |
+|                    | background-color | `$layer` \*                  |
+|                    | border-top       | `$border-subtle` \*          |
 | Menu               | box-shadow       | `0 2px 6px 0 rgba(0,0,0,.2)` |
 | Checkbox icon      | background-color | `$icon-primary`              |
 |                    | check            | `$icon-inverse`              |
 |                    | border           | `$icon-primary`              |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={12}>
@@ -42,24 +47,29 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | State          | Element         | Property         | Color token           |
 | -------------- | --------------- | ---------------- | --------------------- |
 | Focus          | Field           | border           | `$focus`              |
-| Hover          | Field           | background-color | `$field-hover`        |
-|                | Menu option     | background-color | `$layer-hover`        |
+| Hover          | Field           | background-color | `$field-hover` \*     |
+|                | Menu option     | background-color | `$layer-hover` \*     |
 |                | Menu option     | text-color       | `$text-primary`       |
 | Invalid        | Error icon      | svg              | `$support-error`      |
 |                | Field           | border           | `$support-error`      |
 |                | Error message   | text-color       | `$text-error`         |
 | Warning        | Warning message | text-color       | `$text-primary`       |
 |                | Warning icon    | svg              | `$support-warning`    |
-| Active         | Menu option     | background-color | `$layer-active`       |
-| Selected       | Menu option     | background-color | `$layer-selected`     |
+| Active         | Menu option     | background-color | `$layer-active` \*    |
+| Selected       | Menu option     | background-color | `$layer-selected` \*  |
 |                | Menu option     | checkmark        | `$icon-primary`       |
 | Multi-selected | Tag             | background-color | `$background-inverse` |
 |                | Tag             | text-color       | `$text-inverse`       |
-| Disabled       | Field           | background-color | `$field`              |
+| Disabled       | Field           | background-color | `$field` \*           |
 |                | Field           | border-bottom    | transparent           |
 |                | Field           | text-color       | `$text-disabled`      |
 |                | Label           | text-color       | `$text-disabled`      |
 |                | Chevron icon    | svg              | `$icon-disabled`      |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={12}>
@@ -83,22 +93,27 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ### Inline dropdown
 
-| State    | Element       | Property         | Color token       |
-| -------- | ------------- | ---------------- | ----------------- |
-| Enabled  | Field         | background-color | transparent       |
-|          | Field text    | text-color       | `$text-primary`   |
-|          | Chevron icon  | svg              | `$icon-primary`   |
-|          | Menu option   | text-color       | `$text-secondary` |
-|          | Menu option   | background-color | `$layer`          |
-| Hover    | Field         | background-color | `$field-hover`    |
-|          | Menu option   | background-color | `$layer-hover`    |
-|          | Menu option   | text-color       | `$text-primary`   |
-| Active   | Menu option   | background-color | `$layer-active`   |
-| Selected | Menu option   | background-color | `$layer-selected` |
-|          | Menu option   | checkmark        | `$icon-primary`   |
-| Invalid  | Field         | border           | `$support-error`  |
-|          | Error message | text-color       | `$text-error`     |
-|          | Error icon    | svg              | `$support-error`  |
+| State    | Element       | Property         | Color token          |
+| -------- | ------------- | ---------------- | -------------------- |
+| Enabled  | Field         | background-color | transparent          |
+|          | Field text    | text-color       | `$text-primary`      |
+|          | Chevron icon  | svg              | `$icon-primary`      |
+|          | Menu option   | text-color       | `$text-secondary`    |
+|          | Menu option   | background-color | `$layer` \*          |
+| Hover    | Field         | background-color | `$field-hover` \*    |
+|          | Menu option   | background-color | `$layer-hover` \*    |
+|          | Menu option   | text-color       | `$text-primary`      |
+| Active   | Menu option   | background-color | `$layer-active` \*   |
+| Selected | Menu option   | background-color | `$layer-selected` \* |
+|          | Menu option   | checkmark        | `$icon-primary`      |
+| Invalid  | Field         | border           | `$support-error`     |
+|          | Error message | text-color       | `$text-error`        |
+|          | Error icon    | svg              | `$support-error`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={12}>

--- a/src/pages/components/file-uploader/style.mdx
+++ b/src/pages/components/file-uploader/style.mdx
@@ -13,11 +13,16 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Label          | text-color                                                                                      | `$text-primary`   |
 | Description    | text-color                                                                                      | `$text-secondary` |
 | File name      | text-color                                                                                      | `$text-primary`   |
-| File           | background-color                                                                                | `$field`          |
+| File           | background-color                                                                                | `$field` \*       |
 | Close icon     | svg                                                                                             | `$icon-primary`   |
 | Drop container | border                                                                                          | `$border-strong`  |
 | Drop text      | text-color                                                                                      | `$link-primary`   |
 | Button         | See [primary button](https://www.carbondesignsystem.com/components/button/style#primary-button) |                   |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/form/style.mdx
+++ b/src/pages/components/form/style.mdx
@@ -8,10 +8,6 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-Inputs come in two different colors. The default input color is `$field-01` and
-is used on `$ui-background` and `$ui-02` page backgrounds. The `--light` version
-input color is `$field-02` and is used on `$ui-01` page backgrounds.
-
 Refer to the [text input](/components/text-input/usage),
 [dropdown](/components/dropdown/usage), [checkbox](/components/checkbox/usage),
 [radio button](/components/radio-button/usage),

--- a/src/pages/components/inline-loading/style.mdx
+++ b/src/pages/components/inline-loading/style.mdx
@@ -9,11 +9,16 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Class                       | Property | Color token           |
 | --------------------------- | -------- | --------------------- |
-| `.bx--loading__background`  | stroke   | `$border-subtle`      |
+| `.bx--loading__background`  | stroke   | `$border-subtle` \*   |
 | `.bx--loading__stroke`      | stroke   | `$border-interactive` |
 | `.bx--inline-loading__text` | color    | `$text-secondary`     |
 | `status: finished`          | svg      | `$support-success`    |
 | `status: finished`          | svg      | `$support-error`      |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/modal/style.mdx
+++ b/src/pages/components/modal/style.mdx
@@ -11,15 +11,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 Refer to the [button](/components/button/style) for primary and secondary button
 styling in the transactional modal.
 
-| Class                        | Property         | Color token         |
-| ---------------------------- | ---------------- | ------------------- |
-| `.bx--modal-container`       | background-color | `$layer`            |
-| `.bx--modal-header__label`   | text color       | `$text-secondary`   |
-| `.bx--modal-header__heading` | text color       | `$text-primary`     |
-| `.bx--modal-content`         | text color       | `$text-primary`     |
-| `.bx--modal-close__icon`     | fill             | `$icon-primary`     |
-| `.bx--modal-close:hover`     | background-color | `$background-hover` |
-| Overlay                      | color            | `$overlay`          |
+| Class                        | Property         | Color token       |
+| ---------------------------- | ---------------- | ----------------- |
+| `.bx--modal-container`       | background-color | `$layer` \*       |
+| `.bx--modal-header__label`   | text color       | `$text-secondary` |
+| `.bx--modal-header__heading` | text color       | `$text-primary`   |
+| `.bx--modal-content`         | text color       | `$text-primary`   |
+| `.bx--modal-close__icon`     | fill             | `$icon-primary`   |
+| `.bx--modal-close:hover`     | background-color | `$layer-hover` \* |
+| Overlay                      | color            | `$overlay`        |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 ## Typography
 

--- a/src/pages/components/number-input/style.mdx
+++ b/src/pages/components/number-input/style.mdx
@@ -11,13 +11,18 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 Inputs come in two different colors. The default input color is `$field` and is
 used on `$background` and `$overlay` page backgrounds.
 
-| Class                              | Property         | Color token       |
-| ---------------------------------- | ---------------- | ----------------- |
-| `.bx--label`                       | text color       | `$text-secondary` |
-| `.bx--number input[type='number']` | text color       | `$text-primary`   |
-| `.bx--number`                      | background-color | `$field`          |
-| `.bx--number`                      | border-bottom    | `$border-strong`  |
-| `.bx--number__controls`            | svg color        | `$icon-primary`   |
+| Class                              | Property         | Color token         |
+| ---------------------------------- | ---------------- | ------------------- |
+| `.bx--label`                       | text color       | `$text-secondary`   |
+| `.bx--number input[type='number']` | text color       | `$text-primary`     |
+| `.bx--number`                      | background-color | `$field` \*         |
+| `.bx--number`                      | border-bottom    | `$border-strong` \* |
+| `.bx--number__controls`            | svg color        | `$icon-primary`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <div className="image--fixed">
 
@@ -37,21 +42,9 @@ used on `$background` and `$overlay` page backgrounds.
 | `[data-invalid]:focus`                      | color            | `$support-error` |
 | `.bx--form-requirement`                     | text color       | `$support-error` |
 | `.bx--label:disabled`                       | text color       | `$text-disabled` |
-| `.bx--number:disabled`                      | background-color | `$field`         |
+| `.bx--number:disabled`                      | background-color | `$field` \*      |
 | `.bx--number:disabled`                      | border-bottom    | transparent      |
 | `.bx--number input[type='number']:disabled` | text color       | `$text-disabled` |
-
-**Active:** Number input should have a default number to start. The input should
-never be empty.
-
-**Helper text:** Helper text appears below the label when the input is active.
-Helper text remains visible while the input is focused and disappears after
-focus away.
-
-**Error:** Error messages appear below the input field and are always present
-while invalid.
-
-**Disabled:** Disabled state should have a `.not-allowed` cursor on hover.
 
 ## Typography
 

--- a/src/pages/components/number-input/style.mdx
+++ b/src/pages/components/number-input/style.mdx
@@ -8,9 +8,6 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-Inputs come in two different colors. The default input color is `$field` and is
-used on `$background` and `$overlay` page backgrounds.
-
 | Class                              | Property         | Color token         |
 | ---------------------------------- | ---------------- | ------------------- |
 | `.bx--label`                       | text color       | `$text-secondary`   |

--- a/src/pages/components/pagination/style.mdx
+++ b/src/pages/components/pagination/style.mdx
@@ -8,12 +8,12 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                          | Property         | Color token       |
-| ------------------------------ | ---------------- | ----------------- |
-| `.bx--pagination`              | background-color | `$layer`          |
-| `.bx--pagination`              | border-top       | `$border-subtle`  |
-| `.bx--pagination__text`        | text color       | `$text-secondary` |
-| `.bx--pagination__button-icon` | fill             | `$icon-primary`   |
+| Class                          | Property         | Color token         |
+| ------------------------------ | ---------------- | ------------------- |
+| `.bx--pagination`              | background-color | `$layer` \*         |
+| `.bx--pagination`              | border-top       | `$border-subtle` \* |
+| `.bx--pagination__text`        | text color       | `$text-secondary`   |
+| `.bx--pagination__button-icon` | fill             | `$icon-primary`     |
 
 ## Typography
 

--- a/src/pages/components/popover/style.mdx
+++ b/src/pages/components/popover/style.mdx
@@ -9,9 +9,13 @@ tabs: ['Usage', 'Style']
 
 | Element   | Property         | Color token           |
 | --------- | ---------------- | --------------------- |
-| Container | background-color | `$layer-01`           |
-|           | background-color | `$layer-02`           |
+| Container | background-color | `$layer` \*           |
 |           | background-color | `$background-inverse` |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/progress-indicator/style.mdx
+++ b/src/pages/components/progress-indicator/style.mdx
@@ -19,9 +19,14 @@ outlined circle.
 | `.bx--progress-step--complete svg`                          | fill             | `$interactive`        |
 | `.bx--progress-step--incomplete svg`                        | fill             | `$interactive`        |
 | `.bx--progress-step--current` <br/> `.bx--progress-line`    | background-color | `$border-interactive` |
-| `.bx--progress-step--incomplete` <br/> `.bx--progress-line` | background-color | `$border-subtle`      |
+| `.bx--progress-step--incomplete` <br/> `.bx--progress-line` | background-color | `$border-subtle` \*   |
 | `.bx--progress-label`                                       | text color       | `$text-primary`       |
 | `.bx--progress-optional`                                    | text color       | `$text-secondary`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 ### Interactive states
 

--- a/src/pages/components/search/style.mdx
+++ b/src/pages/components/search/style.mdx
@@ -14,8 +14,8 @@ input color is `$field-02` and is used on `$ui-01` page backgrounds.
 
 | Class                            | Property         | Color token         |
 | -------------------------------- | ---------------- | ------------------- |
-| `.bx--search-input`              | background-color | `$field`            |
-| `.bx--search-input`              | border-bottom    | `$border-strong`    |
+| `.bx--search-input`              | background-color | `$field` \*         |
+| `.bx--search-input`              | border-bottom    | `$border-strong` \* |
 | `.bx--search-input`              | text color       | `$text-primary`     |
 | `.bx--search-input::placeholder` | text color       | `$text-placeholder` |
 | `.bx--search-magnifier`          | fill             | `$icon-secondary`   |
@@ -33,7 +33,7 @@ input color is `$field-02` and is used on `$ui-01` page backgrounds.
 | Class                            | Property         | Color token      |
 | -------------------------------- | ---------------- | ---------------- |
 | `.bx--search-input:focus`        | border           | `$focus`         |
-| `.bx--search-input:disabled`     | background-color | `$field`         |
+| `.bx--search-input:disabled`     | background-color | `$field` \*      |
 | `.bx--search-input:disabled`     | border-bottom    | transparent      |
 | `.bx--search-input:disabled`     | text color       | `$text-disabled` |
 | `.bx--search-magnifier:disabled` | fill             | `$icon-disabled` |

--- a/src/pages/components/select/style.mdx
+++ b/src/pages/components/select/style.mdx
@@ -8,15 +8,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                 | Property      | Color token      |
-| --------------------- | ------------- | ---------------- |
-| `.bx--select-input`   | background    | `$field`         |
-| `.bx--select-input`   | border-bottom | `$border-strong` |
-| `.bx--select--inline` | background    | transparent      |
-| `.bx--label`          | text color    | `$text-primary`  |
-| `.bx--select-input`   | text color    | `$text-primary`  |
-| `.bx--select--inline` | text color    | `$icon-primary`  |
-| `.bx--select__arrow`  | fill          | `$icon-primary`  |
+| Class                 | Property      | Color token         |
+| --------------------- | ------------- | ------------------- |
+| `.bx--select-input`   | background    | `$field` \*         |
+| `.bx--select-input`   | border-bottom | `$border-strong` \* |
+| `.bx--select--inline` | background    | transparent         |
+| `.bx--label`          | text color    | `$text-primary`     |
+| `.bx--select-input`   | text color    | `$text-primary`     |
+| `.bx--select--inline` | text color    | `$icon-primary`     |
+| `.bx--select__arrow`  | fill          | `$icon-primary`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <div className="image--fixed">
 
@@ -33,7 +38,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | `.bx--select-input:focus`         | border        | `$focus`         |
 | `.bx--select-input[data-invalid]` | border        | `$support-error` |
 | `.bx--form-requirement`           | text color    | `$support-error` |
-| `.bx--select-input:disabled`      | background    | `$field`         |
+| `.bx--select-input:disabled`      | background    | `$field` \*      |
 | `.bx--select-input:disabled`      | border-bottom | transparent      |
 | `.bx--select-input:disabled`      | text color    | `$text-disabled` |
 

--- a/src/pages/components/slider/style.mdx
+++ b/src/pages/components/slider/style.mdx
@@ -8,13 +8,18 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                       | Property         | Color token       |
-| --------------------------- | ---------------- | ----------------- |
-| `.bx--slider__thumb`        | fill             | `$icon-primary`   |
-| `.bx--slider__filled-track` | background-color | `$border-inverse` |
-| `.bx--slider__track`        | background-color | `$border-subtle`  |
-| `.bx--label`                | text color       | `$text-secondary` |
-| `.bx--slider__range-label`  | text color       | `$text-primary`   |
+| Class                       | Property         | Color token         |
+| --------------------------- | ---------------- | ------------------- |
+| `.bx--slider__thumb`        | fill             | `$icon-primary`     |
+| `.bx--slider__filled-track` | background-color | `$border-inverse`   |
+| `.bx--slider__track`        | background-color | `$border-subtle` \* |
+| `.bx--label`                | text color       | `$text-secondary`   |
+| `.bx--slider__range-label`  | text color       | `$text-primary`     |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 ### Interactive states
 

--- a/src/pages/components/structured-list/style.mdx
+++ b/src/pages/components/structured-list/style.mdx
@@ -8,12 +8,17 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Color
 
-| Class                                  | Property      | Color token       |
-| -------------------------------------- | ------------- | ----------------- |
-| `.bx--structured-list-th`              | text color    | `$text-primary`   |
-| `.bx--structured-list-td`              | text color    | `$text-secondary` |
-| `.bx--structured-list-row--header-row` | border-bottom | `$border-subtle`  |
-| `.bx--structured-list-row`             | border-bottom | `$border-subtle`  |
+| Class                                  | Property      | Color token         |
+| -------------------------------------- | ------------- | ------------------- |
+| `.bx--structured-list-th`              | text color    | `$text-primary`     |
+| `.bx--structured-list-td`              | text color    | `$text-secondary`   |
+| `.bx--structured-list-row--header-row` | border-bottom | `$border-subtle` \* |
+| `.bx--structured-list-row`             | border-bottom | `$border-subtle` \* |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 ### Interactive states
 

--- a/src/pages/components/tabs/style.mdx
+++ b/src/pages/components/tabs/style.mdx
@@ -22,7 +22,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Enabled  | Background            | background-color | transparent                                            |
 |          | Label                 | text-color       | `$text-secondary`                                      |
 |          | Icon                  | svg              | `$icon-secondary`                                      |
-|          | Background            | border-bottom    | `$border-subtle`                                       |
+|          | Background            | border-bottom    | `$border-subtle` \*                                    |
 |          | Scrollable icon       | svg              | `$icon-primary`                                        |
 |          | Scrollable fade       | background-color | 8px, linear-gradient `$background` to 100% transparent |
 |          | Scrollable background | background-color | `$background`                                          |
@@ -88,15 +88,20 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | State    | Element         | Property         | Color token           |
 | -------- | --------------- | ---------------- | --------------------- |
-| Enabled  | Background      | background-color | `$layer-accent`       |
+| Enabled  | Background      | background-color | `$layer-accent` \*    |
 |          | Label           | text-color       | `$text-secondary`     |
 |          | Icon            | svg              | `$icon-secondary`     |
-|          | Background      | border-right     | `$border-strong`      |
+|          | Background      | border-right     | `$border-strong` \*   |
 |          | Scrollable icon | svg              | `$icon-secondary`     |
 |          | Label           | text-color       | `$text-primary`       |
-| Selected | Background      | background-color | `$layer`              |
+| Selected | Background      | background-color | `$layer` \*           |
 |          | Icon            | svg              | `$icon-primary`       |
 |          | Background      | border-top       | `$border-interactive` |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <div className="image--fixed">
 
@@ -112,24 +117,29 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 <br />
 
-| State          | Element               | Property         | Color token            |
-| -------------- | --------------------- | ---------------- | ---------------------- |
-| Hover          | Background            | background-color | `$layer-accent-hover`  |
-|                | Label                 | text-color       | `$text-primary`        |
-|                | Icon                  | svg              | `$icon-primary`        |
-|                | Scrollable background | background-color | `$layer-accent-hover`  |
-| Active         | Scrollable background | background-color | `$layer-accent-active` |
-| Focus          | Scrollable background | border           | `$focus`               |
-| Focus-enabled  | Label                 | text-color       | `$text-secondary`      |
-|                | Background            | background-color | `$layer-accent`        |
-|                | Icon                  | svg              | `$icon-secondary`      |
-| Focus-selected | Label                 | text-color       | `$text-primary`        |
-|                | Background            | background-color | `$layer`               |
-|                | Icon                  | svg              | `$icon-primary`        |
-| Disabled       | Label                 | text-color       | `$text-disabled`       |
-|                | Icon                  | svg              | `$icon-disabled`       |
-|                | Background            | background-color | `$button-disabled`     |
-|                | Border                | border-right     | `$border-disabled`     |
+| State          | Element               | Property         | Color token               |
+| -------------- | --------------------- | ---------------- | ------------------------- |
+| Hover          | Background            | background-color | `$layer-accent-hover` \*  |
+|                | Label                 | text-color       | `$text-primary`           |
+|                | Icon                  | svg              | `$icon-primary`           |
+|                | Scrollable background | background-color | `$layer-accent-hover` \*  |
+| Active         | Scrollable background | background-color | `$layer-accent-active` \* |
+| Focus          | Scrollable background | border           | `$focus`                  |
+| Focus-enabled  | Label                 | text-color       | `$text-secondary`         |
+|                | Background            | background-color | `$layer-accent` \*        |
+|                | Icon                  | svg              | `$icon-secondary`         |
+| Focus-selected | Label                 | text-color       | `$text-primary`           |
+|                | Background            | background-color | `$layer` \*               |
+|                | Icon                  | svg              | `$icon-primary`           |
+| Disabled       | Label                 | text-color       | `$text-disabled`          |
+|                | Icon                  | svg              | `$icon-disabled`          |
+|                | Background            | background-color | `$button-disabled`        |
+|                | Border                | border-right     | `$border-disabled`        |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <div className="image--fixed">
 

--- a/src/pages/components/text-input/style.mdx
+++ b/src/pages/components/text-input/style.mdx
@@ -14,8 +14,13 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Field text       | text color       | `$text-primary`     |
 | Placeholder text | text color       | `$text-placeholder` |
 | Helper text      | text color       | `$text-helper`      |
-| Field            | background-color | `$field`            |
-|                  | border-bottom    | `$border-strong`    |
+| Field            | background-color | `$field` \*         |
+|                  | border-bottom    | `$border-strong` \* |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 <Row>
 <Column colLg={8}>
@@ -33,7 +38,7 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 | Invalid  | Field         | outline       | `$support-error` |
 |          | Error message | text color    | `$text-error`    |
 |          | Warning icon  | svg           | `$support-error` |
-| Disabled | Field         | background    | `$field`         |
+| Disabled | Field         | background    | `$field` \*      |
 |          | Field         | border-bottom | transparent      |
 |          | Field text    | text color    | `$text-disabled` |
 

--- a/src/pages/components/tile/style.mdx
+++ b/src/pages/components/tile/style.mdx
@@ -10,12 +10,17 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 | Class          | Property         | Color token       |
 | -------------- | ---------------- | ----------------- |
-| Tile           | background-color | `$layer`          |
+| Tile           | background-color | `$layer` \*       |
 | Tile: focus    | border           | `$focus`          |
-| Tile: hover    | background-color | `$layer-hover`    |
+| Tile: hover    | background-color | `$layer-hover` \* |
 | Tile: selected | border           | `$border-inverse` |
 | Chevron icon   | svg              | `$icon-primary`   |
 | Checkmark icon | svg              | `$icon-primary`   |
+
+<Caption>
+  * Denotes a contextual color token that will change values based on the layer
+  it is placed on.
+</Caption>
 
 ## Structure
 


### PR DESCRIPTION
Adding annotation to the style tab pages to explain the user of contextual tokens.
- Added an `*` besides contextual tokens
- Added a footnote at the bottom of tables to explain the contextual token.

![image](https://user-images.githubusercontent.com/11670886/145247306-2a7a3aa9-141f-4959-aaec-806176012ad8.png)
