### PR TITLE
docs: add icon section to adobe xd docs

### DIFF
--- a/src/pages/designing/kits/adobe-xd.mdx
+++ b/src/pages/designing/kits/adobe-xd.mdx
@@ -195,7 +195,7 @@ To learn more about applying character styles in Adobe XD, see the
 
 ### Icons
 
-The IBM Icon library is seperate from our theme libraries. Add the library by
+The IBM Icon library is separate from our theme libraries. Add the library by
 using the Creative Cloud app or by visiting this web link.
 
 <Row className="resource-card-group">

--- a/src/pages/designing/kits/adobe-xd.mdx
+++ b/src/pages/designing/kits/adobe-xd.mdx
@@ -193,6 +193,24 @@ change the color of a character style.
 To learn more about applying character styles in Adobe XD, see the
 [Adobe XD docs](https://helpx.adobe.com/xd/help/work-with-assets-and-libraries-xd.html).
 
+### Icons
+
+The IBM Icon library is seperate from our theme libraries. Add the library by
+using the Creative Cloud app or by visiting this web link.
+
+<Row className="resource-card-group">
+<Column colMd={4} colLg={4} noGutterSm>
+  <ResourceCard
+    subTitle="IBM Icons"
+    href="https://assets.adobe.com/more-libraries/urn:aaid:sc:VA7:3609d51f-f1ec-4ad3-87a5-744638af0413?libraryVersion=6&org=973430F0543801CA0A4C98C6%40AdobeOrg"
+    actionIcon="launch">
+
+![Adobe XD icon](/images/adobe-xd.png)
+
+  </ResourceCard>
+</Column>
+</Row>
+
 ### Support
 
 If you’re brand new to Adobe XD, they offer some great


### PR DESCRIPTION
- Add an Icon section to the Adobe XD tab documentation.

---

**New**

- Add Icon section
- Add Icon content and resource card link to add the library.