### PR TITLE
fix(icon-library): use moduleName for icon library

### DIFF
--- a/src/components/SVGLibraries/shared/ActionBar.js
+++ b/src/components/SVGLibraries/shared/ActionBar.js
@@ -1,5 +1,4 @@
 import React, { useRef, useContext, useState } from 'react';
-import { pascalCase } from 'change-case';
 import { Code, Download } from '@carbon/icons-react';
 import { Button } from '@carbon/react';
 import copy from 'copy-to-clipboard';
@@ -8,25 +7,15 @@ import { LibraryContext } from './LibraryProvider';
 import { container, trigger, hidden, tooltip } from './ActionBar.module.scss';
 
 const ActionBar = ({
+  moduleName,
   name,
-  friendlyName,
   source,
   setIsActionBarVisible,
   isActionBarVisible,
   isLastCard,
-  glyphOnly,
 }) => {
-  const { site, type } = useContext(LibraryContext);
-  let suffix;
-  if (type === 'pictogram') {
-    suffix = '';
-  } else if (glyphOnly) {
-    suffix = 'Glyph';
-  } else {
-    suffix = '32';
-  }
-  const component = `<${pascalCase(friendlyName) + suffix} />`;
-  const [copyText, setCopyText] = useState(`Copy ${component}`);
+  const { site } = useContext(LibraryContext);
+  const [copyText, setCopyText] = useState(`Copy <${moduleName} />`);
   const actionBarRef = useRef();
 
   // Don't show copy button on IDL deployment
@@ -52,9 +41,9 @@ const ActionBar = ({
   const handleCopy = () => {
     setCopyText('Copied!');
     setTimeout(() => {
-      setCopyText(`Copy ${component}`);
+      setCopyText(`Copy ${moduleName}`);
     }, 2000);
-    copy(component, { format: 'text/plain' });
+    copy(`<${moduleName} />`, { format: 'text/plain' });
   };
 
   return (
@@ -64,7 +53,8 @@ const ActionBar = ({
       aria-hidden={!isActionBarVisible}
       className={cx(container, {
         [hidden]: !isActionBarVisible,
-      })}>
+      })}
+    >
       <Button
         kind="ghost"
         size="small"

--- a/src/components/SVGLibraries/shared/SvgCard.js
+++ b/src/components/SVGLibraries/shared/SvgCard.js
@@ -11,11 +11,10 @@ import {
 } from './SvgLibrary.module.scss';
 
 const SvgCard = ({ icon, containerIsVisible, isLastCard, ...rest }) => {
-  const { name, Component, friendlyName, assets } = icon;
+  const { name, Component, friendlyName, assets, moduleInfo } = icon;
   const [isActionBarVisible, setIsActionBarVisible] = useState(false);
 
   let { source } = assets[0];
-  const glyphOnly = assets[0].size === 'glyph' && assets.length <= 1;
 
   if (assets.length > 1) {
     source = assets.find(({ size }) => size === 32).source;
@@ -29,7 +28,8 @@ const SvgCard = ({ icon, containerIsVisible, isLastCard, ...rest }) => {
       onMouseLeave={() => {
         setIsActionBarVisible(false);
       }}
-      className={svgCard}>
+      className={svgCard}
+    >
       <div className={svgCardInside}>
         <span className={triggerText}>{friendlyName}</span>
         {containerIsVisible && (
@@ -47,10 +47,9 @@ const SvgCard = ({ icon, containerIsVisible, isLastCard, ...rest }) => {
               isLastCard={isLastCard}
               name={name}
               source={source}
-              friendlyName={friendlyName}
+              moduleName={moduleInfo.global}
               isActionBarVisible={isActionBarVisible}
               setIsActionBarVisible={setIsActionBarVisible}
-              glyphOnly={glyphOnly}
             />
           </>
         )}


### PR DESCRIPTION
Closes #2949
Closes #2926

Update the icon library to use the new syntax in v11

#### Changelog

**New**

**Changed**

- Use the moduleName for copying icons from the icon library

**Removed**
