### PR TITLE
fix(pictograms): use correct module name

### DIFF
--- a/src/components/SVGLibraries/shared/SvgCard.js
+++ b/src/components/SVGLibraries/shared/SvgCard.js
@@ -11,8 +11,9 @@ import {
 } from './SvgLibrary.module.scss';
 
 const SvgCard = ({ icon, containerIsVisible, isLastCard, ...rest }) => {
-  const { name, Component, friendlyName, assets, moduleInfo } = icon;
+  const { name, Component, friendlyName, assets, moduleInfo, output } = icon;
   const [isActionBarVisible, setIsActionBarVisible] = useState(false);
+  const moduleName = moduleInfo?.global ?? output[0].moduleName;
 
   let { source } = assets[0];
 
@@ -47,7 +48,7 @@ const SvgCard = ({ icon, containerIsVisible, isLastCard, ...rest }) => {
               isLastCard={isLastCard}
               name={name}
               source={source}
-              moduleName={moduleInfo.global}
+              moduleName={moduleName}
               isActionBarVisible={isActionBarVisible}
               setIsActionBarVisible={setIsActionBarVisible}
             />


### PR DESCRIPTION
Closes #2962 

Updates our pictogram guidelines page to use the correct module name.

#### Changelog

**New**

**Changed**

- Updated from using the `moduleInfo` field for both pictos and icons and instead conditionally use the output field if there is no `moduleInfo` field in the pictogram case

**Removed**
