### PR TITLE
fix: convert inline styles to objects and fix mdx formatting

### DIFF
--- a/src/pages/community/patterns/create-flows/index.mdx
+++ b/src/pages/community/patterns/create-flows/index.mdx
@@ -84,7 +84,7 @@ respectively.
   src="/images/InlineCreateExample.gif"
   alt="Animated inline create example"
   title="Animated inline create example"
-  style="padding:3rem; background-color:#e0e0e0"
+  style={{ padding: '3rem', backgroundColor: '#e0e0e0' }}
 />
 
 <Caption>Example of an inline create</Caption> 

--- a/src/pages/components/UI-shell-header/code.mdx
+++ b/src/pages/components/UI-shell-header/code.mdx
@@ -69,7 +69,7 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/v10-starter-sandbox-kf3h4?fontsize=14&hidenavigation=1&view=preview"
       title="header-base"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -90,7 +90,7 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-base-v07hj?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -111,7 +111,7 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-actions-vh014?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -132,7 +132,7 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-actions-and-nav-m0lo2?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions-and-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -153,7 +153,7 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-sidenav-1u7su?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-sidenav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',

--- a/src/pages/components/UI-shell-header/code.mdx
+++ b/src/pages/components/UI-shell-header/code.mdx
@@ -69,7 +69,13 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/v10-starter-sandbox-kf3h4?fontsize=14&hidenavigation=1&view=preview"
       title="header-base"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -84,7 +90,13 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-base-v07hj?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -99,7 +111,13 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-actions-vh014?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -114,7 +132,13 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-actions-and-nav-m0lo2?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions-and-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -129,7 +153,13 @@ the Storybooks for each framework below.
       src="https://codesandbox.io/embed/header-with-sidenav-1u7su?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-sidenav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>

--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -75,7 +75,13 @@ independently, but the components were designed to work together.
       src="https://codesandbox.io/embed/header-with-actions-and-nav-m0lo2?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions-and-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>

--- a/src/pages/components/UI-shell-left-panel/code.mdx
+++ b/src/pages/components/UI-shell-left-panel/code.mdx
@@ -69,7 +69,13 @@ see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/fixed-sidenav-tk9cs?fontsize=14&hidenavigation=1&view=preview"
       title="fixed-sidenav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -84,7 +90,13 @@ see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/fixed-sidenav-with-icons-875it?fontsize=14&hidenavigation=1&view=preview"
       title="fixed-sidenav-with-icons"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>

--- a/src/pages/components/UI-shell-left-panel/code.mdx
+++ b/src/pages/components/UI-shell-left-panel/code.mdx
@@ -69,7 +69,7 @@ see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/fixed-sidenav-tk9cs?fontsize=14&hidenavigation=1&view=preview"
       title="fixed-sidenav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -90,7 +90,7 @@ see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/fixed-sidenav-with-icons-875it?fontsize=14&hidenavigation=1&view=preview"
       title="fixed-sidenav-with-icons"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',

--- a/src/pages/components/UI-shell-right-panel/code.mdx
+++ b/src/pages/components/UI-shell-right-panel/code.mdx
@@ -49,7 +49,7 @@ documentation, see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/right-panel-clc2m?fontsize=1&hidenavigation=1&view=preview"
       title="right-panel"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',
@@ -70,7 +70,7 @@ documentation, see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/right-panel-with-switcher-3zpq1?fontsize=14&hidenavigation=1&view=preview"
       title="right-panel-with-switcher"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',

--- a/src/pages/components/UI-shell-right-panel/code.mdx
+++ b/src/pages/components/UI-shell-right-panel/code.mdx
@@ -49,7 +49,13 @@ documentation, see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/right-panel-clc2m?fontsize=1&hidenavigation=1&view=preview"
       title="right-panel"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>
@@ -64,7 +70,13 @@ documentation, see the Storybooks for each framework below.
       src="https://codesandbox.io/embed/right-panel-with-switcher-3zpq1?fontsize=14&hidenavigation=1&view=preview"
       title="right-panel-with-switcher"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+      sstyle={{
+        width: '100%',
+        height: '500px',
+        border: '0',
+        borderRadius: '4px',
+        overflow: 'hidden',
+      }}
       sandbox="allow-modals allow-forms allow-popups allow-scripts allow-same-origin"
     />
   </Column>

