### PR TITLE
fix: cleanup mdx on contributing addons page

### DIFF
--- a/src/pages/contributing/add-ons.mdx
+++ b/src/pages/contributing/add-ons.mdx
@@ -42,19 +42,6 @@ by the Carbon team. For your add-on to be accepted, your components must meet
 WCAG AA standards and include interaction states (hover, active, focus, and
 disabled).
 
-<!--
-
-| Category      | Metric                                              | Core library                                         | Add-ons                                              |
-| ------------- | --------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------- |
-| Accessibility | WCAG AA                                             | ✅ | ✅ |
-|               | Keyboard tabbing                                    | ✅ | ✅ |
-|               | Carbon custom focus states                          | ✅ |                                                      |
-| Visual + UX   | Carbon themed                                       | ✅ |                                                      |
-|               | Universal pattern <br />(fits for 2-3 use cases)    | ✅ |                                                      |
-|               | Interaction states (hover, active, focus, disabled) | ✅ | ✅ |
-
--->
-
 ## Ownership and maintenance
 
 If you build an add-on repo, it's your responsibility to maintain it. This


### PR DESCRIPTION
Cleanup mdx to allow seamless import into the Platform, currently causing an error due to html comments. 

#### Changelog

**Removed**

- html comments / content that isn't needed
