### PR TITLE
chore(tutorial): remove outdated info

### DIFF
--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -149,19 +149,6 @@ the following command to install `sass` as a dependency.
 yarn add sass@1.51.0
 ```
 
-To avoid having to add the `~` prefix when importing SCSS files from
-`node_modules`, create a `.env` file at the project root that contains:
-
-```bash path=.env
-SASS_PATH="node_modules"
-```
-
-For the Windows operating system, use:
-
-```bash path=.env
-SASS_PATH=./node_modules
-```
-
 Then, start the app again. If your app's currently running, you'll need to
 restart it for the new environment variable to be used.
 


### PR DESCRIPTION
After updating to `react-scripts: 5.0.1` we were getting warnings that were causing build errors. I was able to get rid of these errors by simply removing the `.env` file altogether, so I've removed this step from the tutorial. I wasn't able to test on Windows.

https://github.com/carbon-design-system/carbon-tutorial/pull/10215
https://github.com/carbon-design-system/carbon-tutorial/pull/10216
https://github.com/carbon-design-system/carbon-tutorial/pull/10217
https://github.com/carbon-design-system/carbon-tutorial/pull/10218
https://github.com/carbon-design-system/carbon-tutorial/pull/10219
