### PR TITLE
v11-general content updates

### DIFF
--- a/src/pages/components/UI-shell-left-panel/usage.mdx
+++ b/src/pages/components/UI-shell-left-panel/usage.mdx
@@ -28,8 +28,7 @@ interaction patterns that persist between and across products.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://sketch.cloud/s/EjVmA"
-    >
+      href="https://sketch.cloud/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -28,8 +28,7 @@ interaction patterns that persist between and across products.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://sketch.cloud/s/EjVmA"
-    >
+      href="https://sketch.cloud/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -97,8 +97,7 @@ import { Add16 } from '@carbon/icons-react';
       id: 'icon-only',
       label: 'Icon only',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="button"
     knobs={{
@@ -113,8 +112,7 @@ import { Add16 } from '@carbon/icons-react';
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=button',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
-    }}
-  >{`
+    }}>{`
       <Button>Button</Button>
     `}</ComponentVariant>
   <ComponentVariant
@@ -131,8 +129,7 @@ import { Add16 } from '@carbon/icons-react';
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=button',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
-    }}
-  >{`
+    }}>{`
       <Button renderIcon={Add16}>Button</Button>
     `}</ComponentVariant>
   <ComponentVariant
@@ -149,8 +146,7 @@ import { Add16 } from '@carbon/icons-react';
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=button',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--icon',
-    }}
-  >{`
+    }}>{`
       <Button
         hasIconOnly
         renderIcon={Add16}
@@ -372,19 +368,19 @@ Other fluid components include tiles and most recently,
 #### Fluid button border
 
 Many product designers have approached us looking for more guidance around
-borders between all fluid buttons. In a
-[recent update](https://github.com/carbon-design-system/carbon/issues/5638), we
-added a 1px border between all fluid buttons that call the `$ui-03` token for
-subtle borders. This feature adds a 3:1 distinction between the two interactive
-UI elements. The border is a recommended feature to improve accessibility in
-data visualizations, and the same logic should apply here.
+borders between all fluid buttons. There is a 1px border between all fluid
+buttons that call the `$button-separator` token for borders. This feature adds a
+3:1 distinction between the two interactive UI elements. The border is a
+recommended feature to improve accessibility.
 
 <Row>
 <Column colLg={8}>
 
-![Example of $ui-03 token border between fluid buttons](images/button_usage_14.png)
+![Example of $button-separator token border between fluid buttons](images/button_usage_14.png)
 
-<Caption>Example of $ui-03 token border between fluid buttons</Caption>
+<Caption>
+  Example of $button-separator token border between fluid buttons
+</Caption>
 
 </Column>
 </Row>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -14,15 +14,6 @@ main variants of notifications are toast notifications and inline notifications.
 
 </PageDescription>
 
-<InlineNotification>
-
-V11 update: Toast notifications have been refactored to now allow interactive
-content in them, like links and buttons. To support the usecase of having a
-toast with or without interactive content, we have introduced two types of toast
-notifications—polite and assertive.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -14,6 +14,15 @@ main variants of notifications are toast notifications and inline notifications.
 
 </PageDescription>
 
+<InlineNotification>
+
+V11 update: Toast notifications have been refactored to now allow interactive
+content in them, like links and buttons. To support the usecase of having a
+toast with or without interactive content, we have introduced two types of toast
+notifications—polite and assertive.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>
@@ -61,8 +70,7 @@ product teams also support banners and notification centers.
       id: 'inline',
       label: 'Inline notification',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="toast"
     knobs={{
@@ -77,8 +85,7 @@ product teams also support banners and notification centers.
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--toast',
-    }}
-  >{`
+    }}>{`
     <div>
       <ToastNotification
         caption="00:00:00 AM"
@@ -103,8 +110,7 @@ product teams also support banners and notification centers.
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--inline',
-    }}
-  >{`
+    }}>{`
   <div>
     <InlineNotification
       kind="info"

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -13,6 +13,17 @@ between groups of information that appear within the same context.
 
 </PageDescription>
 
+<InlineNotification>
+
+**V11 updates:** the following are the major updates made to tabs in v11.
+
+- Tab variant names have been updated to _Line tabs_ and _Contained tabs_
+- Three new style modifiers—tabs with icons, icon-only tabs, and secondary
+  labels
+- Tabs with auto-width alignment
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -13,17 +13,6 @@ between groups of information that appear within the same context.
 
 </PageDescription>
 
-<InlineNotification>
-
-**V11 updates:** the following are the major updates made to tabs in v11.
-
-- Tab variant names have been updated to _Line tabs_ and _Contained tabs_
-- Three new style modifiers—tabs with icons, icon-only tabs, and secondary
-  labels
-- Tabs with auto-width alignment
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>

--- a/src/pages/designing/kits/sketch.mdx
+++ b/src/pages/designing/kits/sketch.mdx
@@ -345,7 +345,7 @@ previous version.
 ### Migration
 
 The Sketch libraries work on a continous migration stategy. The v11 updates were
-made in the same libraries that were used in v10. If you're Carbon Sketch
+made in the same libraries that were used in v10. If your Carbon Sketch
 Libraries are up to date then they are using v11. If you do not wish to use v11
 yet then do not accept the library update pushed on 31 March 2022.
 

--- a/src/pages/designing/kits/sketch.mdx
+++ b/src/pages/designing/kits/sketch.mdx
@@ -346,7 +346,7 @@ previous version.
 
 The Sketch libraries work on a continous migration stategy. The v11 updates were
 made in the same libraries that were used in v10. If your Carbon Sketch
-Libraries are up to date then they are using v11. If you do not wish to use v11
+libraries are up to date then they are using v11. If you do not wish to use v11
 yet then do not accept the library update pushed on 31 March 2022.
 
 ### Support

--- a/src/pages/designing/kits/sketch.mdx
+++ b/src/pages/designing/kits/sketch.mdx
@@ -40,8 +40,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('P0OEN9TS', 0)}
       subTitle="White theme"
-      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1"
-    >
+      href="sketch://add-library/cloud/557b75ff-67d3-41ab-ada5-fa25447218c1">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -49,8 +48,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('T7D1HJ3L', 0)}
       subTitle="Gray 10 theme"
