### PR TITLE
fix(Data table): live demo zebra stipe styles and size knobs

### DIFF
--- a/src/components/ComponentDemo/ComponentDemo.module.scss
+++ b/src/components/ComponentDemo/ComponentDemo.module.scss
@@ -429,9 +429,9 @@ body[data-live-preview-theme='Gray 100']
   }
 
   [class*='--data-table--zebra'] tbody tr:nth-child(even) td {
-    background-color: var(--cds-ui-03, #e0e0e0);
-    border-bottom: var(--cds-ui-03, #e0e0e0);
-    border-top: var(--cds-ui-03, #e0e0e0);
+    background-color: var(--cds-layer-accent-01, #e0e0e0);
+    border-bottom: var(--cds-layer-accent-01, #e0e0e0);
+    border-top: var(--cds-layer-accent-01, #e0e0e0);
   }
 
   [class*='--data-table--zebra'] tbody tr:nth-child(odd) td {

--- a/src/data/docgen/overrides.json
+++ b/src/data/docgen/overrides.json
@@ -428,6 +428,68 @@
       }
     }
   },
+  "Table": {
+    "description": "",
+    "displayName": "Table",
+    "props": {
+      "isSortable": {
+        "defaultValue": { "value": "false", "computed": false },
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "`false` If true, will apply sorting styles"
+      },
+      "overflowMenuOnHover": {
+        "defaultValue": { "value": "true", "computed": false },
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "Specify whether the overflow menu (if it exists) should be shown always, or only on hover"
+      },
+      "children": {
+        "type": { "name": "node" },
+        "required": false,
+        "description": "Pass in the children that will be rendered within the Table"
+      },
+      "className": {
+        "type": { "name": "string" },
+        "required": false,
+        "description": ""
+      },
+      "shouldShowBorder": {
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "`false` If true, will remove the table border"
+      },
+      "size": {
+        "type": {
+          "name": "enum",
+          "value": [
+            { "value": "'xs'", "computed": false },
+            { "value": "'sm'", "computed": false },
+            { "value": "'md'", "computed": false },
+            { "value": "'lg'", "computed": false },
+            { "value": "'xl'", "computed": false }
+          ]
+        },
+        "required": false,
+        "description": "`normal` Change the row height of table"
+      },
+      "stickyHeader": {
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "`false` If true, will keep the header sticky (only data rows will scroll)"
+      },
+      "useStaticWidth": {
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "`false` If true, will use a width of 'auto' instead of 100%"
+      },
+      "useZebraStyles": {
+        "type": { "name": "bool" },
+        "required": false,
+        "description": "`true` to add useZebraStyles striping."
+      }
+    }
+  },
   "Switch": {
     "description": "",
     "displayName": "Switch",


### PR DESCRIPTION
Closes [#11283](https://github.com/carbon-design-system/carbon/issues/11283)

#### Changelog

- updates some old data table live demo overriding styles
- overrides `Table` component docgen to work for v11 `size` knobs

#### Reviewing

1. go to DataTable page
2. check Usage tab live demo
    - test size knobs (table should update sizes correctly now)
    - test zebra stripes in dark themes (these were previously not working)
3. check Code tab live demo 
    - repeat 
