### PR TITLE
fixing a typo on the Spacing page

### DIFF
--- a/src/pages/guidelines/spacing/overview.mdx
+++ b/src/pages/guidelines/spacing/overview.mdx
@@ -37,12 +37,12 @@ easier and more consistent.
 
 ## Spacing
 
-The Carbon spacing scale complements the 2x Grid and typography scale by 
-using multiples of two, four, and eight. It includes both small increments
-needed to create appropriate spatial relationships for detail-level designs as
-well as larger increments used to control the density of a design. Each level of
-the spacing scale has its own token. Spacing tokens can be used inside of
-components for building and between components for layout spacing.
+The Carbon spacing scale complements the 2x Grid and typography scale by using
+multiples of two, four, and eight. It includes both small increments needed to
+create appropriate spatial relationships for detail-level designs as well as
+larger increments used to control the density of a design. Each level of the
+spacing scale has its own token. Spacing tokens can be used inside of components
+for building and between components for layout spacing.
 
 ### Spacing scale
 

--- a/src/pages/guidelines/spacing/overview.mdx
+++ b/src/pages/guidelines/spacing/overview.mdx
@@ -37,7 +37,7 @@ easier and more consistent.
 
 ## Spacing
 
-The Carbon spacing scale complements the 2x Grid and typography scale by using
+The Carbon spacing scale complements the 2x Grid and typography scale by 
 using multiples of two, four, and eight. It includes both small increments
 needed to create appropriate spatial relationships for detail-level designs as
 well as larger increments used to control the density of a design. Each level of


### PR DESCRIPTION
The keyword 'using' is mentioned twice in the first sentence of the first paragraph under the heading "Spacing".



#### Changelog


**Changed**

- {{updated the first sentence of the first paragraph under the heading "Spacing'}}

