### PR TITLE
fix(carbon-website): remove ibm--z and ibm--z--partition from pictogram index

### DIFF
--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -16,20 +16,31 @@ import {
 
 const IconCategory = ({ category, pictograms, columnCount }) => {
   const [sectionRef, containerIsVisible] = useIntersectionObserver();
+
   return (
     <section ref={sectionRef} className={svgCategory}>
       <h2 className={cx(h2, categoryTitle)}>{category}</h2>
       <ul className={cx(svgGrid, pictogramList)}>
-        {pictograms.map((pictogram, i) => (
-          <SvgCard
-            isLastCard={(i + 1) % columnCount === 0}
-            containerIsVisible={containerIsVisible}
-            key={pictogram.name}
-            icon={pictogram}
-            height="23.5%"
-            width="23.5%"
-          />
-        ))}
+        {pictograms
+          .filter((pictogram) => {
+            if (
+              pictogram.name === 'ibm--z' ||
+              pictogram.name === 'ibm--z--partition'
+            ) {
+              return false;
+            }
+            return true;
+          })
+          .map((pictogram, i) => (
+            <SvgCard
+              isLastCard={(i + 1) % columnCount === 0}
+              containerIsVisible={containerIsVisible}
+              key={pictogram.name}
+              icon={pictogram}
+              height="23.5%"
+              width="23.5%"
+            />
+          ))}
       </ul>
     </section>
   );


### PR DESCRIPTION
Verify that `ibm--z` and `ibm--z--partition` do not show up in the pictogram index. 

Relevant slack convo: 
https://ibm-studios.slack.com/archives/GCQ5R263T/p1646931614070099