### PR TITLE
fix(react-tutorial): remove html comments

### DIFF
--- a/src/pages/components/progress-bar/usage.mdx
+++ b/src/pages/components/progress-bar/usage.mdx
@@ -201,7 +201,8 @@ progress bar.
    a fixed visual reference of what the total length and duration of the process
    could be.
 4. **Bar indicator:** Indicates how much the process has progressed.
-5. **Status icon:** Indicates the state of the progress bar, either in error or success state.
+5. **Status icon:** Indicates the state of the progress bar, either in error or
+   success state.
 
 ### Sizing
 

--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -209,21 +209,18 @@ import { Button } from '@carbon/react';
 
 In the `App` component return, you can now replace:
 
-<!-- prettier-ignore-start -->
 ```html path=src/App.js
 <div>
-  Hello Carbon! Well, not quite yet. This is the starting point for the Carbon tutorial.
+  Hello Carbon! Well, not quite yet. This is the starting point for the Carbon
+  tutorial.
 </div>
 ```
-<!-- prettier-ignore-end -->
 
 with:
 
-<!-- prettier-ignore-start -->
-```html path=src/App.js
+```jsx path=src/App.js
 <Button>Button</Button>
 ```
-<!-- prettier-ignore-end -->
 
 Congratulations, you've imported your first component! You should see a Carbon
 styled button on the page.

--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -350,8 +350,7 @@ header a user can make. Replace:
 
 With:
 
-<!-- prettier-ignore-start -->
-```html path=src/components/TutorialHeader/TutorialHeader.js
+```jsx path=src/components/TutorialHeader/TutorialHeader.js
 <HeaderGlobalBar>
   <HeaderGlobalAction aria-label="Notifications" tooltipAlignment="center">
     <Notification size={20} />
@@ -364,7 +363,6 @@ With:
   </HeaderGlobalAction>
 </HeaderGlobalBar>
 ```
-<!-- prettier-ignore-end -->
 
 ### Render the header
 
@@ -547,14 +545,12 @@ the Button import).
 
 Now inside `Content` we'll add the following:
 
-<!-- prettier-ignore-start -->
-```html path=src/App.js
+```jsx path=src/App.js
 <Switch>
   <Route exact path="/" component={LandingPage} />
   <Route path="/repos" component={RepoPage} />
 </Switch>
 ```
-<!-- prettier-ignore-end -->
 
 After that we need to do a couple quick fixes to the UI Shell to have it work
 with the React router.

--- a/src/pages/developing/react-tutorial/step-2.mdx
+++ b/src/pages/developing/react-tutorial/step-2.mdx
@@ -215,7 +215,6 @@ import { Breadcrumb, BreadcrumbItem, Grid, Column } from '@carbon/react';
 
 We can now add our component to the first row, along with a header, like so:
 
-<!-- prettier-ignore-start -->
 ```jsx path=src/content/LandingPage/LandingPage.js
 <Column lg={16} md={8} sm={4} className="landing-page__banner">
   <Breadcrumb noTrailingSlash>
@@ -226,7 +225,6 @@ We can now add our component to the first row, along with a header, like so:
   <h1 className="landing-page__heading">Design &amp; build with Carbon</h1>
 </Column>
 ```
-<!-- prettier-ignore-end -->
 
 You may notice that the styles look off. Don't worry, we'll fix these later.
 
@@ -323,19 +321,15 @@ accessibility violations, you'd see
 because both the `Breadcrumb` and `Tabs` components use `<nav>` elements. To
 fix, add `aria-label` to the `Breadcrumb` opening tag:
 
-<!-- prettier-ignore-start -->
-```html
+```jsx
 <Breadcrumb noTrailingSlash aria-label="Page navigation">
 ```
-<!-- prettier-ignore-end -->
 
 Same goes for the `TabList` opening tag:
 
-<!-- prettier-ignore-start -->
-```html
+```jsx
 <TabList className="tabs-group" aria-label="Tab navigation">
 ```
-<!-- prettier-ignore-end -->
 
 Next, we'll need to add some styling overrides to move the tabs to the right on
 large viewports. Create a file `_overrides.scss` in `src/content/LandingPage`
@@ -380,7 +374,6 @@ names, you have a consolidated list of styling declaration blocks to review.
 We can now add our images and text for each column in the first `Tab` in
 `LandingPage.js`.
 
-<!-- prettier-ignore-start -->
 ```jsx path=src/content/LandingPage/LandingPage.js
 <Column md={4} lg={{ span: 8, offset: 7 }} sm={4}>
   <img
@@ -390,7 +383,6 @@ We can now add our images and text for each column in the first `Tab` in
   />
 </Column>
 ```
-<!-- prettier-ignore-end -->
 
 Now let's set the image size in `_landing-page.scss`:
 
@@ -409,7 +401,6 @@ we'll leave the code as is.
 The third row will be created in a later tutorial, so we'll just add the headers
 for now.
 
-<!-- prettier-ignore-start -->
 ```jsx path=src/content/LandingPage/LandingPage.js
 <Column lg={16} md={8} sm={4} className="landing-page__r3">
   <Grid>
