### PR TITLE
docs: add adobe xd cc library disclaimers

### DIFF
--- a/src/pages/designing/kits/adobe-xd.mdx
+++ b/src/pages/designing/kits/adobe-xd.mdx
@@ -15,9 +15,10 @@ contains all resources you need to get started.
 
 <InlineNotification>
 
-The Adobe XD kit is maintained by members of the Carbon community. For support,
-contact the
-[kit's maintainers](https://github.com/IBM/design-kit/issues/new?assignees=&labels=kit%3A+adobe+xd&template=-adobe-xd--carbon-kit.md&title=%5Bcomponent%5D+description+of+issue).
+**Available to IBM only:** the Carbon Adobe XD CC libraries are currently only
+available to IBMers. Alternatively you can download local versions of the
+libraries from the
+[Github repo](https://github.com/IBM/design-kit/tree/master/Adobe%20XD).
 
 </InlineNotification>
 
@@ -218,10 +219,10 @@ If you’re brand new to Adobe XD, they offer some great
 
 ### Releases
 
-Enhancements to the kit will be rolling out in the future. When a new version of
-the library is available, you will need to download the new file to replace the
-old one. Releases will be posted to the
-[GitHub repo](https://github.com/IBM/design-kit).
+You can recieve continuous updates by using the Carbon Adobe XD CC libraries.
+These libraries are currently only available to IBMers. Alternatively you can
+download local versions of the libraries from the
+[Github repo](https://github.com/IBM/design-kit/tree/master/Adobe%20XD).
 
 ## Feedback
 


### PR DESCRIPTION
Closes #2969 

- Added content in two places on the Adobe XD tab to notify users that our CC libraries are only available to IBMers currently but that they cant still download local versions via Github.

---

**New**

- New inline notification at the top of the page.

**Changed**

- Changed "Release" section content to tell people CC libraries are preferred for IBMers but we do have github versions available for those who can not access them.
