### PR TITLE
[docs]: v10 type token updates

### DIFF
--- a/src/components/TypesetStyle/TypesetStyle.js
+++ b/src/components/TypesetStyle/TypesetStyle.js
@@ -181,7 +181,7 @@ const typeScale = {
     sm: {
       step: 8,
       font: 'IBM Plex Sans',
-      'font-weight': '300',
+      'font-weight': '400',
       'font-size': 2,
       'line-height': 2.5,
       'letter-spacing': '0',
@@ -273,7 +273,7 @@ const typeScale = {
     xlg: {
       step: 8,
       font: 'IBM Plex Sans',
-      'font-weight': '300',
+      'font-weight': '400',
       'font-size': 2,
       'line-height': 2.5,
       'letter-spacing': '0',
@@ -281,7 +281,7 @@ const typeScale = {
     max: {
       step: 8,
       font: 'IBM Plex Sans',
-      'font-weight': '300',
+      'font-weight': '400',
       'font-size': 2,
       'line-height': 2.5,
       'letter-spacing': '0',
@@ -291,7 +291,7 @@ const typeScale = {
     sm: {
       step: 8,
       font: 'IBM Plex Sans',
-      'font-weight': '300',
+      'font-weight': '400',
       'font-size': 2,
       'line-height': 2.5,
       'letter-spacing': '0',


### PR DESCRIPTION
Closes: https://github.com/carbon-design-system/carbon-website/issues/3191
Spec issue: https://github.com/carbon-design-system/carbon/issues/12174

Reverting some of the previously changed font weights.

Changes
- `$expressive-heading-05`: SM Weight: 400, regular
- `$productive-heading-05`:  Weight: 400 / Regular
- `$expressive-heading-04`: XLG and MAX Weight: 400, Regular