-      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f"
-    >
+      href="sketch://add-library/cloud/b4ea2a21-4b1a-4c64-99dc-a1365eff5d5f">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -58,8 +56,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('LYFJTPDE', 0)}
       subTitle="Gray 90 theme"
-      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc"
-    >
+      href="sketch://add-library/cloud/a324c6dd-df97-435e-b79f-3a29e04922fc">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -67,8 +64,7 @@ own Sketch library. You can subscribe to as many libraries as you'd like.
     <ResourceCard
       onClick={() => fathom.trackGoal('3XH0SIBJ', 0)}
       subTitle="Gray 100 theme"
-      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477"
-    >
+      href="sketch://add-library/cloud/9d47a4fd-70dd-44ff-bc57-22c79da8e477">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -86,24 +82,21 @@ in two different libraries separated by size.
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design Language"
-      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba"
-    >
+      href="sketch://add-library/cloud/4f1cbe6c-6626-405e-8c46-a9ae41a30cba">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Icons (16px, 20px) library"
-      href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7"
-    >
+      href="sketch://add-library/cloud/028e0598-591e-428c-a490-f6ec64b15ea7">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Icons (24px, 32px) library"
-      href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3"
-    >
+      href="sketch://add-library/cloud/d530998a-c94c-4f1c-bc0e-c05417e067e3">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -125,16 +118,14 @@ access the saved grid template at `File → New file from Template`.
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Grid template"
-      href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e"
-    >
+      href="https://www.sketch.com/s/3a3f3f2d-94d7-4c16-8e2e-88ba80a6382e">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
-    >
+      href="https://www.sketch.com/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -353,9 +344,10 @@ previous version.
 
 ### Migration
 
-If you're using an older version of Carbon, check out the v10
-[migration docs](/help/migration-guide/design/) when you're ready to make the
-switch.
+The Sketch libraries work on a continous migration stategy. The v11 updates were
+made in the same libraries that were used in v10. If you're Carbon Sketch
+Libraries are up to date then they are using v11. If you do not wish to use v11
+yet then do not accept the library update pushed on 31 March 2022.
 
 ### Support
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -35,50 +35,11 @@ theming, size naming, and new components.
 
 ### Kit migration
 