--- a/src/pages/components/breadcrumb/code.mdx
+++ b/src/pages/components/breadcrumb/code.mdx
@@ -80,13 +80,15 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-breadcrumb--default',
     }}
-  >{`
+  >
+    {`
 <Breadcrumb noTrailingSlash>
   <BreadcrumbItem href="/">Breadcrumb 1</BreadcrumbItem>
   <BreadcrumbItem href="/">Breadcrumb 2</BreadcrumbItem>
   <BreadcrumbItem isCurrentPage href="/">Breadcrumb 3</BreadcrumbItem>
 </Breadcrumb>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="breadcrumb"
     links={{
@@ -98,11 +100,13 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-breadcrumb--default',
     }}
-  >{`
+  >
+    {`
 <Breadcrumb>
   <BreadcrumbItem href="/">Breadcrumb 1</BreadcrumbItem>
   <BreadcrumbItem href="/">Breadcrumb 2</BreadcrumbItem>
   <BreadcrumbItem href="/">Breadcrumb 3</BreadcrumbItem>
 </Breadcrumb>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/button/code.mdx
+++ b/src/pages/components/button/code.mdx
@@ -93,9 +93,11 @@ import { Add } from '@carbon/react/icons';
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
     }}
-  >{`
+  >
+    {`
       <Button>Button</Button>
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
   <ComponentVariant
     id="button-with-icon"
     knobs={{
@@ -110,9 +112,11 @@ import { Add } from '@carbon/react/icons';
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
     }}
-  >{`
+  >
+    {`
       <Button renderIcon={Add}>Button</Button>
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
   <ComponentVariant
     id="icon-only"
     knobs={{}}
@@ -125,9 +129,11 @@ import { Add } from '@carbon/react/icons';
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--icon',
     }}
-  >{`
+  >
+    {`
      <IconButton align='top' label='Icon button' className='cds--btn--icon-only'>
        <Add size={16}/>
      </IconButton>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/checkbox/code.mdx
+++ b/src/pages/components/checkbox/code.mdx
@@ -80,11 +80,13 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-checkbox--default',
     }}
-  >{`
+  >
+    {`
 <fieldset className="cds--fieldset">
   <legend className="cds--label">Checkbox heading</legend>
   <Checkbox labelText="Checkbox label" id="checked" />
   <Checkbox labelText="Checkbox label" id="checked-2" />
 </fieldset>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/code-snippet/code.mdx
+++ b/src/pages/components/code-snippet/code.mdx
@@ -94,11 +94,13 @@ import {
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--single-line',
     }}
-  >{`
+  >
+    {`
     <CodeSnippet type="single">
     ${codeSnippetSingle}
     </CodeSnippet>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="code-snippet-multi"
     knobs={{ CodeSnippet: ['light'] }}
@@ -111,11 +113,13 @@ import {
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--multi-line',
     }}
-  >{`
+  >
+    {`
     <CodeSnippet type="multi">
     ${codeSnippet}
     </CodeSnippet>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="code-snippet-inline"
     knobs={{ CodeSnippet: ['light'] }}
@@ -128,9 +132,11 @@ import {
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--inline',
     }}
-  >{`
+  >
+    {`
     <CodeSnippet type="inline">${codeSnippetSingle}</CodeSnippet>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>
 
 ## Sample data

--- a/src/pages/components/content-switcher/code.mdx
+++ b/src/pages/components/content-switcher/code.mdx
@@ -84,11 +84,13 @@ code usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-content-switcher--default',
     }}
-  >{`
+  >
+    {`
 <ContentSwitcher onChange={console.log}>
   <Switch name={'first'} text='First section' />
   <Switch name={'second'} text='Second section' />
   <Switch name={'third'} text='Third section' />
 </ContentSwitcher>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/date-picker/code.mdx
+++ b/src/pages/components/date-picker/code.mdx
@@ -96,7 +96,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-date-picker--default',
     }}
