### PR TITLE
docs(form): update spacing examples to use Stack

### DIFF
--- a/src/pages/components/form/code.mdx
+++ b/src/pages/components/form/code.mdx
@@ -88,7 +88,7 @@ documentation, see the Storybooks for each framework below.
     }}
   >{`
   <Form>
-  <div style={{marginBottom: '2rem'}}>
+  <Stack gap={6}>
     <TextInput
       helperText="Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)"
       id="test2"
@@ -96,8 +96,8 @@ documentation, see the Storybooks for each framework below.
       labelText="Text input label"
       placeholder="Placeholder text"
     />
-  </div>
-  <div style={{marginBottom: '2rem'}}>
+  </Stack>
+  <Stack gap={6}>
   <TextArea
     cols={50}
     helperText="Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)"
@@ -107,8 +107,8 @@ documentation, see the Storybooks for each framework below.
     placeholder="Placeholder text"
     rows={4}
   />
-  </div>
-  <div style={{marginBottom: '2rem'}}>
+  </Stack>
+  <Stack gap={6}>
     <Select
       defaultValue="placeholder-item"
       id="select-1"
@@ -128,7 +128,7 @@ documentation, see the Storybooks for each framework below.
         value="option-3"
       />
     </Select>
-  </div>
+  </Stack>
   <Button
     kind="primary"
     tabIndex={0}

--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -66,7 +66,7 @@ do you gain by collecting this information?
     }}
   >{`
   <Form>
-  <div style={{marginBottom: '2rem'}}>
+  <Stack gap=
     <TextInput
       helperText="Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)"
       id="test2"
@@ -75,7 +75,7 @@ do you gain by collecting this information?
       placeholder="Placeholder text"
     />
   </div>
-  <div style={{marginBottom: '2rem'}}>
+  <Stack gap={6}>
   <TextArea
     cols={50}
     helperText="Optional helper text here; if message is more than one line text should wrap (~100 character count maximum)"
@@ -85,8 +85,8 @@ do you gain by collecting this information?
     placeholder="Placeholder text"
     rows={4}
   />
-  </div>
-  <div style={{marginBottom: '2rem'}}>
+  </Stack>
+  <Stack gap={6}>
     <Select
       defaultValue="placeholder-item"
       id="select-1"
@@ -106,7 +106,7 @@ do you gain by collecting this information?
         value="option-3"
       />
     </Select>
-  </div>
+  </Stack>
   <Button
     kind="primary"
     tabIndex={0}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/2343
Part of https://github.com/carbon-design-system/carbon/issues/9948

#### Changelog

**Changed**

- Update form examples to use Stack instead of a hardcoded 2rem margin.