### PR TITLE
docs: fix broken link in DataTable sizing section

### DIFF
--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -354,7 +354,7 @@ import {
 ### Sizing
 
 The data table is available in four different
-[row sizes](/data-table/style#row-sizes): tall, normal, short, compact.
+[row sizes](/data-table/style#rows): tall, normal, short, compact.
 
 <Row>
 <Column colLg={8}>


### PR DESCRIPTION

Fixes a broken link in the DataTable docs under the Sizing section.
