### PR TITLE
fix: react url on data table code tab

### DIFF
--- a/src/pages/components/data-table/code.mdx
+++ b/src/pages/components/data-table/code.mdx
@@ -22,7 +22,7 @@ usage documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/components-datatable-basic--default-lg"
+    href="https://react.carbondesignsystem.com/?path=/story/components-datatable-basic--default"
     >
 
 <MdxIcon name="react" />


### PR DESCRIPTION
Related [#2232](https://github.com/carbon-design-system/carbon-website/issues/2232)
- Fixed a url for the React resource card on the Data table Code tab

