### PR TITLE
Change tab text of typography from "Styling strategies" to "Style strategies"

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -66,9 +66,9 @@ exports.createPages = ({ actions }) => {
     toPath: '/developing/vue-tutorial/overview',
     isPermanent: true,
   });
-    createRedirect({ 
-     fromPath: '/guidelines/typography/styling-strategies', 
-     toPath: '/guidelines/typography/style-strategies', 
-     isPermanent: true, 
-   });
+  createRedirect({
+    fromPath: '/guidelines/typography/styling-strategies',
+    toPath: '/guidelines/typography/style-strategies', 
+    isPermanent: true,
+  });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -66,4 +66,9 @@ exports.createPages = ({ actions }) => {
     toPath: '/developing/vue-tutorial/overview',
     isPermanent: true,
   });
+    createRedirect({ 
+     fromPath: '/guidelines/typography/styling-strategies', 
+     toPath: '/guidelines/typography/style-strategies', 
+     isPermanent: true, 
+   });
 };

--- a/src/pages/guidelines/typography/code.mdx
+++ b/src/pages/guidelines/typography/code.mdx
@@ -7,7 +7,7 @@ title: Typography
 description:
   Typography can help create clear hierarchies, organize information, and guide
   users through a product or experience.
-tabs: ['Overview', 'Styling strategies', 'Type sets', 'Code']
+tabs: ['Overview', 'Style strategies', 'Type sets', 'Code']
 ---
 
 <PageDescription>

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -63,7 +63,7 @@ headings are responsive and the type styles change size at different
 breakpoints.
 
 For more detail, see
-[Style strategies](/guidelines/typography/styling-strategies/) and
+[Style strategies](/guidelines/typography/style-strategies/) and
 [Type sets](/guidelines/typography/type-sets/).
 
 ## Typeface: IBM Plex

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -51,7 +51,7 @@ The productive styles work together to support the hierarchy of information and
 set user expectations. On the other hand, the larger expressive type styles
 allow for a more dramatic, graphic use of type in editorial and marketing
 design. These type styles are excellent for long form reading and scanning, but
-would be distracting for use in product.
+would be distracting if used in product.
 
 Within **Body styles** and **Utility styles**, the same set of styles are
 offered. Productive styles are named with a suffix of `-01` and expressive style
@@ -63,7 +63,7 @@ headings are responsive and the type styles change size at different
 breakpoints.
 
 For more detail, see
-[Style strategies](/guidelines/typography/style-strategies/) and
+[Style strategies](/guidelines/typography/styling-strategies/) and
 [Type sets](/guidelines/typography/type-sets/).
 
 ## Typeface: IBM Plex
@@ -134,7 +134,7 @@ long text.
 ### Italic
 
 Each weight has an italic style, which should only be used when you need to
