### PR TITLE
chore(Carbon-Website): bump Gatsby Theme Carbon

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "gatsby": "^4.9.2",
     "gatsby-image": "^3.7.1",
     "gatsby-plugin-image": "^2.9.0",
-    "gatsby-theme-carbon": "^3.0.0-next.10",
+    "gatsby-theme-carbon": "^3.0.0-next.11",
     "lodash-es": "^4.17.15",
     "markdown-it": "^12.3.2",
     "nanoid": "^2.1.11",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8575,10 +8575,10 @@ gatsby-telemetry@^3.9.0:
     lodash "^4.17.21"
     node-fetch "^2.6.7"
 
-gatsby-theme-carbon@^3.0.0-next.10:
-  version "3.0.0-next.10"
-  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-3.0.0-next.10.tgz#8334c0987e7fbbb90644f7f57eada06787397748"
-  integrity sha512-meUKpC2aZzQeSqhtfkdhe3AboeszJ9RkWVA6fQShB2LaJRPQymw8KRqw+jeooB06yAw7DYd7UCV6I0eQnVBtYQ==
+gatsby-theme-carbon@^3.0.0-next.11:
+  version "3.0.0-next.11"
+  resolved "https://registry.yarnpkg.com/gatsby-theme-carbon/-/gatsby-theme-carbon-3.0.0-next.11.tgz#df00fb1f4c9874f7f4c4292942d7f256c0a538f6"
+  integrity sha512-bVllzUOAMdJZsocjB09dkKL6BMS1N0AqUrAgjGg9LoYmUFsNLHzEt7FTS5+6plzwV2GqAsYkyhBhZqi4e1AB9Q==
   dependencies:
     "@babel/core" "^7.14.6"
     "@carbon/elements" "^11.2.0"


### PR DESCRIPTION
closes #2884 

updates gatsby-theme-carbon dependency addressing some broken grid styling

### Testing
 Status indicator tables should look to spec (or at least not busted)
 
![image](https://user-images.githubusercontent.com/40970507/169548388-f3f1578a-a31d-408f-8152-e28c4cd05c5b.png)
