### PR TITLE
fix(website): icon page, code blocks fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "gatsby": "^4.9.2",
     "gatsby-image": "^3.7.1",
     "gatsby-plugin-image": "^2.9.0",
-    "gatsby-theme-carbon": "^3.0.0-next.6",
+    "gatsby-theme-carbon": "^3.0.0-next.7",
     "lodash-es": "^4.17.15",
     "markdown-it": "^9.0.1",
     "nanoid": "^2.1.11",

--- a/src/components/SVGLibraries/shared/ActionBar.js
+++ b/src/components/SVGLibraries/shared/ActionBar.js
@@ -65,6 +65,17 @@ const ActionBar = ({
       className={cx(container, {
         [hidden]: !isActionBarVisible,
       })}>
+      {/* Refactor to use IconButton once popover styles are included in gatsby-theme-carbon */}
+      {/* <IconButton
+        align="top"
+        kind="ghost"
+        size="sm"
+        label="Download SVG"
+        onFocus={() => setIsActionBarVisible(true)}
+        onClick={handleDownload}
+        className={tooltip}>
+        <Download16 />
+      </IconButton> */}
       <Button
         kind="ghost"
         size="small"
@@ -92,6 +103,17 @@ const ActionBar = ({
           className={tooltip}
           triggerClassName={trigger}
         />
+        // Refactor to use IconButton once popover styles are included in gatsby-theme-carbon
+        // <IconButton
+        //   align="top"
+        //   kind="ghost"
+        //   size="sm"
+        //   label={copyText}
+        //   onFocus={() => setIsActionBarVisible(true)}
+        //   onClick={handleDownload}
+        //   className={tooltip}>
+        //   <Code16 />
+        // </IconButton>
       )}
     </div>
   );

--- a/src/components/SVGLibraries/shared/FilterRow.js
+++ b/src/components/SVGLibraries/shared/FilterRow.js
@@ -27,6 +27,7 @@ const FilterRow = ({
         labelText={`filter ${type}s by searching for their name or category`}
         onChange={onSearchChange}
         placeHolderText={placeHolderText}
+        size="lg"
       />
       <Dropdown
         className={dropdown}

--- a/src/components/SVGLibraries/shared/SvgLibrary.module.scss
+++ b/src/components/SVGLibraries/shared/SvgLibrary.module.scss
@@ -39,6 +39,10 @@
   }
 }
 
+.filter-row :global(.cds--dropdown) {
+  border-bottom: none;
+}
+
 .filter-row.pictograms :global(.cds--search) {
   @include breakpoint('lg') {
     width: calc(75% + 1px);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8491,10 +8491,10 @@ gatsby-telemetry@^3.9.0:
     lodash "^4.17.21"
     node-fetch "^2.6.7"
 
-gatsby-theme-carbon@^3.0.0-next.6:
-  version "3.0.0-next.6"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-3.0.0-next.6.tgz#966fefd7e9afbfbb311e0ddef61fd21b90cc5581"
-  integrity sha512-QrRcTDd6h6AS1VqbQVVkLPYXpMwDJdglgTRQBA3pHxD508KxArMW4xLvf7mkr2Bfhgh6CwKEyk8lFzetMr39iw==
+gatsby-theme-carbon@^3.0.0-next.7:
+  version "3.0.0-next.7"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-3.0.0-next.7.tgz#b1e02fd2486bade7db8bf3787d9a1c878d6c02b4"
+  integrity sha512-+QR/YUhPIbaLcXPTj+0ColS3JBxaOilMokI89LPnIklqgya1Mn2tRb0UccrMK/WPhUvgiTtPuoRpB0g6OGn35A==
   dependencies:
     "@babel/core" "^7.14.6"
     "@carbon/elements" "^10.55.0"


### PR DESCRIPTION
Part of https://github.com/carbon-design-system/carbon-website/issues/2785

#### Changelog

**Changed**

- update gatsby theme carbon to ensure we're using the right font family for code blocks
- updated dropdown styles for the icons page
- stubbed out some fixes for the icon page copy/download buttons (blocked currently, will be able to fix once the v11 release is out)
