### PR TITLE
React Tutorial: Replace deprecated layout token with spacing token

### DIFF
--- a/src/pages/developing/react-tutorial/step-2.mdx
+++ b/src/pages/developing/react-tutorial/step-2.mdx
@@ -600,8 +600,8 @@ baseline, for consistency as well as development ease so `margins` and
 
 ```scss path=src/content/LandingPage/_landing-page.scss
 .landing-page__tab-content {
-  padding-top: $layout-05;
-  padding-bottom: $layout-05;
+  padding-top: $spacing-10;
+  padding-bottom: $spacing-10;
 }
 
 .landing-page__subheading {


### PR DESCRIPTION
**React Tutorial Part 2**

One of the code examples uses the scss variables `$layout-05` for vertical padding/spacing. 
No mention of the layout token system is made in the tutorial (only the spacing tokens are referenced). 
It seems that the layout tokens are deprecated, and it's a bit confusing for tutorial users to see a rogue example of the layout token with no context or explanation (its also absent from the latest spacing documentation page)
Suggest replacing it with $spacing-10 (equivalent rem).