-  >{`
+  >
+    {`
     <DatePicker dateFormat="m/d/Y" datePickerType="simple">
       <DatePickerInput
         id="date-picker-default-id"
@@ -105,7 +106,8 @@ usage documentation, see the Storybooks for each framework below.
         type="text"
       />
     </DatePicker>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="single-calendar"
     knobs={{
@@ -121,7 +123,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-date-picker--single-with-calendar',
     }}
-  >{`
+  >
+    {`
     <DatePicker dateFormat="m/d/Y" datePickerType="single">
       <DatePickerInput
         id="date-picker-calendar-id"
@@ -130,7 +133,8 @@ usage documentation, see the Storybooks for each framework below.
         type="text"
       />
     </DatePicker>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="range-calendar"
     knobs={{
@@ -146,7 +150,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-date-picker--range-with-calendar',
     }}
-  >{`
+  >
+    {`
     <DatePicker dateFormat="m/d/Y" datePickerType="range">
       <DatePickerInput
         id="date-picker-range-start"
@@ -161,7 +166,8 @@ usage documentation, see the Storybooks for each framework below.
         type="text"
       />
     </DatePicker>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="time-picker"
     knobs={{
@@ -176,7 +182,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-date-picker--default',
     }}
-  >{`
+  >
+    {`
     <TimePicker id="time-picker">
       <TimePickerSelect id="time-picker-select-1">
         <SelectItem value="AM" text="AM" />
@@ -187,5 +194,6 @@ usage documentation, see the Storybooks for each framework below.
         <SelectItem value="Time zone 2" text="Time zone 2" />
       </TimePickerSelect>
     </TimePicker>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/dropdown/code.mdx
+++ b/src/pages/components/dropdown/code.mdx
@@ -97,7 +97,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-dropdown--default',
     }}
-  >{`
+  >
+    {`
     <Dropdown
       ariaLabel="Dropdown"
       id="carbon-dropdown-example"
@@ -105,7 +106,8 @@ documentation, see the Storybooks for each framework below.
       label="Dropdown menu options"
       titleText="Dropdown title"
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="combo-box"
     knobs={{
@@ -120,7 +122,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-combo-box--default',
     }}
-  >{`
+  >
+    {`
     <ComboBox
       ariaLabel="ComboBox"
       id="carbon-combobox-example"
@@ -128,7 +131,8 @@ documentation, see the Storybooks for each framework below.
       label="Combo box menu options"
       titleText="Combo box title"
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="multiselect"
     knobs={{
@@ -143,7 +147,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-multi-select--default',
     }}
-  >{`
+  >
+    {`
     <MultiSelect
       ariaLabel="MultiSelect"
       id="carbon-multiselect-example"
@@ -151,7 +156,8 @@ documentation, see the Storybooks for each framework below.
       label="Multiselect menu options"
       titleText="Multiselect title"
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="filter-multiselect"
     links={{
@@ -163,7 +169,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-multi-select--default',
     }}
-  >{`
+  >
+    {`
     <MultiSelect.Filterable
       ariaLabel="Filterable MultiSelect"
       id="filterable-multiselect-example"
@@ -171,7 +178,8 @@ documentation, see the Storybooks for each framework below.
       label="Filterable multiselect options"
       titleText="Filterable multiselect title"
     />
- `}</ComponentVariant>
+ `}
+  </ComponentVariant>
 </ComponentDemo>
 
 ## Sample data

--- a/src/pages/components/file-uploader/code.mdx
+++ b/src/pages/components/file-uploader/code.mdx
@@ -90,7 +90,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-file-uploader--default',
     }}
-  >{`
+  >
+    {`
       <div className="cds--file__container">
         <FileUploader
           accept={[
@@ -105,7 +106,8 @@ usage documentation, see the Storybooks for each framework below.
           labelTitle="Upload"
         />
       </div>
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
   <ComponentVariant
     id="drag-and-drop"
     knobs={{
@@ -120,7 +122,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-file-uploader--default',
     }}
-  >{`
+  >
+    {`
       <div className="cds--file__container">
         <strong className='cds--file--label'>Account photo</strong>
         <p className='cds--label-description'>
@@ -135,7 +138,8 @@ usage documentation, see the Storybooks for each framework below.
           tabIndex={0}
         />
       </div>
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
   <ComponentVariant
     id="upload-states"
     knobs={{
@@ -150,9 +154,11 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-file-uploader--default',
     }}
-  >{`
+  >
+    {`
       <div className="cds--file__container">
         <FileUploaderItem name='color.jpg' errorSubject='File size exceeds limits' errorBody='500 kb max file size. Select a new file and try again.'/>
       </div>
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/form/code.mdx
+++ b/src/pages/components/form/code.mdx
@@ -85,7 +85,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-input--form-item',
     }}
-  >{`
+  >
+    {`
   <Form>
   <Stack gap={7}>
     <TextInput
@@ -132,5 +133,6 @@ documentation, see the Storybooks for each framework below.
   </Button>
   </Stack>
 </Form>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/inline-loading/code.mdx
+++ b/src/pages/components/inline-loading/code.mdx
@@ -81,7 +81,9 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-inline-loading--default',
     }}
-  >{`
+  >
+    {`
     <InlineLoading description="Loading..." />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/link/code.mdx
+++ b/src/pages/components/link/code.mdx
@@ -80,7 +80,9 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-link--default',
     }}
-  >{`
+  >
+    {`
   <Link href="#">Link</Link>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/list/code.mdx
+++ b/src/pages/components/list/code.mdx
@@ -82,7 +82,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-list--ordered',
     }}
-  >{`
+  >
+    {`
     <OrderedList>
       <ListItem>
         Ordered list level 1
@@ -105,7 +106,8 @@ documentation, see the Storybooks for each framework below.
         Ordered list level 1
       </ListItem>
     </OrderedList>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="unordered"
     links={{
@@ -117,7 +119,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-list--unordered',
     }}
-  >{`
+  >
+    {`
       <UnorderedList>
         <ListItem>
           Unordered list level 1
@@ -140,5 +143,6 @@ documentation, see the Storybooks for each framework below.
           Unordered list level 1
         </ListItem>
       </UnorderedList>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/loading/code.mdx
+++ b/src/pages/components/loading/code.mdx
@@ -80,9 +80,11 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-loading--default',
     }}
-  >{`
+  >
+    {`
     <Loading
       description="Active loading indicator" withOverlay={false}
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/modal/code.mdx
+++ b/src/pages/components/modal/code.mdx
@@ -94,7 +94,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-modal--default',
     }}
-  >{`
+  >
+    {`
     <ModalWrapper
       buttonTriggerText="Launch modal"
       modalHeading="Modal heading"
@@ -102,7 +103,8 @@ documentation, see the Storybooks for each framework below.
     >
       <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse cursus fermentum risus, sit amet fringilla nunc pellentesque quis. Duis quis odio ultrices, cursus lacus ac, posuere felis. Donec dignissim libero in augue mattis, a molestie metus vestibulum. Aliquam placerat felis ultrices lorem condimentum, nec ullamcorper felis porttitor. </p>
     </ModalWrapper>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="scrolling-content"
     links={{
@@ -114,7 +116,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-modal--default',
     }}
-  >{`
+  >
+    {`
     <ModalWrapper
       hasScrollingContent
       size="sm"
@@ -149,7 +152,8 @@ documentation, see the Storybooks for each framework below.
         </p>
       </>
     </ModalWrapper>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="with-one-button"
     links={{
@@ -161,7 +165,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-modal--single-button',
     }}
-  >{`
+  >
+    {`
     <ModalWrapper
       buttonTriggerText="Launch modal"
       modalHeading="Modal heading"
@@ -170,7 +175,8 @@ documentation, see the Storybooks for each framework below.
     >
       <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse cursus fermentum risus, sit amet fringilla nunc pellentesque quis. Duis quis odio ultrices, cursus lacus ac, posuere felis. Donec dignissim libero in augue mattis, a molestie metus vestibulum. Aliquam placerat felis ultrices lorem condimentum, nec ullamcorper felis porttitor. </p>
     </ModalWrapper>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="with-three-buttons"
     links={{
@@ -182,7 +188,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-modal--three-buttons',
     }}
-  >{`
+  >
+    {`
     <ModalWrapper
       buttonTriggerText="Launch modal"
       modalHeading="Modal heading"
@@ -202,5 +209,6 @@ documentation, see the Storybooks for each framework below.
     >
       <p> Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse cursus fermentum risus, sit amet fringilla nunc pellentesque quis. Duis quis odio ultrices, cursus lacus ac, posuere felis. Donec dignissim libero in augue mattis, a molestie metus vestibulum. Aliquam placerat felis ultrices lorem condimentum, nec ullamcorper felis porttitor. </p>
     </ModalWrapper>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/notification/code.mdx
+++ b/src/pages/components/notification/code.mdx
@@ -86,7 +86,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--toast',
     }}
-  >{`
+  >
+    {`
     <div>
       <ToastNotification
         caption="00:00:00 AM"
@@ -96,7 +97,8 @@ usage documentation, see the Storybooks for each framework below.
         title="Notification title"
       />
     </div>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
   <ComponentVariant
     id="inline"
     knobs={{
@@ -111,7 +113,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-notifications--inline',
     }}
-  >{`
+  >
+    {`
   <div>
     <InlineNotification
       kind="info"
@@ -121,5 +124,6 @@ usage documentation, see the Storybooks for each framework below.
       title="Notification title"
     />
   </div>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/number-input/code.mdx
+++ b/src/pages/components/number-input/code.mdx
@@ -83,7 +83,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-number-input--default',
     }}
-  >{`
+  >
+    {`
     <NumberInput
       helperText="Optional helper text"
       id="tj-input"
@@ -94,7 +95,8 @@ usage documentation, see the Storybooks for each framework below.
       step={10}
       value={50}
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="mobile-number-input"
     links={{
@@ -106,7 +108,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-number-input--default',
     }}
-  >{`
+  >
+    {`
         <NumberInput
           isMobile
           helperText="Optional helper text"
@@ -118,5 +121,6 @@ usage documentation, see the Storybooks for each framework below.
           step={10}
           value={50}
         />
-    `}</ComponentVariant>
+    `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/overflow-menu/code.mdx
+++ b/src/pages/components/overflow-menu/code.mdx
@@ -82,7 +82,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-overflow-menu--default',
     }}
-  >{`
+  >
+    {`
     <OverflowMenu
       data-floating-menu-container
       selectorPrimaryFocus={'.optionOne'}
@@ -99,5 +100,6 @@ usage documentation, see the Storybooks for each framework below.
       <OverflowMenuItem itemText="Option 3" />
       <OverflowMenuItem itemText="Option 4" hasDivider/>
     </OverflowMenu>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/pagination/code.mdx
+++ b/src/pages/components/pagination/code.mdx
@@ -87,7 +87,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-pagination--default',
     }}
-  >{`
+  >
+    {`
   <div style={{width: '800px'}}>
     <Pagination
       backwardText="Previous page"
@@ -106,5 +107,6 @@ usage documentation, see the Storybooks for each framework below.
       totalItems={103}
     />
   </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/progress-indicator/code.mdx
+++ b/src/pages/components/progress-indicator/code.mdx
@@ -84,7 +84,8 @@ code usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-progress-indicator--default',
     }}
-  >{`
+  >
+    {`
   <div className="some-container">
     <ProgressIndicator currentIndex={1}>
         <ProgressStep
@@ -123,5 +124,6 @@ code usage documentation, see the Storybooks for each framework below.
         />
       </ProgressIndicator>
   </div>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/radio-button/code.mdx
+++ b/src/pages/components/radio-button/code.mdx
@@ -82,7 +82,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-radio-button--default',
     }}
-  >{`
+  >
+    {`
   <FormGroup
   legendText="Radio button heading"
 >
@@ -109,5 +110,6 @@ usage documentation, see the Storybooks for each framework below.
     />
   </RadioButtonGroup>
 </FormGroup>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/search/code.mdx
+++ b/src/pages/components/search/code.mdx
@@ -80,10 +80,12 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-search--default',
     }}
