### PR TITLE
ci(issue-triage): update workflow to use workflow from carbon monorepo

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -5,11 +5,5 @@ on:
   issue_comment:
     types: [created]
 jobs:
-  add-to-project:
-    name: Add issue to Design System project
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/add-to-project@v0.0.3
-        with:
-          project-url: https://github.com/orgs/carbon-design-system/projects/39
-          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+  issue-triage:
+    uses: carbon-design-system/carbon/.github/workflows/issue-triage.yml@main


### PR DESCRIPTION
Closes #11693

This is dependent on https://github.com/carbon-design-system/carbon/pull/11694

This will ensure the same automation is ran between this repo and the monorepo to auto-label issues as part of the issue triage process

#### Changelog

**Changed**

- Modify issue triage workflow to use the newly reusable workflow from Carbon monorepo