### PR TITLE
fix(componentdemo): update codesandbox demos for v11

### DIFF
--- a/src/components/ComponentDemo/Code/useCodesandbox.js
+++ b/src/components/ComponentDemo/Code/useCodesandbox.js
@@ -18,7 +18,7 @@ const getIndex = ({ code = '' }) => {
   return `
   import React from 'react';
   import { render } from 'react-dom';
-  import 'carbon-components/css/carbon-components.min.css';
+  import './index.scss';
   import { ${uniqueComponents.join(', ')} } from '@carbon/react';
   ${importSampleData()}
 
@@ -47,8 +47,6 @@ const useCodesandbox = (code) => {
               react: 'latest',
               'react-dom': 'latest',
               '@carbon/react': 'latest',
-              'carbon-components': 'latest',
-              'carbon-icons': 'latest',
             },
           },
         },
@@ -57,6 +55,9 @@ const useCodesandbox = (code) => {
         },
         'index.html': {
           content: `<div id="root"></div>`,
+        },
+        'index.scss': {
+          content: `@use '@carbon/react';`,
         },
         ...(/^<DataTable/.test(code) && sampleData.DataTable),
       },


### PR DESCRIPTION
Closes #2872 

#### Changelog

**Changed**

- update codesandbox demo code to properly config styles/packages for v11

Steps to review:
- Navigate to the codesandbox links on component demos, the codesandboxes should now work.