@@ -428,7 +419,6 @@ for now.
   </Grid>
 </Column>
 ```
-<!-- prettier-ignore-end -->
 
 ## Style landing page
 
@@ -746,7 +736,6 @@ import {
 Then, let's create the `RepoTable` component and export it at the very bottom of
 `RepoTable.js`.
 
-<!-- prettier-ignore-start -->
 ```javascript path=src/content/RepoPage/RepoTable.js
 const RepoTable = ({ rows, headers }) => {
   return (
@@ -762,12 +751,13 @@ const RepoTable = ({ rows, headers }) => {
       }) => (
         <TableContainer
           title="Carbon Repositories"
-          description="A collection of public Carbon repositories.">
+          description="A collection of public Carbon repositories."
+        >
           <Table {...getTableProps()}>
             <TableHead>
               <TableRow>
                 <TableExpandHeader />
-                {headers.map(header => (
+                {headers.map((header) => (
                   <TableHeader {...getHeaderProps({ header })}>
                     {header.header}
                   </TableHeader>
@@ -775,10 +765,10 @@ const RepoTable = ({ rows, headers }) => {
               </TableRow>
             </TableHead>
             <TableBody>
-              {rows.map(row => (
+              {rows.map((row) => (
                 <React.Fragment key={row.id}>
                   <TableExpandRow {...getRowProps({ row })}>
-                    {row.cells.map(cell => (
+                    {row.cells.map((cell) => (
                       <TableCell key={cell.id}>{cell.value}</TableCell>
                     ))}
                   </TableExpandRow>
@@ -797,7 +787,6 @@ const RepoTable = ({ rows, headers }) => {
 
 export default RepoTable;
 ```
-<!-- prettier-ignore-end -->
 
 This component uses two props, `rows` and `headers`, and returns a Carbon
 `DataTable`. As for where the various `Table*` components came from? The
@@ -895,11 +884,9 @@ const rows = [
 Lastly in `RepoPage.js`, we need to simply replace `Data table will go here`
 with:
 
-<!-- prettier-ignore-start -->
-```html path=src/content/RepoPage/RepoPage.js
+```jsx path=src/content/RepoPage/RepoPage.js
 <RepoTable headers={headers} rows={rows} />
 ```
-<!-- prettier-ignore-end -->
 
 ## Style repo page
 

--- a/src/pages/developing/react-tutorial/step-3.mdx
+++ b/src/pages/developing/react-tutorial/step-3.mdx
@@ -179,7 +179,6 @@ Replace:
 
 With:
 
-<!-- prettier-ignore-start -->
 ```jsx path=src/index.js
 <ApolloProvider client={client}>
   <Router>
@@ -187,7 +186,6 @@ With:
   </Router>
 </ApolloProvider>
 ```
-<!-- prettier-ignore-end -->
 
 ## Fetch data
 
@@ -492,14 +490,12 @@ Then we need to update our `RepoTable` `rows` prop to only render the subset of
 rows for the current "page". Update
 `<RepoTable headers={headers} rows={rows} />` to:
 
-<!-- prettier-ignore-start -->
 ```javascript path=src/content/RepoPage/RepoPage.js
 <RepoTable
   headers={headers}
   rows={rows.slice(firstRowIndex, firstRowIndex + currentPageSize)}
 />
 ```
-<!-- prettier-ignore-end -->
 
 <InlineNotification>
 

--- a/src/pages/developing/react-tutorial/step-4.mdx
+++ b/src/pages/developing/react-tutorial/step-4.mdx
@@ -274,7 +274,6 @@ With everything imported, replace the current:
 
 With the new components:
 
-<!-- prettier-ignore-start -->
 ```javascript path=src/content/LandingPage/LandingPage.js
 <InfoSection heading="The Principles" className="landing-page__r3">
   <InfoCard
@@ -294,7 +293,6 @@ With the new components:
   />
 </InfoSection>
 ```
-<!-- prettier-ignore-end -->
 
 <InlineNotification>
 

--- a/src/pages/developing/react-tutorial/step-5.mdx
+++ b/src/pages/developing/react-tutorial/step-5.mdx
@@ -231,7 +231,7 @@ root: build
 
 After telling Cloud Foundry what to include, we can also specify what to ignore.
 Create a top-level `.cfignore` file. Cloud Foundry doesn't let you push
-read-only files (specifically, files with permissions <`400`), so to prevent
+read-only files (specifically, files with permissions < `400`), so to prevent
 issues with the deploy, add:
 
 ```bash path=.cfignore


### PR DESCRIPTION
Removed HTML comments form react tutorial step pages (This will help carbon index them while we refine our remote mdx loading logic)

#### Changelog

**Changed**

- converted some html code snippets into jsx for consistency

**Removed**

- HTML comments in step 1 - 5 of react tutorial
