### PR TITLE
Update style.mdx

### DIFF
--- a/src/pages/components/checkbox/style.mdx
+++ b/src/pages/components/checkbox/style.mdx
@@ -43,8 +43,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Typography
 
-Checkbox headings and labels should be sentence case, with only the first word
-in a phrase and any proper nouns capitalized. Checkbox headings and labels
+Checkbox labels and group labels should be sentence case, with only the first word
+in a phrase and any proper nouns capitalized. Checkbox labels and group labels
 should not exceed three words.
 
 | Class                 | Font-size (px/rem) | Font-weight   | Type token       |


### PR DESCRIPTION
Updated use of "heading" to be "group label", as per the Usage tab and discussion.
@laurenmrice **NOTE** that there is an image (checkbox-style-3.png) which should be changed to match. "Label" should become "Group label". "Check option 1" etc should become "Checkbox label 1" etc.

