### PR TITLE
fix(switcher): fix app switcher bugs

### DIFF
--- a/src/components/Banner/Banner.module.scss
+++ b/src/components/Banner/Banner.module.scss
@@ -5,6 +5,11 @@
   top: rem(48px);
 }
 
+// adjust nav container to account for banner
+.banner + header + nav[class*='Switcher-module--nav'] {
+  top: 6rem;
+}
+
 // banner styles
 .banner {
   position: fixed;

--- a/src/styles/Layout.module.scss
+++ b/src/styles/Layout.module.scss
@@ -9,6 +9,7 @@
   }
   [class*='Switcher-module--nav'] {
     top: 3rem;
+    overflow-y: auto;
   }
   [class*='PageTabs-module--tabs-container'] {
     top: 3rem;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-website/issues/3204

Allows the app switcher to be closed now. Also allows scrolling when the screen size is reduced.

#### Changelog

**Changed**

- Adjusted the `top` placement when the banner is present
- Added `overflow-y` on the app switcher to allow scrolling

