### PR TITLE
docs: remove invalid MDX

### DIFF
--- a/src/pages/developing/angular-tutorial/step-5.mdx
+++ b/src/pages/developing/angular-tutorial/step-5.mdx
@@ -215,7 +215,7 @@ root: dist
 
 After telling Cloud Foundry what to include, we can also specify what to ignore.
 Create a top-level `.cfignore` file. Cloud Foundry doesn't let you push
-read-only files (specifically, files with permissions <`400`), so to prevent
+read-only files (specifically, files with permissions < `400`), so to prevent
 issues with the deploy, add:
 
 ```bash path=.cfignore

--- a/src/pages/developing/vue-tutorial/step-5.mdx
+++ b/src/pages/developing/vue-tutorial/step-5.mdx
@@ -219,7 +219,7 @@ root: dist
 
 After telling Cloud Foundry what to include, we can also specify what to ignore.
 Create a top-level `.cfignore` file. Cloud Foundry doesn't let you push
-read-only files (specifically, files with permissions <`400`), so to prevent
+read-only files (specifically, files with permissions < `400`), so to prevent
 issues with the deploy, add:
 
 ```bash path=.cfignore


### PR DESCRIPTION
Per https://github.com/carbon-design-system/carbon-platform/issues/1182#issuecomment-1228943119, this PR removes invalid MDX by adding a space between two instances of `<` followed by `.

Because this is a PR into the `carbon-platform` branch, this change is just so we can render these pages in the platform right now. When we're closer to a platform release that replaces this repo, we'll do proper content migration so there's no need for this special branch.