### PR TITLE
Added classes for different typography types

### DIFF
--- a/src/components/TypeWeight/type-weight.scss
+++ b/src/components/TypeWeight/type-weight.scss
@@ -25,4 +25,13 @@
   .cds--type-light {
     font-weight: 300;
   }
+
+  .cds--type-serif {
+    font-family: 'IBM Plex Serif', 'Georgia', Times, serif;
+  }
+
+  .cds--type-mono {
+    font-family: 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono',
+      'Bitstream Vera Sans Mono', Courier, monospace;
+  }
 }


### PR DESCRIPTION
Part of #2900

Made the typeface examples show the correct font by adding new classes to `type-weight.scss`.

#### Changelog

**New**

- Class `cds--type-serif` which uses the serif font stack
- Class `cds--type-mono` which uses the mono font stack
