### PR TITLE
fix(livedemo): add left border

### DIFF
--- a/src/components/ComponentDemo/ComponentDemo.module.scss
+++ b/src/components/ComponentDemo/ComponentDemo.module.scss
@@ -281,6 +281,7 @@ fieldset.form-group:last-of-type {
   overflow: auto;
   padding: $spacing-05;
   border: $spacing-03 solid $background;
+  border-left: 1px solid $ui-03;
   background-color: var(--cds-background);
   width: 100%;
   display: flex;


### PR DESCRIPTION
This updates all live demo preview containers to now have a left border to avoid the issue described in https://github.com/carbon-design-system/carbon/issues/10889#issuecomment-1077992681

#### Changelog

**Changed**

- add back the left border to the live demo preview container
