### PR TITLE
V11 - add component banners + other updates

### DIFF
--- a/src/pages/all-about-carbon/releases.mdx
+++ b/src/pages/all-about-carbon/releases.mdx
@@ -69,7 +69,7 @@ experience standards. For more details about this release, see our
 <!-- prettier-ignore-start -->
 | Carbon Design System | IBM Design Language | Carbon Elements | Carbon Components | Carbon React |
 | -------------------- | ------------------- | --------------- | ----------------- | ------------ |
-| [Carbon v11]((https://www.carbondesignsystem.com)<br />— 31 Mar 2022<br />— Improves token and prop naming<br />— Adds light/dark mode support<br />— Uses CSS grid | [IDL v2](https://www.ibm.com/design/language) | v11.x | v11.x | v8.x |
+| [Carbon v11](https://www.carbondesignsystem.com)<br />— 31 Mar 2022<br />— Improves token and prop naming<br />— Adds light/dark mode support<br />— Uses CSS grid | [IDL v2](https://www.ibm.com/design/language) | v11.x | v11.x | v8.x |
 | [Carbon v10](https://v10.carbondesignsystem.com)<br />— 29 Mar 2019<br />— Updates assets to IDL v2<br />— Updates grid to 16 columns<br />— Adds Carbon Elements package | [IDL v2](https://www.ibm.com/design/language) | [v10.x](https://www.npmjs.com/package/@carbon/elements/v/latest) | [v10.x](https://www.npmjs.com/package/carbon-components/v/latest) | [v7.x](https://www.npmjs.com/package/carbon-components-react/v/latest) |
 | [Carbon v9](https://v9.carbondesignsystem.com)<br />— 4 June 2018 | IDL v1 | — | [v9.x](https://www.npmjs.com/package/carbon-components/v/9.x) | [v6.x](https://www.npmjs.com/package/carbon-components-react/v/6.x) |
 | [Carbon v8](https://v8.carbondesignsystem.com)<br />— 26 Oct 2017 | IDL v1 | — | [v8.23.1](https://www.npmjs.com/package/carbon-components/v/8.23.1) | [v5.x](https://www.npmjs.com/package/carbon-components-react/v/5.x) |

--- a/src/pages/all-about-carbon/releases.mdx
+++ b/src/pages/all-about-carbon/releases.mdx
@@ -62,15 +62,15 @@ Carbon v10 implemented our newly-updated brand expression (IBM Design Language
 v2) into our components. The updated components required product teams to
 redesign product UIs and begin a migration plan to comply with IBM brand
 experience standards. For more details about this release, see our
-[v10 release page](https://www.carbondesignsystem.com/help/migration-guide/overview).
+[v10 release page](https://v10.carbondesignsystem.com/help/migration-guide/overview).
 
 ## Release history
 
 <!-- prettier-ignore-start -->
 | Carbon Design System | IBM Design Language | Carbon Elements | Carbon Components | Carbon React |
 | -------------------- | ------------------- | --------------- | ----------------- | ------------ |
-| Carbon v11<br />— Q1 2022<br />— Improves token and prop naming<br />— Adds light/dark mode support<br />— Uses CSS grid | [IDL v2](https://www.ibm.com/design/language) | v11.x | v11.x | v8.x |
-| [Carbon v10](https://www.carbondesignsystem.com)<br />— 29 Mar 2019<br />— Updates assets to IDL v2<br />— Updates grid to 16 columns<br />— Adds Carbon Elements package | [IDL v2](https://www.ibm.com/design/language) | [v10.x](https://www.npmjs.com/package/@carbon/elements/v/latest) | [v10.x](https://www.npmjs.com/package/carbon-components/v/latest) | [v7.x](https://www.npmjs.com/package/carbon-components-react/v/latest) |
+| [Carbon v11]((https://www.carbondesignsystem.com)<br />— 31 Mar 2022<br />— Improves token and prop naming<br />— Adds light/dark mode support<br />— Uses CSS grid | [IDL v2](https://www.ibm.com/design/language) | v11.x | v11.x | v8.x |
+| [Carbon v10](https://v10.carbondesignsystem.com)<br />— 29 Mar 2019<br />— Updates assets to IDL v2<br />— Updates grid to 16 columns<br />— Adds Carbon Elements package | [IDL v2](https://www.ibm.com/design/language) | [v10.x](https://www.npmjs.com/package/@carbon/elements/v/latest) | [v10.x](https://www.npmjs.com/package/carbon-components/v/latest) | [v7.x](https://www.npmjs.com/package/carbon-components-react/v/latest) |
 | [Carbon v9](https://v9.carbondesignsystem.com)<br />— 4 June 2018 | IDL v1 | — | [v9.x](https://www.npmjs.com/package/carbon-components/v/9.x) | [v6.x](https://www.npmjs.com/package/carbon-components-react/v/6.x) |
 | [Carbon v8](https://v8.carbondesignsystem.com)<br />— 26 Oct 2017 | IDL v1 | — | [v8.23.1](https://www.npmjs.com/package/carbon-components/v/8.23.1) | [v5.x](https://www.npmjs.com/package/carbon-components-react/v/5.x) |
 | [Carbon v7](https://v7.carbondesignsystem.com)<br />— 30 Mar 2017 | IDL v1 | — | [v7.26.10](https://www.npmjs.com/package/carbon-components/v/7.26.10) | [v4.2.2](https://www.npmjs.com/package/carbon-components-react/v/4.2.2) |

--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -18,7 +18,7 @@ interaction patterns that persist between and across products.
 
 **v11 update:** The UI shell is now themeable and has been updated to use inline
 theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each themes styles.
+tokens and the color will follow each theme's styles.
 
 </InlineNotification>
 

--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -14,6 +14,14 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** The UI shell is now themeable and has been updated to use inline
+theming. The UI shell uses Carbon theme tokens instead of component specific
+tokens and the color will follow each themes styles.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>

--- a/src/pages/components/UI-shell-left-panel/usage.mdx
+++ b/src/pages/components/UI-shell-left-panel/usage.mdx
@@ -18,7 +18,7 @@ interaction patterns that persist between and across products.
 
 **v11 update:** The UI shell is now themeable and has been updated to use inline
 theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each themes styles.
+tokens and the color will follow each theme's styles.
 
 </InlineNotification>
 

--- a/src/pages/components/UI-shell-left-panel/usage.mdx
+++ b/src/pages/components/UI-shell-left-panel/usage.mdx
@@ -14,6 +14,14 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** The UI shell is now themeable and has been updated to use inline
+theming. The UI shell uses Carbon theme tokens instead of component specific
+tokens and the color will follow each themes styles.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>General guidance</AnchorLink>

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -18,7 +18,7 @@ interaction patterns that persist between and across products.
 
 **v11 update:** The UI shell is now themeable and has been updated to use inline
 theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each themes styles.
+tokens and the color will follow each theme's styles.
 
 </InlineNotification>
 

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -14,6 +14,14 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** The UI shell is now themeable and has been updated to use inline
+theming. The UI shell uses Carbon theme tokens instead of component specific
+tokens and the color will follow each themes styles.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>General guidance</AnchorLink>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -15,6 +15,15 @@ actionable notifications.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** An actionable variant has been added to the notification
+component. Actionable notifications allow for interactive elements within a
+notification, like buttons. Toast and inline notification no longer allow any
+interactive elements.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>
@@ -76,8 +85,7 @@ although some product teams also support banners and notification centers.
         'https://react.carbondesignsystem.com/?path=/story/components-notifications--toast',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-notification--toast',
-      Vue:
-        'http://vue.carbondesignsystem.com/?path=/story/components-cvtoastnotification--default',
+      Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtoastnotification--default',
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--toast',
@@ -102,8 +110,7 @@ although some product teams also support banners and notification centers.
         'https://react.carbondesignsystem.com/?path=/story/components-notifications--inline',
       Angular:
         'https://angular.carbondesignsystem.com/?path=/story/components-notification--basic',
-      Vue:
-        'http://vue.carbondesignsystem.com/?path=/story/components-cvinlinenotification--default',
+      Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvinlinenotification--default',
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=notification',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--inline',

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -20,7 +20,8 @@ actionable notifications.
 **v11 update:** An actionable variant has been added to the notification
 component. Actionable notifications allow for interactive elements within a
 notification, like buttons. Toast and inline notification no longer allow any
-interactive elements.
+interactive elements. For more information see the
+[migration guide](/migrating/guide/develop#notifications-breaking).
 
 </InlineNotification>
 

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -20,8 +20,7 @@ actionable notifications.
 **v11 update:** An actionable variant has been added to the notification
 component. Actionable notifications allow for interactive elements within a
 notification, like buttons. Toast and inline notification no longer allow any
-interactive elements. For more information see the
-[migration guide](/migrating/guide/develop#notifications-breaking).
+interactive elements.
 
 </InlineNotification>
 

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -20,8 +20,7 @@ between groups of information that appear within the same context.
 **v11 update:** The tab component variant names are changing. Default tabs has
 become _Line tabs_ and Container tabs has become _Contained tabs_. Tabs has also
 been refactor to have composable component API which allows for additional
-modifications like icons in tabs and secondary labels. For more information see
-the [migration guide](/guide/develop#tabs-breaking).
+modifications like icons in tabs and secondary labels.
 
 </InlineNotification>
 

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -15,6 +15,15 @@ between groups of information that appear within the same context.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** The tab component variant names are changing. Default tabs has
+become _Line tabs_ and Container tabs has become _Contained tabs_. Tabs has also
+been refactor to have composable component API which allows for additional
+modifications like icons in tabs and secondary labels.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>
@@ -101,8 +110,7 @@ such as modals, cards, or side panels.
     Tab,
     TabPanels,
     TabPanel,
-  }}
->
+  }}>
   <ComponentVariant
     id="tabs"
     knobs={{
@@ -118,8 +126,7 @@ such as modals, cards, or side panels.
       Vanilla: 'https://the-carbon-components.netlify.com/?nav=tabs',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tabs--default',
-    }}
-  >{`
+    }}>{`
 <div style={{ width: '50%' }}>
   <Tabs>
     <TabList aria-label="List of tabs" contained>

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -20,7 +20,8 @@ between groups of information that appear within the same context.
 **v11 update:** The tab component variant names are changing. Default tabs has
 become _Line tabs_ and Container tabs has become _Contained tabs_. Tabs has also
 been refactor to have composable component API which allows for additional
-modifications like icons in tabs and secondary labels.
+modifications like icons in tabs and secondary labels. For more information see
+the [migration guide](/guide/develop#tabs-breaking).
 
 </InlineNotification>
 

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -17,10 +17,11 @@ between groups of information that appear within the same context.
 
 <InlineNotification>
 
-**v11 update:** The tab component variant names are changing. Default tabs has
-become _Line tabs_ and Container tabs has become _Contained tabs_. Tabs has also
-been refactor to have composable component API which allows for additional
-modifications like icons in tabs and secondary labels.
+**v11 update:** The tab component variant names have changed. Default tabs has
+become _Line tabs_ and Container tabs has become _Contained tabs_. The tabs
+component has also been refactored and now includes a composable component API
+which allows for additional style modifications like icons in tabs and secondary
+labels.
 
 </InlineNotification>
 

--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -14,6 +14,16 @@ extra ability to communicate and give clarity to a user.
 
 </PageDescription>
 
+<InlineNotification>
+
+**v11 update:** The tooltip component has been refactored to use the
+[popover](/components/popover/usage/) component under the hood to improve
+accessibility. Definition and interactive tootips now use the
+[toggletip](/components/toggletip/usage/) component to achieve accessibility
+standards.
+
+</InlineNotification>
+
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -39,7 +39,7 @@ Carbon uses type tokens to manage typography, and these tokens sit within two
 type sets. The productive and expressive type sets support designers creating
 for a full range of user needs and activities across product and web pages. To
 understand when to use styles from each set, see
-[Type usage](/guidelines/typography/type-usage).
+[Styling strategies](/guidelines/typography/styling-strategies).
 
 #### Base type sizes
 
@@ -105,7 +105,7 @@ styles change size at different breakpoints.
 Do not use these styles inside a container. They may be used in product pages
 where text sits outside of a container, and a blend of expressive and productive
 type styles is desired for hierarchy and distinction. For more information, see
-[Type usage](/guidelines/typography/type-usage).
+[Styling strategies](/guidelines/typography/styling-strategies).
 
 <TypesetStyle typesets="fluidHeadings" breakpointControls={true} />
 
@@ -114,7 +114,7 @@ type styles is desired for hierarchy and distinction. For more information, see
 The callout and display styles are part of the expressive set and being fluid,
 they will adjust at different breakpoints. Do not use these styles inside a
 container. For guidance about using display styles, see
-[Type usage](/guidelines/typography/type-usage#expressive-use-cases/).
+[Styling strategies](/guidelines/typography/styling-strategies#expressive-use-cases).
 
 <TypesetStyle typesets="fluidCallouts,fluidDisplay" breakpointControls={true} />
 


### PR DESCRIPTION
- Added "v11 update" notification banner to the component usage pages with major updates (notification, tabs, tooltip, UI Shell). 
- Updated Release page with new links
- Updated broken links on Typography page.