### PR TITLE
docs(typography): fix line-height unit

### DIFF
--- a/src/components/TypesetStyle/TypesetExample.js
+++ b/src/components/TypesetStyle/TypesetExample.js
@@ -106,7 +106,7 @@ const TypesetExample = (props) => (
         // eslint-disable-next-line no-useless-concat
         lineHeight: `${`${calculateFluidLineHeight('line-height')}px / `}${
           currentBreakpointSpecs['line-height']
-        }em`,
+        }rem`,
         letterSpacing: currentBreakpointSpecs['letter-spacing']
           .toString()
           .replace('0.', '.'),


### PR DESCRIPTION
Updates the typography documentation to use `rem` instead of `em` as the unit for line heights as they are in fact using `rem` / are always based on 16px instead of the individual type style's font size.

#### Changelog

**Changed**

- Changed `em` to `rem` in typgraphy documentation for line height specifications