-  >{`
+  >
+    {`
 <Search
   id="search-1"
   placeHolderText="Search"
 />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/select/code.mdx
+++ b/src/pages/components/select/code.mdx
@@ -84,7 +84,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-select--default',
     }}
-  >{`
+  >
+    {`
 <Select
   defaultValue="placeholder-item"
   helperText="Optional helper text"
@@ -121,5 +122,6 @@ documentation, see the Storybooks for each framework below.
     />
   </SelectItemGroup>
 </Select>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/slider/code.mdx
+++ b/src/pages/components/slider/code.mdx
@@ -80,7 +80,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-slider--default',
     }}
-  >{`
+  >
+    {`
   <div className="some-container">
 <Slider
   ariaLabelInput="Label for slider value"
@@ -93,5 +94,6 @@ documentation, see the Storybooks for each framework below.
   value={50}
 />
 </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/structured-list/code.mdx
+++ b/src/pages/components/structured-list/code.mdx
@@ -86,7 +86,8 @@ code usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-structured-list--default',
     }}
-  >{`
+  >
+    {`
     <StructuredListWrapper ariaLabel="Structured list">
       <StructuredListHead>
         <StructuredListRow
@@ -129,7 +130,8 @@ code usage documentation, see the Storybooks for each framework below.
         </StructuredListRow>
       </StructuredListBody>
     </StructuredListWrapper>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="select-structured-list"
     links={{
@@ -141,7 +143,8 @@ code usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-structured-list--default',
     }}
-  >{`
+  >
+    {`
     <StructuredListWrapper selection ariaLabel="Structured list">
       <StructuredListHead>
         <StructuredListRow
@@ -236,5 +239,6 @@ code usage documentation, see the Storybooks for each framework below.
         </StructuredListRow>
       </StructuredListBody>
     </StructuredListWrapper>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/tabs/code.mdx
+++ b/src/pages/components/tabs/code.mdx
@@ -93,7 +93,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tabs--default',
     }}
