### PR TITLE
fix(analytics): set SPA to false

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -11,7 +11,7 @@ export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
       },
       pageInfo: {
         ibm: {
-          siteID: 'CARBON_DESIGN_SYSTEM',
+          siteID: 'CARBON_DESIGN_SYSTEM_WWW',
           country: 'US',
           industry: 'Design',
           owner: 'carbon@us.ibm.com',

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -3,7 +3,7 @@ import React from 'react';
 export const onRenderBody = ({ setHeadComponents, setPostBodyComponents }) => {
   const script = `
   if(!window) window = {};
-  window.idaPageIsSPA = true;
+  window.idaPageIsSPA = false;
   window.digitalData = {
     page: {
       category: {


### PR DESCRIPTION
Trying to get the commonjs script working. Data isn't flowing into GA, the cookie banner isn't popping either.

#### Changelog

**Changed**

- Sets the SPA value to false since website isn't a SPA and we're not calling `pageView()`
- Update site ID so it's unique and doesn't use the same one as platform
