### PR TITLE
docs: bi-weekly carbon and idl design playbacks

### DIFF
--- a/src/pages/whats-happening/meetups/index.mdx
+++ b/src/pages/whats-happening/meetups/index.mdx
@@ -26,7 +26,7 @@ peers, and getting reviews on work in progress.
 <Column colLg={7} colMd={5}>
 
 <h2>
-  Carbon and IDL weekly design playbacks
+  Carbon and IDL bi-weekly design playbacks
   <span>Fridays, 12pm–1pm Central</span>
 </h2>
 


### PR DESCRIPTION
- Change carbon and idl playbacks to say "bi-weekly" instead of weekly to match our calendar events.