-  >{`
+  >
+    {`
 <div style={{ width: '75%' }}>
   <Tabs>
     <TabList aria-label="List of tabs">
@@ -116,5 +117,6 @@ documentation, see the Storybooks for each framework below.
     </TabPanels>
   </Tabs>
 </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/tag/code.mdx
+++ b/src/pages/components/tag/code.mdx
@@ -80,7 +80,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tag--default',
     }}
-  >{`
+  >
+    {`
   <>
 <Tag type="red" title="Clear Filter"> Red </Tag>
 <Tag type="magenta" title="Clear Filter"> Magenta </Tag>
@@ -93,5 +94,6 @@ documentation, see the Storybooks for each framework below.
 <Tag type="cool-gray" title="Clear Filter"> Cool gray </Tag>
 <Tag type="warm-gray" title="Clear Filter"> Warm gray </Tag>
 </>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/text-input/code.mdx
+++ b/src/pages/components/text-input/code.mdx
@@ -90,7 +90,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-input--default',
     }}
-  >{`
+  >
+    {`
     <div>
       <TextInput
         helperText="Optional helper text"
@@ -100,7 +101,8 @@ usage documentation, see the Storybooks for each framework below.
         placeholder="Placeholder text"
       />
     </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="password-input"
     links={{
@@ -112,7 +114,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-input--default',
     }}
-  >{`
+  >
+    {`
     <div>
     <TextInput.PasswordInput
       helperText="Optional helper text"
@@ -124,7 +127,8 @@ usage documentation, see the Storybooks for each framework below.
       showPasswordLabel="Show password"
     />
     </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="text-area"
     knobs={{
@@ -139,7 +143,8 @@ usage documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-textarea--default',
     }}
-  >{`
+  >
+    {`
     <div>
     <TextArea
       cols={50}
@@ -151,5 +156,6 @@ usage documentation, see the Storybooks for each framework below.
       rows={4}
     />
     </div>
-`}</ComponentVariant>
+`}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/tile/code.mdx
+++ b/src/pages/components/tile/code.mdx
@@ -98,11 +98,13 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--default',
     }}
