### PR TITLE
[update] figma kit page with themes

### DIFF
--- a/src/pages/designing/kits/figma.mdx
+++ b/src/pages/designing/kits/figma.mdx
@@ -97,7 +97,8 @@ Under the same team `[NEW] IBM Design Systems` you can also turn on the
 following libraries:
 
 - Color styles - IBM Design Language
-- Icons and Pictograms - IBM Design Language
+- Icons - IBM Design Language
+- Pictograms - IBM Design Language
 - Text styles - IBM Design Language
 
 ## Start designing

--- a/src/pages/designing/kits/figma.mdx
+++ b/src/pages/designing/kits/figma.mdx
@@ -13,15 +13,6 @@ contains all resources you need to get started.
 
 </PageDescription>
 
-<InlineNotification>
-
-**Beta release:** Only the White theme is available in Beta. The other three
-themes will be available by the end of year. The beta is also only available to
-IBMers at the moment however we are hoping to publish it the the Figma community
-in early 2022 for external use.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Get the library</AnchorLink>
@@ -40,6 +31,8 @@ libraries.
 
 #### 2. Turn on the theme libraries
 
+There are four Carbon themes, two light (White and Gray 10) and two dark (Gray 90 and Gray 100). Each theme lives in its own Figma library. You can turn on as many libraries as you’d like.
+
 Inside of a design file, navigate to the **Main menu** panel in the top left of
 the toolbar (A). Open the menu and select **Libraries** from the list (B).
 
@@ -52,8 +45,7 @@ the toolbar (A). Open the menu and select **Libraries** from the list (B).
 </Row>
 
 Then in the Libraries modal that appears, find the team called
-`[NEW] IBM Design Systems` (C) and switch the toggle beside
-`White theme - Carbon Design System` to on (D).
+`[NEW] IBM Design Systems` (C) and switch the toggle beside a themed library, for example the `White theme - Carbon Design System` to on (D).
 
 <Row>
 <Column colLg={8}>
@@ -63,8 +55,41 @@ Then in the Libraries modal that appears, find the team called
 </Column>
 </Row>
 
-To preview the library, visit this
-[view-only link](https://www.figma.com/file/Vzz8k68Pqk5HfaTdQOQrGu/White-Theme---Carbon-Design-System?node-id=456%3A14680).
+To preview the four themed libraries, visit these view-only files.
+
+<Row className="resource-card-group">
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      onClick={() => fathom.trackGoal('P0OEN9TS', 0)}
+      subTitle="White theme"
+      href="https://www.figma.com/file/Vzz8k68Pqk5HfaTdQOQrGu/White-Theme---Carbon-Design-System">
+    </ResourceCard>
+  </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      onClick={() => fathom.trackGoal('T7D1HJ3L', 0)}
+      subTitle="Gray 10 theme"
+      href="https://www.figma.com/file/i6y80WeotmhmbWxpmcffz7/Gray-10-Theme---Carbon-Design-System">
+    </ResourceCard>
+  </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      onClick={() => fathom.trackGoal('LYFJTPDE', 0)}
+      subTitle="Gray 90 theme"
+      href="https://www.figma.com/file/fCucrHE8tdGDVJX7ODqajd/Gray-90-Theme---Carbon-Design-System">
+    </ResourceCard>
+  </Column>
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      onClick={() => fathom.trackGoal('3XH0SIBJ', 0)}
+      subTitle="Gray 100 theme"
+      href="https://www.figma.com/file/TckQzGe3bNxHPLoRhbXFal/Gray-100-Theme---Carbon-Design-System">
+    </ResourceCard>
+  </Column>
+</Row>
+
+<br />
+<br />
 
 #### 3. Turn on the other IBM Design Language libraries 
 


### PR DESCRIPTION
**Changed**
- Updating the Figma Design kit page to add all four themes.

----

**Testing**
- Go to Designing --> Design kits --> Figma
  - Make sure the links in the themed cards work.
  - Make sure content makes sense.