-emphasize certain words in a sentence (titles of works, technical terms, names
+emphasize certain words in a sentence (i.e., titles of works, technical terms, names
 of devices, and captions).
 
 <TypeWeight type="italic" />

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -8,7 +8,7 @@ title: Typography
 description:
   Typography can help create clear hierarchies, organize information, and guide
   users through a product or experience.
-tabs: ['Overview', 'Styling strategies', 'Type sets', 'Code']
+tabs: ['Overview', 'Style strategies', 'Type sets', 'Code']
 ---
 
 import TypeScaleTable from '../../../../src/components/TypeScaleTable';

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -63,7 +63,7 @@ headings are responsive and the type styles change size at different
 breakpoints.
 
 For more detail, see
-[Styling strategies](/guidelines/typography/styling-strategies/) and
+[Style strategies](/guidelines/typography/style-strategies/) and
 [Type sets](/guidelines/typography/type-sets/).
 
 ## Typeface: IBM Plex

--- a/src/pages/guidelines/typography/style-strategies.mdx
+++ b/src/pages/guidelines/typography/style-strategies.mdx
@@ -129,7 +129,7 @@ facilitate focus.
 
 ### Using productive moments within IBM.com pages
 
-Here are some of the places the Dotcom team use productive moments:
+Here are some of the places the Dotcom team uses productive moments:
 
 - The global masthead mega menu
 - IBM.com search

--- a/src/pages/guidelines/typography/styling-strategies.mdx
+++ b/src/pages/guidelines/typography/styling-strategies.mdx
@@ -6,7 +6,7 @@ title: Typography
 description:
   Carbon provides designers with two type sets that support productive and
   expressive experiences.
-tabs: ['Overview', 'Styling strategies', 'Type sets', 'Code']
+tabs: ['Overview', 'Style strategies', 'Type sets', 'Code']
 ---
 
 <PageDescription>

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -50,7 +50,7 @@ Carbon uses type tokens to manage typography, and these tokens sit within two
 type sets. The productive and expressive type sets support designers creating
 for a full range of user needs and activities across product and web pages. To
 understand when to use styles from each set, see
-[Style strategies](/guidelines/typography/style-strategies).
+[Style strategies](/guidelines/typography/styling-strategies).
 
 #### Base type sizes
 
@@ -74,7 +74,7 @@ nature of the pages.
   density of information housed inside containers for space efficiency, and in
   these situations fixed type styles are a must.
 
-- The expressive type set has two fixed headings, for use where smaller headings
+- The expressive type set has two fixed headings that are to be used where smaller headings
   are needed. The remaining headings are _fluid_. Web pages need to be able to
   flex and work at different breakpoints, and the fluid heading styles change
   size at different breakpoints, and can extrapolate/stretch in between sizes
@@ -82,7 +82,7 @@ nature of the pages.
 
 ## Utility styles
 
-The utility styles are for use with productive and expressive moments and
+The utility styles are used with productive and expressive moments and
 include styles for code snippets, labels for captions and helper text, as well
 as legal copy. Productive styles have a suffix of `-01` and expressive styles
 have a suffix of `-02`.
@@ -116,7 +116,7 @@ styles change size at different breakpoints.
 Do not use these styles inside a container. They may be used in product pages
 where text sits outside of a container, and a blend of expressive and productive
 type styles is desired for hierarchy and distinction. For more information, see
-[Style strategies](/guidelines/typography/style-strategies).
+[Style strategies](/guidelines/typography/styling-strategies).
 
 <TypesetStyle typesets="fluidHeadings" breakpointControls={true} />
 
@@ -125,7 +125,7 @@ type styles is desired for hierarchy and distinction. For more information, see
 The callout and display styles are part of the expressive set and being fluid,
 they will adjust at different breakpoints. Do not use these styles inside a
 container. For guidance about using display styles, see
-[Style strategies](/guidelines/typography/style-strategies#expressive-use-cases).
+[Style strategies](/guidelines/typography/styling-strategies#expressive-use-cases).
 
 <TypesetStyle typesets="fluidCallouts,fluidDisplay" breakpointControls={true} />
 

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -8,7 +8,7 @@ title: Typography
 description:
   The productive and expressive type sets support designers creating for a full
   range of user needs and activities across product and web pages.
-tabs: ['Overview', 'Styling strategies', 'Type sets', 'Code']
+tabs: ['Overview', 'Style strategies', 'Type sets', 'Code']
 ---
 
 import TypesetStyle from 'components/TypesetStyle';

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -50,7 +50,7 @@ Carbon uses type tokens to manage typography, and these tokens sit within two
 type sets. The productive and expressive type sets support designers creating
 for a full range of user needs and activities across product and web pages. To
 understand when to use styles from each set, see
-[Style strategies](/guidelines/typography/styling-strategies).
+[Style strategies](/guidelines/typography/style-strategies).
 
 #### Base type sizes
 
@@ -116,7 +116,7 @@ styles change size at different breakpoints.
 Do not use these styles inside a container. They may be used in product pages
 where text sits outside of a container, and a blend of expressive and productive
 type styles is desired for hierarchy and distinction. For more information, see
-[Style strategies](/guidelines/typography/styling-strategies).
+[Style strategies](/guidelines/typography/style-strategies).
 
 <TypesetStyle typesets="fluidHeadings" breakpointControls={true} />
 
@@ -125,7 +125,7 @@ type styles is desired for hierarchy and distinction. For more information, see
 The callout and display styles are part of the expressive set and being fluid,
 they will adjust at different breakpoints. Do not use these styles inside a
 container. For guidance about using display styles, see
-[Style strategies](/guidelines/typography/styling-strategies#expressive-use-cases).
+[Style strategies](/guidelines/typography/style-strategies#expressive-use-cases).
 
 <TypesetStyle typesets="fluidCallouts,fluidDisplay" breakpointControls={true} />
 

--- a/src/pages/guidelines/typography/type-sets.mdx
+++ b/src/pages/guidelines/typography/type-sets.mdx
@@ -50,7 +50,7 @@ Carbon uses type tokens to manage typography, and these tokens sit within two
 type sets. The productive and expressive type sets support designers creating
 for a full range of user needs and activities across product and web pages. To
 understand when to use styles from each set, see
-[Styling strategies](/guidelines/typography/styling-strategies).
+[Style strategies](/guidelines/typography/style-strategies).
 
 #### Base type sizes
 
@@ -116,7 +116,7 @@ styles change size at different breakpoints.
 Do not use these styles inside a container. They may be used in product pages
 where text sits outside of a container, and a blend of expressive and productive
 type styles is desired for hierarchy and distinction. For more information, see
-[Styling strategies](/guidelines/typography/styling-strategies).
+[Style strategies](/guidelines/typography/style-strategies).
 
 <TypesetStyle typesets="fluidHeadings" breakpointControls={true} />
 
@@ -125,7 +125,7 @@ type styles is desired for hierarchy and distinction. For more information, see
 The callout and display styles are part of the expressive set and being fluid,
 they will adjust at different breakpoints. Do not use these styles inside a
 container. For guidance about using display styles, see
-[Styling strategies](/guidelines/typography/styling-strategies#expressive-use-cases).
+[Style strategies](/guidelines/typography/style-strategies#expressive-use-cases).
 
 <TypesetStyle typesets="fluidCallouts,fluidDisplay" breakpointControls={true} />
 


### PR DESCRIPTION
Closes #3148 

**Change log**

- Changed tab text of typography section by replacing "Styling strategies" with "Style strategies"

- Updated corresponding links to "Style strategies" in the pages

- Improved minor verbiage