-  >{`
+  >
+    {`
     <Tile>
       Default tile
     </Tile>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="clickable-tile"
     knobs={{
@@ -117,13 +119,15 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--clickable',
     }}
-  >{`
+  >
+    {`
     <ClickableTile
       href="#"
     >
       Clickable tile
     </ClickableTile>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="radio-tile"
     knobs={{
@@ -138,7 +142,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--single-selectable',
     }}
-  >{`
+  >
+    {`
     <TileGroup
       defaultSelected="default-selected"
       legend="Radio tile group"
@@ -169,7 +174,8 @@ documentation, see the Storybooks for each framework below.
         Radio tile
       </RadioTile>
     </TileGroup>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="selectable-tile"
     knobs={{
@@ -184,7 +190,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--single-selectable',
     }}
-  >{`
+  >
+    {`
     <div
       aria-label="selectable tiles"
       role="group"
@@ -217,7 +224,8 @@ documentation, see the Storybooks for each framework below.
         Multiselect tile
       </SelectableTile>
     </div>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="expandable-tile"
     knobs={{
@@ -232,7 +240,8 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--expandable',
     }}
-  >{`
+  >
+    {`
     <ExpandableTile
       tabIndex={0}
       tileCollapsedIconText="Interact to Expand tile"
@@ -251,5 +260,6 @@ documentation, see the Storybooks for each framework below.
         </div>
       </TileBelowTheFoldContent>
     </ExpandableTile>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/toggle/code.mdx
+++ b/src/pages/components/toggle/code.mdx
@@ -83,14 +83,16 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-toggle--default',
     }}
-  >{`
+  >
+    {`
     <Toggle
       aria-label="toggle button"
       defaultToggled
       id="toggle-1"
       labelText="Label text"
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="small-toggle"
     links={{
@@ -102,12 +104,14 @@ documentation, see the Storybooks for each framework below.
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-toggle--default',
     }}
-  >{`
+  >
+    {`
     <ToggleSmall
       aria-label="toggle button"
       defaultToggled
       id="toggle-2"
       labelText="Label text"
     />
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/toggletip/code.mdx
+++ b/src/pages/components/toggletip/code.mdx
@@ -49,7 +49,8 @@ import { Information } from '@carbon/icons-react';
       React:
         'https://react.carbondesignsystem.com/?path=/story/components-toggletip--default',
     }}
-  >{`
+  >
+    {`
     <Toggletip>
       <ToggletipButton label="Additional information">
         <Information />
@@ -58,5 +59,6 @@ import { Information } from '@carbon/icons-react';
         <p>Custom content here</p>
       </ToggletipContent>
     </Toggletip>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/components/tooltip/code.mdx
+++ b/src/pages/components/tooltip/code.mdx
@@ -86,7 +86,8 @@ import { Information } from '@carbon/react/icons';
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tooltip--default',
     }}
-  >{`
+  >
+    {`
     <Tooltip
       align="bottom"
       label="This is some tooltip text. This box shows the maximum amount of text that should appear inside. If more room is needed please use a modal instead."
@@ -97,7 +98,8 @@ import { Information } from '@carbon/react/icons';
         <Information />
       </button>
     </Tooltip>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
   <ComponentVariant
     id="definition-tooltip"
     knobs={{
@@ -112,11 +114,13 @@ import { Information } from '@carbon/react/icons';
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tooltip--definition',
     }}
-  >{`
+  >
+    {`
     <DefinitionTooltip
       definition="Brief description of the dotted, underlined word above."
     >
       Definition Tooltip
     </DefinitionTooltip>
-  `}</ComponentVariant>
+  `}
+  </ComponentVariant>
 </ComponentDemo>

--- a/src/pages/data-visualization/complex-charts/index.mdx
+++ b/src/pages/data-visualization/complex-charts/index.mdx
@@ -147,6 +147,13 @@ Here's an example using elkjs in react
 <iframe
   src="https://codesandbox.io/embed/carbon-charts-react-elkjs-diagram-b9xyp?fontsize=14&hidenavigation=1&theme=dark"
   style="width:100%; height:500px; border:0; border-radius: 4px; overflow:hidden;"
+  style={{
+    width: '100%',
+    height: '500px',
+    border: '0',
+    borderRadius: '4px',
+    overflow: 'hidden',
+  }}
   title="carbon-charts-react-elkjs-diagram"
   allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
   sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"

--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -65,7 +65,7 @@ and experiences. Additional colors are used sparingly and purposefully.
   <ColorGrid colorFamily="gray" />
 </div>
 {/* possible TODO: remove inline style */}
-<ColorGrid colorFamily="alerts" style="margin-top: 2rem" />
+<ColorGrid colorFamily="alerts" style={{ marginTop: '2rem' }} />
 <Caption>Alert Colors</Caption>
 
 ### Layering model

--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -160,7 +160,7 @@ example in CodePen shows how it is implemented.
       frameborder="no"
       allowtransparency="true"
       allowfullscreen="true"
-      style="width: 100%;"
+      style={{ width: '100%' }}
     >
       See the Pen{' '}
       <a href="https://codepen.io/team/carbon/pen/KRoBQe/">Middle Truncation</a>{' '}


### PR DESCRIPTION
Closes #

The Platform is using v2 of mdx which requires styles to be formatted as objects. 

#### Changelog

- Converted all inline styles to objects
- Fixed formatting in code mdx files to prevent [`Unexpected end of file in expression, expected a corresponding closing brace for {” error?`
](https://mdxjs.com/docs/troubleshooting-mdx/#unexpected-end-of-file-in-expression-expected-a-corresponding-closing-brace-for-)



