### PR TITLE
fix(tooltip): remove outdated docs regarding focus/click prop option

### DIFF
--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -134,9 +134,6 @@ information that is not interactive. A toggletip is used on click or enter when
 you need to expose interactive elements, such as button, that a user needs to
 interact with.
 
-The exception here is that definition tooltip can be invoked on `hover` or
-`click` depending on use case.
-
 ### Variants
 
 | Variant                                     | Purpose                                                                                                                                 |


### PR DESCRIPTION
[Surfaced in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1656001490175759)

#### Changelog

**Removed**

- remove outdated docs regarding focus/click prop option
   - IIRC this prop was removed after feedback from a review by the Carbon Accessibility Guild