-| Design tool                          | V11              | Migration strategy                                                                                                                                                         |
-| ------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Sketch](/designing/kits/sketch)     | Update available | The same Sketch Cloud libraries that were used in v10 have been updated to include the v11 changes. Do not accept the library update until you are ready to work in v11.  |
-| [Figma](/designing/kits/figma)       | TBD              | TBD                                                                                                                                                                        |
-| [Adobe XD](/designing/kits/adobe-xd) | TBD              | TBD                                                                                                                                                                        |
-
-<!---
-### v11 Beta kit
-
-Try out the v11 Beta Sketch kit that has been updated to reflect our color token
-name changes and additional token layer sets and contextual layer sets. The v11
-Beta kit is available in the White and Gray 100 themes.
-
-<InlineNotification>
-  Note: The v11 Beta kit is temporary and only available during our beta release
-  timeframe. The existing v10 kits will be updated with these changes and
-  additions once v11 is released to the general public.
-</InlineNotification>
-
-<Row className="resource-card-group">
-<Column colLg={4} colMd={4} noGutterSm>
-<ResourceCard
-    subTitle="White theme (Beta)"
-    href="sketch://add-library/cloud/fabc8814-ead2-4eeb-a893-ef3b6ea88875"
-    actionIcon="download"
-    >
-
-<MdxIcon name="sketch" />
-
-</ResourceCard>
-</Column>
-<Column colLg={4} colMd={4} noGutterSm>
-<ResourceCard
-    subTitle="Gray 100 theme (Beta)"
-    actionIcon="download"
-    href="sketch://add-library/cloud/9b33e49d-9b79-4696-9f57-c7a15c1e276a"
-    >
-      
-<MdxIcon name="sketch" />
-
-</ResourceCard>
-</Column>
-</Row>
---->
+| Design tool                          | V11                                  | Migration strategy                                                                                                                                                        |
+| ------------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Sketch](/designing/kits/sketch)     | Update available                     | The same Sketch Cloud libraries that were used in v10 have been updated to include the v11 changes. Do not accept the library update until you are ready to work in v11.  |
+| [Figma](/designing/kits/figma)       | Expected release by the end of April | The same Figma libraries that were used in v10 will be updated to include the v11 changes. Do not accept the library update until you are ready to work in v11.           |
+| [Adobe XD](/designing/kits/adobe-xd) | Partial update available             | Some of the v11 changes have been made in the XD files. It is yet to be determined when all the other changes will be added.                                              |
 
 ## Components
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -1,7 +1,7 @@
 ---
 title: Guide
 description:
-The transition from v10 to v11 includes updates and additions to color tokens, theming, size naming, and new components.
+The transition from v10 to v11 includes updates and additions to color tokens, theming, and introduces beta kits to experiment with.
 tabs: ['Overview', 'Design', 'Develop']
 ---
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -1,7 +1,8 @@
 ---
 title: Guide
 description:
-The transition from v10 to v11 includes updates and additions to color tokens, theming, and introduces beta kits to experiment with.
+  The transition from v10 to v11 includes updates and additions to color tokens,
+  theming, and introduces beta kits to experiment with.
 tabs: ['Overview', 'Design', 'Develop']
 ---
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -1,16 +1,14 @@
 ---
 title: Guide
 description:
-  The design transition from v10 to v11 includes updates and additions to
-  components, color tokens, theming, and introduces beta kits to experiment
-  with.
+The transition from v10 to v11 includes updates and additions to color tokens, theming, size naming, and new components.
 tabs: ['Overview', 'Design', 'Develop']
 ---
 
 <PageDescription>
 
 The transition from v10 to v11 includes updates and additions to color tokens,
-theming, and introduces beta kits to experiment with.
+theming, size naming, and new components.
 
 </PageDescription>
 
@@ -31,9 +29,18 @@ theming, and introduces beta kits to experiment with.
 
 - Updated existing color token names to better reflect their usage
 - Updated layer styles with new color tokens
