### PR TITLE
docs(motion): update duration token names

### DIFF
--- a/src/pages/guidelines/motion/overview.mdx
+++ b/src/pages/guidelines/motion/overview.mdx
@@ -288,12 +288,12 @@ easier implementation.
 
 | Token                   | Usage                                                         | Value |     |
 | ----------------------- | ------------------------------------------------------------- | ----- | --- |
-| `duration--fast-01`     | Micro-interactions such as button and toggle                  | 70ms  |     |
-| `duration--fast-02`     | Micro-interactions such as fade                               | 110ms |     |
-| `duration--moderate-01` | Micro-interactions, small expansion, short distance movements | 150ms |     |
-| `duration--moderate-02` | Expansion, system communication, toast                        | 240ms |     |
-| `duration--slow-01`     | Large expansion, important system notifications               | 400ms |     |
-| `duration--slow-02`     | Background dimming                                            | 700ms |     |
+| `duration-fast-01`     | Micro-interactions such as button and toggle                  | 70ms  |     |
+| `duration-fast-02`     | Micro-interactions such as fade                               | 110ms |     |
+| `duration-moderate-01` | Micro-interactions, small expansion, short distance movements | 150ms |     |
+| `duration-moderate-02` | Expansion, system communication, toast                        | 240ms |     |
+| `duration-slow-01`     | Large expansion, important system notifications               | 400ms |     |
+| `duration-slow-02`     | Background dimming                                            | 700ms |     |
 
 ## Implementation
 


### PR DESCRIPTION
Update duration token names on the v11 guidance page

#### Changelog

**New**

**Changed**

- Update `duration--` tokens to `duration-`

**Removed**
