### PR TITLE
fix: broken link on tag style tab

### DIFF
--- a/src/pages/components/tag/style.mdx
+++ b/src/pages/components/tag/style.mdx
@@ -13,7 +13,7 @@ Tag uses component level tokens and values from the IBM Design Language
 light themes tags use color step 20 for the background and step 70 for the text.
 In the dark themes, tags use color step 70 for the background and step 20 for
 the text. For the list of token values, see
-[Carbon repo](https://github.com/carbon-design-system/carbon/blob/next/packages/components/src/components/tag/_tokens.scss).
+[Carbon repo](https://github.com/carbon-design-system/carbon/blob/b43f63e3bbf1e13589e613528fe06a401b08eacb/packages/themes/src/component-tokens/tag/tokens.js).
 
 | Tag color     | Color token                 |
 | ------------- | --------------------------- |

--- a/src/pages/components/tag/style.mdx
+++ b/src/pages/components/tag/style.mdx
@@ -13,7 +13,7 @@ Tag uses component level tokens and values from the IBM Design Language
 light themes tags use color step 20 for the background and step 70 for the text.
 In the dark themes, tags use color step 70 for the background and step 20 for
 the text. For the list of token values, see
-[Carbon repo](https://github.com/carbon-design-system/carbon/blob/b43f63e3bbf1e13589e613528fe06a401b08eacb/packages/themes/src/component-tokens/tag/tokens.js).
+[Carbon repo](https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/component-tokens/tag/tokens.js).
 
 | Tag color     | Color token                 |
 | ------------- | --------------------------- |


### PR DESCRIPTION
Closes #3213 

- Fixes the code link under the Color section on the `Tag > Style tab` page to point to the correct URL.