-- Updated text styles with new color tokens
-- Removal of light variants (in favor of new layer and contextual token sets)
+- Updated text styles with new tokens names
+- Removal of `light` variants (in favor of new layer and contextual token sets)
 
+### Kit migration
+
+| Design tool                          | V11              | Migration strategy                                                                                                                                                         |
+| ------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Sketch](/designing/kits/sketch)     | Update available | The same Sketch Cloud libraries that were used in v10 have been updated to include the v11 changes. Do not accept the library updated until you are ready to work in v11.  |
+| [Figma](/designing/kits/figma)       | TBD              | TBD                                                                                                                                                                        |
+| [Adobe XD](/designing/kits/adobe-xd) | TBD              | TBD                                                                                                                                                                        |
+
+ <!---
 ### v11 Beta kit
 
 Try out the v11 Beta Sketch kit that has been updated to reflect our color token
@@ -70,6 +77,8 @@ Beta kit is available in the White and Gray 100 themes.
 </ResourceCard>
 </Column>
 </Row>
+
+--->
 
 ## Components
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -30,14 +30,14 @@ theming, size naming, and new components.
 
 - Updated existing color token names to better reflect their usage
 - Updated layer styles with new color tokens
-- Updated text styles with new tokens names
+- Updated text styles with new token names
 - Removal of `light` variants (in favor of new layer and contextual token sets)
 
 ### Kit migration
 
 | Design tool                          | V11              | Migration strategy                                                                                                                                                         |
 | ------------------------------------ | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Sketch](/designing/kits/sketch)     | Update available | The same Sketch Cloud libraries that were used in v10 have been updated to include the v11 changes. Do not accept the library updated until you are ready to work in v11.  |
+| [Sketch](/designing/kits/sketch)     | Update available | The same Sketch Cloud libraries that were used in v10 have been updated to include the v11 changes. Do not accept the library update until you are ready to work in v11.  |
 | [Figma](/designing/kits/figma)       | TBD              | TBD                                                                                                                                                                        |
 | [Adobe XD](/designing/kits/adobe-xd) | TBD              | TBD                                                                                                                                                                        |
 

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -41,7 +41,7 @@ theming, size naming, and new components.
 | [Figma](/designing/kits/figma)       | TBD              | TBD                                                                                                                                                                        |
 | [Adobe XD](/designing/kits/adobe-xd) | TBD              | TBD                                                                                                                                                                        |
 
- <!---
+<!---
 ### v11 Beta kit
 
 Try out the v11 Beta Sketch kit that has been updated to reflect our color token
@@ -78,7 +78,6 @@ Beta kit is available in the White and Gray 100 themes.
 </ResourceCard>
 </Column>
 </Row>
-
 --->
 
 ## Components

--- a/src/pages/migrating/guide/overview.mdx
+++ b/src/pages/migrating/guide/overview.mdx
@@ -8,9 +8,9 @@ tabs: ['Overview', 'Design', 'Develop']
 
 <PageDescription>
 
-Ready to make the migration to Carbon v11 Beta? There are breaking changes along
-with net new features that your product can now consume. Getting started with
-Carbon has never been easier!
+Ready to make the migration to Carbon v11? There are breaking changes along with
+net new features that your product can now consume. Getting started with Carbon
+has never been easier!
 
 </PageDescription>
 
@@ -43,8 +43,8 @@ use.
 - **Sass modules:** Carbon styles have been updated to use its own dedicated
   package and is transitioning to Sass modules.
 - **Theming:** New support for inline theming and light or dark modes.
-- **Design kit:** A new v11 Beta kit has been created with color token updates
-  for testing purposes.
+- **Design kit:** The Sketch theme libraries have been updated to include all
+  v11 updates. Other design tools may have a rolling update to come.
 - **Components:** A new one-package install along with new components and API
   updates.
 - **Grid:** New CSS Grid support to make it easier to build layouts.


### PR DESCRIPTION
Migration guide updates:
- Update language for GA release (removed beta references) 
- Added kit migration table

Other:
- Update old UI Shell Sketch links
- Updated v10 tokens and content on button usage page
- Update migration section on Sketch kit page.


FYI More updates being made in: https://github.com/carbon-design-system/carbon-website/pull/2807