### PR TITLE
ci: add CNAME file when deploying

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,9 @@ jobs:
           GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
           NODE_ENV: production
           CI: true
+      - name: Add CNAME record
+        run: |
+          echo 'staging.carbondesignsystem.com' > public/CNAME
       - name: Deploy
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,6 @@ jobs:
       - name: Deploy
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npx gh-pages -d public -u "github-actions-bot <support+actions@github.com>"
+          npx gh-pages -d public -u "github-actions <github-actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds in a CNAME file to the `public` folder when deploying. It also updates the user associated with the commit based on the recommendations in: https://github.com/actions/checkout#push-a-commit-using-the-built-in-token

#### Changelog

**New**

**Changed**

- Add CNAME file to `public` folder
- Update git user for commits

**Removed**
