### PR TITLE
fix: remove imports for short-term indexing

### DIFF
--- a/src/pages/all-about-carbon/partners.mdx
+++ b/src/pages/all-about-carbon/partners.mdx
@@ -6,8 +6,6 @@ description:
   direction, governance, and support.
 ---
 
-import { dividedSection } from '../../styles/Layout.module.scss';
-
 <PageDescription>
 
 Carbon is not just one team. To sustain productive contribution and maintain a
@@ -23,7 +21,7 @@ Carbon and its design and development community, to improve the Carbon Design
 System for IBM and the world. It is made up of Carbon practitioners to ensure
 Carbon stays true to the community we’re serving.
 
-<Row className={dividedSection}>
+<Row>
 <Column colMd={2} colLg={4}>
 
 #### Drive impactful human and business outcomes
@@ -39,7 +37,7 @@ outcomes that people love.
 </Column>
 </Row>
 
-<Row className={dividedSection}>
+<Row>
 <Column colMd={2} colLg={4}>
 
 #### Scale design consistency and excellence
@@ -57,7 +55,7 @@ priorities.
 </Column>
 </Row>
 
-<Row className={dividedSection}>
+<Row>
 <Column colMd={2} colLg={4}>
 
 #### Grow and strengthen the community

--- a/src/pages/community/patterns/chatbot/overview.mdx
+++ b/src/pages/community/patterns/chatbot/overview.mdx
@@ -11,8 +11,6 @@ tabs: ['Overview', 'Usage', 'Flows', 'Content']
 
 [Sarah Liu](https://w3.ibm.com/bluepages/profile.html?uid=5G1630897)
 
-import { Tag, Link } from '@carbon/react';
-
 #### Maintainers:
 
 [Sarah Liu](https://w3.ibm.com/bluepages/profile.html?uid=5G1630897)

--- a/src/pages/community/patterns/chatbot/usage.mdx
+++ b/src/pages/community/patterns/chatbot/usage.mdx
@@ -7,16 +7,6 @@ description:
 tabs: ['Overview', 'Usage', 'Flows', 'Content']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListRow,
-  StructuredListCell,
-  StructuredListBody,
-  UnorderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
 
 <AnchorLink> Anatomy </AnchorLink>

--- a/src/pages/components/UI-shell-header/accessibility.mdx
+++ b/src/pages/components/UI-shell-header/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The UI shell React Carbon component has been tested against the latest

--- a/src/pages/components/button/code.mdx
+++ b/src/pages/components/button/code.mdx
@@ -60,8 +60,6 @@ documentation, see the Storybooks for each framework below.
 
 ## Live demo
 
-import { Add } from '@carbon/react/icons';
-
 <ComponentDemo
   scope={{ Add }}
   components={[

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -80,8 +80,6 @@ actions.
 
 ## Live demo
 
-import { Add } from '@carbon/react/icons';
-
 <ComponentDemo
   scope={{ Add }}
   components={[

--- a/src/pages/components/code-snippet/accessibility.mdx
+++ b/src/pages/components/code-snippet/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for code snippets, but keep these

--- a/src/pages/components/code-snippet/code.mdx
+++ b/src/pages/components/code-snippet/code.mdx
@@ -60,11 +60,6 @@ usage documentation, see the Storybooks for each framework below.
 
 ## Live demo
 
-import {
-  codeSnippet,
-  codeSnippetSingle,
-} from '../../../data/components/code-snippet.js';
-
 <ComponentDemo
   scope={{ codeSnippet, codeSnippetSingle }}
   components={[

--- a/src/pages/components/code-snippet/usage.mdx
+++ b/src/pages/components/code-snippet/usage.mdx
@@ -28,11 +28,6 @@ and inserted in a code file.
 
 </AnchorLinks>
 
-import {
-  codeSnippet,
-  codeSnippetSingle,
-} from '../../../data/components/code-snippet.js';
-
 ## Overview
 
 There are three different variants of code snippets to help cater to varied line

--- a/src/pages/components/content-switcher/accessibility.mdx
+++ b/src/pages/components/content-switcher/accessibility.mdx
@@ -7,17 +7,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The content switcher React Carbon component has been tested against the latest

--- a/src/pages/components/data-table/code.mdx
+++ b/src/pages/components/data-table/code.mdx
@@ -6,9 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import { rowData, headerData } from '../../../data/components/data-table.js';
-import { TrashCan, Save, Download } from '@carbon/icons-react';
-
 <PageDescription>
 
 Preview the data table component with the React live demo. For detailed code

--- a/src/pages/components/data-table/usage.mdx
+++ b/src/pages/components/data-table/usage.mdx
@@ -58,9 +58,6 @@ table display settings, and other utilities.
 
 ## Live demo
 
-import { rowData, headerData } from '../../../data/components/data-table.js';
-import { TrashCan, Save, Download } from '@carbon/icons-react';
-
 <ComponentDemo
   components={[
     {

--- a/src/pages/components/date-picker/accessibility.mdx
+++ b/src/pages/components/date-picker/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The date picker React Carbon component has been tested against the latest

--- a/src/pages/components/dropdown/accessibility.mdx
+++ b/src/pages/components/dropdown/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The dropdown React Carbon component has been tested against the latest

--- a/src/pages/components/dropdown/code.mdx
+++ b/src/pages/components/dropdown/code.mdx
@@ -6,8 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import items from '../../../data/components/dropdown.js';
-
 <PageDescription>
 
 Preview the dropdown component with the React live demo. For detailed code usage

--- a/src/pages/components/dropdown/usage.mdx
+++ b/src/pages/components/dropdown/usage.mdx
@@ -32,8 +32,6 @@ action to filter or sort existing content.
 
 </AnchorLinks>
 
-import items from '../../../data/components/dropdown.js';
-
 ## Overview
 
 There are three different variants of dropdowns that support various kinds of

--- a/src/pages/components/file-uploader/accessibility.mdx
+++ b/src/pages/components/file-uploader/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for file uploaders, but keep these

--- a/src/pages/components/form/accessibility.mdx
+++ b/src/pages/components/form/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 Design annotations are needed for specific instances shown below, but Carbon

--- a/src/pages/components/inline-loading/accessibility.mdx
+++ b/src/pages/components/inline-loading/accessibility.mdx
@@ -3,17 +3,6 @@ title: Inline loading
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for inline loading components, but keep

--- a/src/pages/components/link/accessibility.mdx
+++ b/src/pages/components/link/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 Design annotations are needed for specific instances shown below, but for the

--- a/src/pages/components/list/accessibility.mdx
+++ b/src/pages/components/list/accessibility.mdx
@@ -5,17 +5,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>What Carbon provides</AnchorLink>
   <AnchorLink>Developer considerations</AnchorLink>

--- a/src/pages/components/loading/accessibility.mdx
+++ b/src/pages/components/loading/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/modal/accessibility.mdx
+++ b/src/pages/components/modal/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/notification/accessibility.mdx
+++ b/src/pages/components/notification/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/number-input/accessibility.mdx
+++ b/src/pages/components/number-input/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 Design annotations are needed for specific instances shown below, but for the

--- a/src/pages/components/overflow-menu/accessibility.mdx
+++ b/src/pages/components/overflow-menu/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/pagination/accessibility.mdx
+++ b/src/pages/components/pagination/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The pagination React Carbon component has been tested against the latest

--- a/src/pages/components/popover/code.mdx
+++ b/src/pages/components/popover/code.mdx
@@ -5,8 +5,6 @@ description:
 tabs: ['Usage', 'Style', 'Code']
 ---
 
-import PopoverComponentDemo from './ComponentDemo';
-
 <PageDescription>
 
 Preview the popover component with the React live demo. For detailed code usage

--- a/src/pages/components/popover/usage.mdx
+++ b/src/pages/components/popover/usage.mdx
@@ -5,8 +5,6 @@ description:
 tabs: ['Usage', 'Style', 'Code']
 ---
 
-import PopoverComponentDemo from './ComponentDemo';
-
 <PageDescription>
 
 A popover is a layer that pops up over all other elements on a page.

--- a/src/pages/components/progress-bar/usage.mdx
+++ b/src/pages/components/progress-bar/usage.mdx
@@ -6,24 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import localVideo from './videos/progress-bar-usage-4.mp4';
-import localPoster from './images/progress-bar-usage-4.png';
-
-import localVideo1 from './videos/progress-bar-usage-5.mp4';
-import localPoster1 from './images/progress-bar-usage-5.png';
-
-import localVideo2 from './videos/progress-bar-usage-11.mp4';
-import localPoster2 from './images/progress-bar-usage-11.png';
-
-import localVideo3 from './videos/progress-bar-usage-17.mp4';
-import localPoster3 from './images/progress-bar-usage-17.png';
-
-import localVideo4 from './videos/progress-bar-usage-18.mp4';
-import localPoster4 from './images/progress-bar-usage-18.png';
-
-import localVideo5 from './videos/progress-bar-usage-21.mp4';
-import localPoster5 from './images/progress-bar-usage-21.png';
-
 <PageDescription>
 
 A progress bar provides feedback about the duration and progression of a

--- a/src/pages/components/progress-indicator/accessibility.mdx
+++ b/src/pages/components/progress-indicator/accessibility.mdx
@@ -7,17 +7,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The progress indicator React Carbon component has been tested against the latest

--- a/src/pages/components/radio-button/accessibility.mdx
+++ b/src/pages/components/radio-button/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for radio buttons, but keep these

--- a/src/pages/components/search/accessibility.mdx
+++ b/src/pages/components/search/accessibility.mdx
@@ -3,17 +3,6 @@ title: Search
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/select/accessibility.mdx
+++ b/src/pages/components/select/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/slider/accessibility.mdx
+++ b/src/pages/components/slider/accessibility.mdx
@@ -6,9 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import localVideo from './videos/slider.mp4';
-import localPoster from './images/slider-accessibility-3.png';
-
 <PageDescription>
 
 No accessibility annotations are needed for sliders, but keep these

--- a/src/pages/components/structured-list/accessibility.mdx
+++ b/src/pages/components/structured-list/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The structured list React Carbon component has been tested against the latest

--- a/src/pages/components/structured-list/code.mdx
+++ b/src/pages/components/structured-list/code.mdx
@@ -6,8 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import { CheckmarkFilled } from '@carbon/icons-react';
-
 <PageDescription>
 
 Preview the structured list component with the React live demo. For detailed

--- a/src/pages/components/structured-list/usage.mdx
+++ b/src/pages/components/structured-list/usage.mdx
@@ -55,8 +55,6 @@ which supports nesting items and presents a larger set of content.
 
 ## Live demo
 
-import { CheckmarkFilled } from '@carbon/icons-react';
-
 <ComponentDemo
   components={[
     {

--- a/src/pages/components/tabs/accessibility.mdx
+++ b/src/pages/components/tabs/accessibility.mdx
@@ -5,17 +5,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The tabs React Carbon component has been tested against the latest

--- a/src/pages/components/tabs/code.mdx
+++ b/src/pages/components/tabs/code.mdx
@@ -5,8 +5,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@carbon/react';
-
 <PageDescription>
 
 Preview the tabs component with the React live demo. For detailed code usage

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -6,8 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from '@carbon/react';
-
 <PageDescription>
 
 Tabs are used to organize related content. They allow the user to navigate

--- a/src/pages/components/tag/accessibility.mdx
+++ b/src/pages/components/tag/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <AnchorLinks>
   <AnchorLink>How it works</AnchorLink>
   <AnchorLink>Accessibility considerations</AnchorLink>

--- a/src/pages/components/text-input/accessibility.mdx
+++ b/src/pages/components/text-input/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for text inputs, but keep these

--- a/src/pages/components/tile/accessibility.mdx
+++ b/src/pages/components/tile/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The tile React Carbon component has been tested against the latest

--- a/src/pages/components/toggle/accessibility.mdx
+++ b/src/pages/components/toggle/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 No accessibility annotations are needed for toggles, but keep these

--- a/src/pages/components/toggletip/code.mdx
+++ b/src/pages/components/toggletip/code.mdx
@@ -31,8 +31,6 @@ usage documentation, see the Storybooks for each framework below.
 
 ## Live demo
 
-import { Information } from '@carbon/icons-react';
-
 <ComponentDemo
   components={[
     {

--- a/src/pages/components/toggletip/usage.mdx
+++ b/src/pages/components/toggletip/usage.mdx
@@ -7,8 +7,6 @@ description:
 tabs: ['Usage', 'Style', 'Code']
 ---
 
-import { Toggletip } from '@carbon/react';
-
 <PageDescription>
 
 Toggletips use the disclosure pattern to toggle the visibility of a popover.
@@ -98,8 +96,6 @@ complete a workflow. Use the [modal component](/components/modal/usage/)
 instead.
 
 ## Live demo
-
-import { Information } from '@carbon/icons-react';
 
 <ComponentDemo
   components={[

--- a/src/pages/components/tooltip/accessibility.mdx
+++ b/src/pages/components/tooltip/accessibility.mdx
@@ -6,17 +6,6 @@ description:
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 The tooltip React Carbon component has been tested against the latest

--- a/src/pages/components/tooltip/code.mdx
+++ b/src/pages/components/tooltip/code.mdx
@@ -60,8 +60,6 @@ documentation, see the Storybooks for each framework below.
 
 ## Live demo
 
-import { Information } from '@carbon/react/icons';
-
 <ComponentDemo
   components={[
     {

--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -153,8 +153,6 @@ interact with.
 
 ## Live demo
 
-import { Information } from '@carbon/react/icons';
-
 <ComponentDemo
   components={[
     {

--- a/src/pages/contributing/add-ons.mdx
+++ b/src/pages/contributing/add-ons.mdx
@@ -5,8 +5,6 @@ description:
   a specific product or experience.
 ---
 
-import { CheckmarkFilled } from '@carbon/icons-react';
-
 <AnchorLinks>
 
 <AnchorLink>Carbon add-ons</AnchorLink>

--- a/src/pages/data-visualization/chart-types/index.mdx
+++ b/src/pages/data-visualization/chart-types/index.mdx
@@ -3,8 +3,6 @@ title: Chart types
 description: Overview of all chart types available.
 ---
 
-import OverviewCard from 'components/OverviewCard';
-
 <PageDescription>
 
 Start by identifying the purpose of the visualization and then choose the

--- a/src/pages/data-visualization/complex-charts/index.mdx
+++ b/src/pages/data-visualization/complex-charts/index.mdx
@@ -3,14 +3,6 @@ title: Complex charts
 description: Complex charts are a powerful way to display complex data sets.
 ---
 
-import {
-  complexChartDemoGroups,
-  getDemoGroupByTitle,
-} from '../../../data/data-visualization';
-
-import { AnchorLinks, AnchorLink } from 'gatsby-theme-carbon';
-import ChartDemoGroup from '../../../components/data-visualization/ChartDemoGroup.js';
-
 <PageDescription>
 
 Complex charts are a powerful way to display complex data sets. While less

--- a/src/pages/data-visualization/simple-charts/index.mdx
+++ b/src/pages/data-visualization/simple-charts/index.mdx
@@ -13,11 +13,6 @@ on the page where it is found.
 
 </PageDescription>
 
-import { simpleChartDemoGroups } from '../../../data/data-visualization';
-
-import { AnchorLinks, AnchorLink } from 'gatsby-theme-carbon';
-import ChartDemoGroup from '../../../components/data-visualization/ChartDemoGroup.js';
-
 <AnchorLinks>
   {simpleChartDemoGroups.map((storybookDemoGroup) => (
     <AnchorLink>{storybookDemoGroup.title}</AnchorLink>

--- a/src/pages/designing/tutorials.mdx
+++ b/src/pages/designing/tutorials.mdx
@@ -5,9 +5,6 @@ description:
   and teach you about some of the foundational pieces of the design system.
 ---
 
-import { Button } from '@carbon/react';
-import { ArrowRight } from '@carbon/icons-react';
-
 <PageDescription>
 
 The Carbon design tutorials will get you set up to start designing with Carbon

--- a/src/pages/developing/angular-tutorial/overview.mdx
+++ b/src/pages/developing/angular-tutorial/overview.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Welcome to Carbon! This tutorial will guide you in creating an Angular app with

--- a/src/pages/developing/angular-tutorial/step-1.mdx
+++ b/src/pages/developing/angular-tutorial/step-1.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Starting with the Carbon Angular, there are two ways to begin working with

--- a/src/pages/developing/angular-tutorial/step-2.mdx
+++ b/src/pages/developing/angular-tutorial/step-2.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Now that we have a base Angular app, it's time to build a few static pages. In

--- a/src/pages/developing/angular-tutorial/step-3.mdx
+++ b/src/pages/developing/angular-tutorial/step-3.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 This step takes our static components and populates them with data from the

--- a/src/pages/developing/angular-tutorial/step-4.mdx
+++ b/src/pages/developing/angular-tutorial/step-4.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 With two pages comprised entirely of Carbon components, let's revisit the

--- a/src/pages/developing/angular-tutorial/step-5.mdx
+++ b/src/pages/developing/angular-tutorial/step-5.mdx
@@ -4,8 +4,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 This step takes what we've built so far and optimizes the app for a production

--- a/src/pages/developing/vue-tutorial/overview.mdx
+++ b/src/pages/developing/vue-tutorial/overview.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Welcome to Carbon! This tutorial will guide you in creating a Vue app with the

--- a/src/pages/developing/vue-tutorial/step-1.mdx
+++ b/src/pages/developing/vue-tutorial/step-1.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Starting with our Vue CLI generated app, let's install Carbon and begin using

--- a/src/pages/developing/vue-tutorial/step-2.mdx
+++ b/src/pages/developing/vue-tutorial/step-2.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 Now that we have a Vue app using the UI Shell, it's time to build a few static

--- a/src/pages/developing/vue-tutorial/step-3.mdx
+++ b/src/pages/developing/vue-tutorial/step-3.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 This step takes our static components and populates them with data from the

--- a/src/pages/developing/vue-tutorial/step-4.mdx
+++ b/src/pages/developing/vue-tutorial/step-4.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 With two pages comprised entirely of Carbon components, let's revisit the

--- a/src/pages/developing/vue-tutorial/step-5.mdx
+++ b/src/pages/developing/vue-tutorial/step-5.mdx
@@ -8,8 +8,6 @@ tabs:
   ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up']
 ---
 
-import Preview from 'components/Preview';
-
 <PageDescription>
 
 This step takes what we've built so far and optimizes the app for a production

--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -6,9 +6,6 @@ description:
 tabs: ['Overview', 'Usage', 'Code', 'Implementation']
 ---
 
-import ColorBlock from 'components/ColorBlock';
-import ColorGrid from 'components/ColorGrid';
-
 <PageDescription>
 
 Maintaining consistent and engaging digital interfaces throughout IBM, whether

--- a/src/pages/guidelines/content/action-labels.mdx
+++ b/src/pages/guidelines/content/action-labels.mdx
@@ -10,8 +10,6 @@ description:
 tabs: ['Overview', 'Writing style', 'Action labels']
 ---
 
-import GlossaryComponent from 'components/GlossaryComponent';
-
 <PageDescription>
 
 Users rely on consistent labels for common actions to predict how to interact

--- a/src/pages/guidelines/pictograms/usage.mdx
+++ b/src/pages/guidelines/pictograms/usage.mdx
@@ -6,8 +6,6 @@ description:
 tabs: ['Library', 'Usage', 'Code', 'Contribute']
 ---
 
-import { Bee } from '@carbon/icons-react';
-
 <PageDescription>
 
 Use pictograms to communicate in a glance, offer interactivity, or simplify

--- a/src/pages/migrating/guide/design.mdx
+++ b/src/pages/migrating/guide/design.mdx
@@ -7,8 +7,6 @@ description:
 tabs: ['Overview', 'Design', 'Develop']
 ---
 
-import { Tag } from '@carbon/react';
-
 <PageDescription>
 
 The transition from v10 to v11 includes significant updates and additions to

--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -6,8 +6,6 @@ description:
 tabs: ['Overview', 'Design', 'Develop']
 ---
 
-import { Tag } from '@carbon/react';
-
 <PageDescription>
 
 Step-by-step guide to updating your code from Carbon v10 to v11.

--- a/src/pages/patterns/empty-states-pattern/index.mdx
+++ b/src/pages/patterns/empty-states-pattern/index.mdx
@@ -5,17 +5,6 @@ description:
   user.
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  UnorderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 Empty states are moments in an app where there is no data to display to the

--- a/src/pages/patterns/search-pattern/index.mdx
+++ b/src/pages/patterns/search-pattern/index.mdx
@@ -5,18 +5,6 @@ description:
   pieces of content.
 ---
 
-import {
-  StructuredListWrapper,
-  StructuredListHead,
-  StructuredListBody,
-  StructuredListRow,
-  StructuredListInput,
-  StructuredListCell,
-  OrderedList,
-  UnorderedList,
-  ListItem,
-} from '@carbon/react';
-
 <PageDescription>
 
 Search is an essential pattern for navigation or discovery. We live in the age

--- a/src/pages/patterns/status-indicator-pattern/index.mdx
+++ b/src/pages/patterns/status-indicator-pattern/index.mdx
@@ -6,8 +6,6 @@ description:
   assess and identify status and respond accordingly.
 ---
 
-import StatusIndicatorTable from 'components/StatusIndicatorTable';
-
 <PageDescription>
 
 Status indicators are an important method of communicating severity level

--- a/src/pages/whats-happening/meetups/index.mdx
+++ b/src/pages/whats-happening/meetups/index.mdx
@@ -6,9 +6,6 @@ description:
   leveling up your skills.
 ---
 
-import { Button } from '@carbon/react';
-import { ArrowRight } from '@carbon/icons-react';
-
 <PageDescription>
 
 The Carbon team is committed to helping members of the IBM community be


### PR DESCRIPTION
The `carbon-platform` branch is a temporary branched used to clean up any MDX file that the `carbon-platform` indexes and renders.

The platform will show a page-wide error if any remote MDX file includes an import statement. This PR removes all import statements for any MDX file that could get indexed by the platform.

This will likely cause errors when MDX components aren't available in the platform, or when MDX component props are undefined.

That's okay, because the platform should handle those with inline errors, so the rest of the page content can render.

We'll make a pass in a future PR to ensure that content from main branch has made its way to this short-lived `carbon-platform` branch.

Eventually, when platform is on Carbon's top-level domain, the MDX from this repo will either get migrated to the `carbon-platform` repo or a different repo, so this repo can get archived.

#### Changelog

**New**

- NA

**Changed**

- NA

**Removed**

- Removed import statements
