### PR TITLE
chore: update gatsby theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "gatsby": "^3.14.3",
     "gatsby-image": "^3.7.1",
     "gatsby-plugin-image": "^1.14.1",
-    "gatsby-theme-carbon": "^2.1.6",
+    "gatsby-theme-carbon": "^2.2.0",
     "lodash-es": "^4.17.15",
     "markdown-it": "^9.0.1",
     "nanoid": "^2.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8614,10 +8614,10 @@ gatsby-telemetry@^2.14.0:
     node-fetch "^2.6.1"
     uuid "3.4.0"
 
-gatsby-theme-carbon@^2.1.6:
-  version "2.1.6"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-2.1.6.tgz#6394a5502929e10b745dfc963938e4f8cd11dbb7"
-  integrity sha512-HmsASuhayNyvU0isBxO4EZdnC1FfPJTjPcq/dxCxX8Szz7YD/sh2yp4HoLKiHV5cEXoyr807V2UB1PI09X1dOw==
+gatsby-theme-carbon@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-2.2.0.tgz#51d2ec459354d68bf53cac7695a4fae1cd95b449"
+  integrity sha512-iaOlsCin0G+Gat2SBzktrJbq5WPBojAQ8+cZaPrliZ0OyrnIrHs4lt2pF7GqHmt/gKfWEono2I2N4S1kBfqKlg==
   dependencies:
     "@babel/core" "^7.14.6"
     "@carbon/elements" "^10.38.0"


### PR DESCRIPTION
Pulls in latest switcher update