### PR TITLE
fix: broken link ui shell right panel

### DIFF
--- a/src/pages/components/UI-shell-right-panel/code.mdx
+++ b/src/pages/components/UI-shell-right-panel/code.mdx
@@ -19,7 +19,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="React"
-    href="https://react.carbondesignsystem.com/?path=/story/ui-shell--header-base-w-actions-and-right-panel"
+    href="https://react.carbondesignsystem.com/?path=/story/components-ui-shell--header-base-w-actions-and-right-panel"
     >
 
 <MdxIcon name="react" />


### PR DESCRIPTION
Closes #3214 

- Fixes the React resource card on the `UI shell right panel > Code tab` to point to the correct URL.

