### PR TITLE
refactor: add 'do' type to DoDont uses that don't specify it

### DIFF
--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -146,7 +146,7 @@ any set of icons for their UI. Icons should always be aligned to the right of
 the header with no gaps between icons.
 
 <DoDontRow>
-  <DoDont caption="Header utilities are right aligned with no gaps">
+  <DoDont type="do" caption="Header utilities are right aligned with no gaps">
 
 ![Example of header icons right aligned with no gaps.](images/utility_placement_do.png)
 

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -38,8 +38,7 @@ guidance, go to
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="UI Shell template"
-      href="https://sketch.cloud/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0"
-    >
+      href="https://sketch.cloud/s/6a8e1d7b-f00a-4d8d-9d83-79ecf4dc12a0">
       <MdxIcon name="sketch" />
     </ResourceCard>
   </Column>
@@ -104,7 +103,7 @@ The far right header icon is reserved for the switcher icon. The switcher icon
 and the switcher panel should only be used together.
 
 <DoDontRow>
-  <DoDont colLg={6} caption="Positioned the switcher to the far right.">
+  <DoDont type="do" colLg={6} caption="Positioned the switcher to the far right.">
 
 ![Example of the switcher icon being used correctly.](images/right-panel-usage-2.png)
 

--- a/src/pages/components/button/usage.mdx
+++ b/src/pages/components/button/usage.mdx
@@ -97,8 +97,7 @@ import { Add } from '@carbon/react/icons';
       id: 'icon-only',
       label: 'Icon only',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="button"
     knobs={{
@@ -112,8 +111,7 @@ import { Add } from '@carbon/react/icons';
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvbutton--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
-    }}
-  >{`
+    }}>{`
       <Button>Button</Button>
     `}</ComponentVariant>
   <ComponentVariant
@@ -129,8 +127,7 @@ import { Add } from '@carbon/react/icons';
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvbutton--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--default',
-    }}
-  >{`
+    }}>{`
       <Button renderIcon={Add}>Button</Button>
     `}</ComponentVariant>
   <ComponentVariant
@@ -144,8 +141,7 @@ import { Add } from '@carbon/react/icons';
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvbutton--icon-only',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-button--icon',
-    }}
-  >{`
+    }}>{`
      <IconButton align='top' label='Icon button' className='cds--btn--icon-only'>
        <Add size={16}/>
      </IconButton>
@@ -198,7 +194,7 @@ B. Container (optional) <br /> C. Icon
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do left-align text in a button, even if the button is wide.">
+  <DoDont type="do" caption="Do left-align text in a button, even if the button is wide.">
 
 ![Do left-align text in a button, even if the button is wide.](images/button_usage_5.png)
 
@@ -267,7 +263,7 @@ and dashboards—low emphasis buttons (tertiary or ghost) may be a better choice
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do use high-emphasis and medium-emphasis buttons in a button group.">
+  <DoDont type="do" caption="Do use high-emphasis and medium-emphasis buttons in a button group.">
 
 ![Do use high-emphasis and medium-emphasis buttons in a button group.](images/button_usage_8_test.png)
 
@@ -348,7 +344,7 @@ Other fluid components include tiles and most recently,
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do bleed ghost button hovers when they are paired with other fluid buttons.">
+  <DoDont type="do" caption="Do bleed ghost button hovers when they are paired with other fluid buttons.">
 
 ![Do bleed ghost button hovers when they are paired with other fluid buttons.](images/button_usage_12.png)
 
@@ -423,7 +419,7 @@ or ghost buttons in layouts with more than three calls to action.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do use a primary and two of the same lower emphasis buttons in a button group.">
+  <DoDont type="do" caption="Do use a primary and two of the same lower emphasis buttons in a button group.">
 
 ![Do use a primary and two of the same lower emphasis buttons in a button group.](images/button_usage_17.png)
 
@@ -475,7 +471,7 @@ container with a programmatic 16px gutter between them.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do apply the same width to all buttons in a group, even if they don’t bleed.">
+  <DoDont type="do" caption="Do apply the same width to all buttons in a group, even if they don’t bleed.">
 
 ![Do apply the same width to all buttons in a group](images/button_usage_21.png)
 
@@ -567,7 +563,7 @@ For consistency, see Carbon’s
 recommended action labels.
 
 <DoDontRow>
-  <DoDont caption="Do use the {verb} + {noun} content formula in buttons whenever possible.">
+  <DoDont type="do" caption="Do use the {verb} + {noun} content formula in buttons whenever possible.">
 
 ![Do use the verb + noun content formula in buttons whenever possible](images/button_usage_26.png)
 
@@ -617,7 +613,7 @@ a text label, but use icon buttons cautiously.
 - Glyphs must be the same color value as the text within a button
 
 <DoDontRow>
-  <DoDont caption="Do place the icon on the right side of the button after the text.">
+  <DoDont type="do" caption="Do place the icon on the right side of the button after the text.">
 
 ![Do place the icon on the right side of the button after the text](images/button_usage_28.png)
 

--- a/src/pages/components/checkbox/usage.mdx
+++ b/src/pages/components/checkbox/usage.mdx
@@ -75,7 +75,7 @@ instead of checkboxes. Checkboxes allow the user to select multiple items in a
 set whereas radio buttons allow the user to select only one option.
 
 <DoDontRow>
-  <DoDont caption="Do use radio buttons when only one item can be selected.">
+  <DoDont type="do" caption="Do use radio buttons when only one item can be selected.">
 
 ![Do use radio buttons when only one item can be selected.](images/checkbox-usage-2-do.png)
 
@@ -95,8 +95,7 @@ set whereas radio buttons allow the user to select only one option.
       id: 'checkbox',
       label: 'Checkbox',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="checkbox"
     knobs={{ Checkbox: ['checked', 'indeterminate', 'disabled', 'hideLabel'] }}
@@ -108,8 +107,7 @@ set whereas radio buttons allow the user to select only one option.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcheckbox--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-checkbox--default',
-    }}
-  >{`
+    }}>{`
 <fieldset className="cds--fieldset">
   <legend className="cds--label">Checkbox heading</legend>
   <Checkbox labelText="Checkbox label" id="checked" />
@@ -231,7 +229,7 @@ For more information about spacing for the checkbox component itself, see the
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do let text wrap beneath the checkbox so the control and label are top aligned.">
+  <DoDont type="do" caption="Do let text wrap beneath the checkbox so the control and label are top aligned.">
 
 ![Do let text wrap beneath the checkbox so the control and label are top aligned.](images/checkbox-usage-11-do.png)
 

--- a/src/pages/components/code-snippet/usage.mdx
+++ b/src/pages/components/code-snippet/usage.mdx
@@ -75,8 +75,7 @@ length use cases—inline, single line, and multi-line.
       id: 'code-snippet-inline',
       label: 'Inline',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="code-snippet-single"
     knobs={{ CodeSnippet: ['light'] }}
@@ -88,8 +87,7 @@ length use cases—inline, single line, and multi-line.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcodesnippet--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--single-line',
-    }}
-  >{`
+    }}>{`
     <CodeSnippet type="single">${codeSnippetSingle}</CodeSnippet>
 `}</ComponentVariant>
   <ComponentVariant
@@ -103,8 +101,7 @@ length use cases—inline, single line, and multi-line.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcodesnippet--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--multi-line',
-    }}
-  >{`
+    }}>{`
     <CodeSnippet type="multi">
     {\`${codeSnippet}\`}
     </CodeSnippet>
@@ -120,8 +117,7 @@ length use cases—inline, single line, and multi-line.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcodesnippet--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-code-snippet--inline',
-    }}
-  >{`
+    }}>{`
     <CodeSnippet type="inline">${codeSnippetSingle}</CodeSnippet>
 `}</ComponentVariant>
 </ComponentDemo>
@@ -152,7 +148,7 @@ _Note: If using an inline code snippet, the snippet will live within a body of
 text._
 
 <DoDontRow>
-  <DoDont caption="Do align code snippet containers to the grid.">
+  <DoDont type="do" caption="Do align code snippet containers to the grid.">
 
 ![Do align code snippet containers to the grid.](images/code-snippet-usage-2-do.png)
 

--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -70,8 +70,7 @@ binary decision.
       id: 'content-switcher',
       label: 'Content switcher',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="content-switcher"
     knobs={{
@@ -86,8 +85,7 @@ binary decision.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcontentswitcher--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-content-switcher--default',
-    }}
-  >{`
+    }}>{`
 <ContentSwitcher onChange={console.log}>
   <Switch name={'first'} text='First section' />
   <Switch name={'second'} text='Second section' />
@@ -137,7 +135,7 @@ longest text label should have 16px spacing to the right of the label. The width
 of all other tabs should match the widest tab.
 
 <DoDontRow>
-  <DoDont caption="Do base content tab width on the longest text label.">
+  <DoDont type="do" caption="Do base content tab width on the longest text label.">
 
 ![Do base content tab width on the longest text label.](images/contentswitcher-usage-3-do.png)
 

--- a/src/pages/components/dropdown/usage.mdx
+++ b/src/pages/components/dropdown/usage.mdx
@@ -88,8 +88,7 @@ functionality—dropdown, multiselect, and combo box.
       label: 'Filterable multiselect',
     },
   ]}
-  scope={{ items }}
->
+  scope={{ items }}>
   <ComponentVariant
     id="default-dropdown"
     knobs={{
@@ -103,8 +102,7 @@ functionality—dropdown, multiselect, and combo box.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvdropdown--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-dropdown--default',
-    }}
-  >{`
+    }}>{`
       <div style={{width: '300px', height: '100px'}}>
         <Dropdown
           ariaLabel="Dropdown"
@@ -128,8 +126,7 @@ functionality—dropdown, multiselect, and combo box.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvcombobox--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-combo-box--default',
-    }}
-  >{`
+    }}>{`
       <div style={{width: '300px', height: '100px'}}>
         <ComboBox
           ariaLabel="ComboBox"
@@ -153,8 +150,7 @@ functionality—dropdown, multiselect, and combo box.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvmultiselect--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-multi-select--default',
-    }}
-  >{`
+    }}>{`
       <div style={{width: '300px', height: '100px'}}>
         <MultiSelect
           ariaLabel="MultiSelect"
@@ -176,8 +172,7 @@ functionality—dropdown, multiselect, and combo box.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvmultiselect--user-filter-and-or-highlight',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-multi-select--default',
-    }}
-  >{`
+    }}>{`
       <div style={{width: '300px', height: '100px'}}>
         <FilterableMultiSelect
           ariaLabel="Filterable MultiSelect"
@@ -262,7 +257,7 @@ Field containers should vertically align to the grid and with other form
 components on a page.
 
 <DoDontRow>
-  <DoDont caption="Do align field containers to the grid.">
+  <DoDont type="do" caption="Do align field containers to the grid.">
 
 ![Do align field containers to the grid.](images/dropdown-usage-4-do.png)
 

--- a/src/pages/components/inline-loading/accessibility.mdx
+++ b/src/pages/components/inline-loading/accessibility.mdx
@@ -63,7 +63,7 @@ the status to assistive technologies like screen readers. Where there is no
 text, Carbon provides a text equivalent (“loading”) for the loading symbol.
 
 <DoDontRow>
-  <DoDont caption="Inline loading text is provided to assistive technologies.">
+  <DoDont type="do" caption="Inline loading text is provided to assistive technologies.">
 
 ![a loading icon with a text message of "Submitting..."](images/inline-loading-accessibility-2.png)
 

--- a/src/pages/components/popover/usage.mdx
+++ b/src/pages/components/popover/usage.mdx
@@ -113,7 +113,7 @@ four columns.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do keep width between one to four columns.">
+  <DoDont type="do" caption="Do keep width between one to four columns.">
 
 ![Do keep width between one to four columns.](images/popover-usage-4-do.png)
 
@@ -203,7 +203,7 @@ what size button is being used.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do flush align the popover edge with the trigger button.">
+  <DoDont type="do" caption="Do flush align the popover edge with the trigger button.">
 
 ![Do flush align the popover edge with the trigger button.](images/popover-usage-8-do.png)
 
@@ -262,7 +262,7 @@ should be placed 4px away from the popover container.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do align the caret tip center with the trigger button.">
+  <DoDont type="do" caption="Do align the caret tip center with the trigger button.">
 
 ![Do align the caret tip center with the trigger button.](images/popover-usage-12-do.png)
 
@@ -307,7 +307,7 @@ container because they are connected to eachother.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do top align the tab tip with the layer behind it.">
+  <DoDont type="do" caption="Do top align the tab tip with the layer behind it.">
 
 ![Do top align the tab tip with the layer behind it.](images/popover-usage-15-do.png)
 

--- a/src/pages/components/progress-bar/usage.mdx
+++ b/src/pages/components/progress-bar/usage.mdx
@@ -231,7 +231,7 @@ application.
 
 <DoDontRow>
 
-  <DoDont caption="Do keep a width within six columns.">
+  <DoDont type="do" caption="Do keep a width within six columns.">
 
 ![Do keep a width within six columns.](images/progress-bar-usage-8.png)
 
@@ -283,7 +283,7 @@ alignment. Meanwhile, placing the text far away from the progress bar could
 cause confusion in the context.
 
 <DoDontRow>
-  <DoDont caption="Do place text close to the progress bar.">
+  <DoDont type="do" caption="Do place text close to the progress bar.">
 
 ![Do place text inline with the progress bar.](images/progress-bar-usage-12.png)
 
@@ -296,7 +296,7 @@ cause confusion in the context.
 </DoDontRow>
 
 <DoDontRow>
-  <DoDont caption="Do place text close to the progress bar.">
+  <DoDont type="do" caption="Do place text close to the progress bar.">
 
 ![Do place the label close to the progress bar](images/progress-bar-usage-14.png)
 

--- a/src/pages/components/radio-button/usage.mdx
+++ b/src/pages/components/radio-button/usage.mdx
@@ -59,7 +59,7 @@ buttons. Radio buttons allow the user to select only one item in a set whereas
 checkboxes allow the user to select multiple items.
 
 <DoDontRow>
-  <DoDont caption="Do use checkboxes when multiple items can be selected.">
+  <DoDont type="do" caption="Do use checkboxes when multiple items can be selected.">
 
 ![Do use checkboxes when multiple items can be selected.](images/radio-button-usage-2-do.png)
 
@@ -79,8 +79,7 @@ checkboxes allow the user to select multiple items.
       id: 'radio-button',
       label: 'Radio button',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="radio-button"
     knobs={{
@@ -94,8 +93,7 @@ checkboxes allow the user to select multiple items.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvradiobutton--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-radio-button--default',
-    }}
-  >{`
+    }}>{`
   <FormGroup
   legendText="Radio button heading"
 >
@@ -251,7 +249,7 @@ label for the radio button component itself is not needed.
 </Row>
 
 <DoDontRow>
-<DoDont caption="Do let text wrap beneath the radio button so the control and label are top aligned.">
+<DoDont type="do" caption="Do let text wrap beneath the radio button so the control and label are top aligned.">
 
 ![Do let text wrap beneath the radio button so the control and label are top aligned.](images/radio-button-usage-12-do.png)
 

--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -113,8 +113,7 @@ such as modals, cards, or side panels.
     Tab,
     TabPanels,
     TabPanel,
-  }}
->
+  }}>
   <ComponentVariant
     id="tabs"
     knobs={{
@@ -129,8 +128,7 @@ such as modals, cards, or side panels.
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtabs--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tabs--default',
-    }}
-  >{`
+    }}>{`
 <div style={{ width: '50%' }}>
   <Tabs>
     <TabList aria-label="List of tabs" contained>
@@ -237,7 +235,7 @@ within another component, such as a card, follow the grid that you are using
 inside the component and align the label with text in the component.
 
 <DoDontRow>
-  <DoDont caption="Do align tab labels with the grid">
+  <DoDont type="do" caption="Do align tab labels with the grid">
 
 ![Do align tab labels with the grid](images/tab-usage-6-do.png)
 

--- a/src/pages/components/tile/usage.mdx
+++ b/src/pages/components/tile/usage.mdx
@@ -84,8 +84,7 @@ modules. Here are some common use cases for when to use tiles:
       id: 'expandable-tile',
       label: 'Expandable tile',
     },
-  ]}
->
+  ]}>
   <ComponentVariant
     id="tile"
     knobs={{
@@ -99,8 +98,7 @@ modules. Here are some common use cases for when to use tiles:
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtile--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--default',
-    }}
-  >{`
+    }}>{`
     <Tile>
       Default tile
     </Tile>
@@ -118,8 +116,7 @@ modules. Here are some common use cases for when to use tiles:
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtile--default',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--clickable',
-    }}
-  >{`
+    }}>{`
     <ClickableTile
       href="#"
     >
@@ -139,8 +136,7 @@ modules. Here are some common use cases for when to use tiles:
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtile--clickable',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--single-selectable',
-    }}
-  >{`
+    }}>{`
     <TileGroup
       defaultSelected="default-selected"
       legend="Radio tile group"
@@ -185,8 +181,7 @@ modules. Here are some common use cases for when to use tiles:
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtile--selectable',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--single-selectable',
-    }}
-  >{`
+    }}>{`
     <div
       aria-label="selectable tiles"
       role="group"
@@ -233,8 +228,7 @@ modules. Here are some common use cases for when to use tiles:
       Vue: 'http://vue.carbondesignsystem.com/?path=/story/components-cvtile--expandable',
       'Web Components':
         'https://web-components.carbondesignsystem.com/?path=/story/components-tile--expandable',
-    }}
-  >{`
+    }}>{`
     <ExpandableTile
       tabIndex={0}
       tileCollapsedIconText="Interact to Expand tile"
@@ -390,7 +384,7 @@ icon button, place the icon or pictorgram in the lower left corner of the tile
 and move the icon button (action) to the right corner.
 
 <DoDontRow>
-  <DoDont caption="Do left align icon, link, or text when it is by itself.">
+  <DoDont type="do" caption="Do left align icon, link, or text when it is by itself.">
 
 ![Do left align icon, link, or text when it is by itself.](images/tile-usage-8.png)
 
@@ -400,18 +394,18 @@ and move the icon button (action) to the right corner.
 
 ![Do not right align an icon, link, or text when it is by itself.](images/tile-usage-9.png)
 
-  </DoDont> 
+  </DoDont>
 </DoDontRow>
 
 <DoDontRow>
 
-  <DoDont caption="Do move icon to the right when there is an icon or pictogram.">
+  <DoDont type="do" caption="Do move icon to the right when there is an icon or pictogram.">
 
 ![Do move icon to the right when there is an icon or pictogram.](images/tile-usage-10.png)
 
   </DoDont>
 
-  <DoDont caption="Do move icon to the right when there is text or link.">
+  <DoDont type="do" caption="Do move icon to the right when there is text or link.">
 
 ![Do move icon to the right when there is text or link.](images/tile-usage-11.png)
 
@@ -541,7 +535,7 @@ confused as links or clickable.
 
 <DoDontRow>
 
-  <DoDont caption="Do use text or icon for clickable tiles if needed.">
+  <DoDont type="do" caption="Do use text or icon for clickable tiles if needed.">
 
 ![Do use text or icon for clickable tiles if needed.](images/tile-usage-22.png)
 

--- a/src/pages/components/toggle/accessibility.mdx
+++ b/src/pages/components/toggle/accessibility.mdx
@@ -66,12 +66,12 @@ captured programmatically for users who cannot see or understand the visual
 indicators.
 
 <DoDontRow>
-  <DoDont caption="Do include the on/off text for the toggle's state whenever space permits.">
+  <DoDont type="do" caption="Do include the on/off text for the toggle's state whenever space permits.">
 
 ![The alert toggle shows "off" and "on" to indicate state](images/toggle-accessibility-2-do.png)
 
   </DoDont>
-  <DoDont caption="Where space is confined, use the tickmark variation in lieu of on/off text.">
+  <DoDont type="do" caption="Where space is confined, use the tickmark variation in lieu of on/off text.">
 
 ![Toggles in the Alert column of a table show their "on" state with a green tickmark](images/toggle-accessibility-3-do.png)
 
@@ -89,7 +89,7 @@ on/off state of the toggle and the text that is the toggle’s label. The label'
 text should not change based on the on/off state.
 
 <DoDontRow>
-  <DoDont caption="Do keep the label consistent. Only change the state text between On and Off.">
+  <DoDont type="do" caption="Do keep the label consistent. Only change the state text between On and Off.">
 
 ![the same 'Alerts' toggle keeping its label in both states](images/toggle-accessibility-4-do.png)
 

--- a/src/pages/data-visualization/axes-and-labels/index.mdx
+++ b/src/pages/data-visualization/axes-and-labels/index.mdx
@@ -41,7 +41,7 @@ such as bar and area chart. Truncating the Y axis can distort the perception,
 making a small difference look big and significant.
 
 <DoDontRow>
-<DoDont caption="For bar charts, the numerical axis should start at zero.">
+<DoDont type="do" caption="For bar charts, the numerical axis should start at zero.">
 
 ![Legends behavior highlight on hover](images/axislabel-zero-a.png)
 

--- a/src/pages/guidelines/2x-grid/implementation.mdx
+++ b/src/pages/guidelines/2x-grid/implementation.mdx
@@ -416,7 +416,7 @@ columns within our system.
 </Row>
 
 <DoDontRow>
-  <DoDont caption="Do feel free to mix and match column structure.">
+  <DoDont type="do" caption="Do feel free to mix and match column structure.">
 
 ![Do feel free to mix and match column structure.](images/Responsive_classes_do.png)
 
@@ -602,7 +602,7 @@ the gutter in order to get field type to align.
 ![32px gutter](images/32px_gutter.png)
 
 <DoDontRow>
-  <DoDont caption="Do align type (outside of a container), components, and tiles to the columns.">
+  <DoDont type="do" caption="Do align type (outside of a container), components, and tiles to the columns.">
 
 ![Do align type (outside of a container), components and tiles to the columns.](images/32px_do.png)
 
@@ -676,7 +676,7 @@ Wide and a Narrow grid scenario in the [Mix and match](#mix-and-match) section.
 ![16px gutter](images/16px_gutter.png)
 
 <DoDontRow>
-  <DoDont caption="Do align components within containers flush to the columns.">
+  <DoDont type="do" caption="Do align components within containers flush to the columns.">
 
 ![Do align components within containers flush to the columns.](images/16px_do.png)
 
@@ -747,7 +747,7 @@ dropdowns, should not hang into the gutter.
 ![1px gutter](images/2px_gutter.png)
 
 <DoDontRow>
-  <DoDont caption="Do keep all type (inside and outside containers) aligned with the column grid.">
+  <DoDont type="do" caption="Do keep all type (inside and outside containers) aligned with the column grid.">
 
 ![Do keep all type (inside and outside containers) aligned with the column grid.](images/2px_do.png)
 
@@ -784,7 +784,7 @@ cases as we find them.
 <br />
 
 <DoDontRow>
-  <DoDont caption="Do apply different grid modes to different components (like input fields with labels and tiles).">
+  <DoDont type="do" caption="Do apply different grid modes to different components (like input fields with labels and tiles).">
 
 ![Do apply different grid modes to different components (like input fields with labels and tiles).](images/Mixed_use_do.png)
 
@@ -806,7 +806,7 @@ cases as we find them.
 <br />
 
 <DoDontRow>
-  <DoDont caption="Do apply different grid modes to different components (like input fields with labels and tiles).">
+  <DoDont type="do" caption="Do apply different grid modes to different components (like input fields with labels and tiles).">
 
 ![Do apply different grid modes to different components (like input fields with labels and tiles).](images/Mixed_use_do_2.png)
 
@@ -1318,7 +1318,7 @@ Image size can change ratios when the breakpoint changes.
 ![Aspect ratio flexible](images/Aspect_Ratio_flexible.png)
 
 <DoDontRow>
-  <DoDont caption="When combining tiles, or tiles and images, do give each a designated aspect ratio.">
+  <DoDont type="do" caption="When combining tiles, or tiles and images, do give each a designated aspect ratio.">
 
 ![When combining tiles, or tiles and images, do give each a designated aspect ratio.](images/AR_do_1.png)
 
@@ -1331,7 +1331,7 @@ Image size can change ratios when the breakpoint changes.
 </DoDontRow>
 
 <DoDontRow>
-  <DoDont caption="Do use a designated aspect ratio for a grid of same-size fixed ratio tiles.">
+  <DoDont type="do" caption="Do use a designated aspect ratio for a grid of same-size fixed ratio tiles.">
 
 ![Do use a designated aspect ratio for a grid of same-size fixed ratio tiles.](images/AR_do_2.png)
 

--- a/src/pages/guidelines/2x-grid/overview.mdx
+++ b/src/pages/guidelines/2x-grid/overview.mdx
@@ -152,7 +152,7 @@ if necessary.
 ![Padding](images/Layout_overview_Paddings.svg)
 
 <DoDontRow>
-  <DoDont caption="Always place type against the padding.">
+  <DoDont type="do" caption="Always place type against the padding.">
 
 ![Always place type against the padding.](images/Layout_overview_Paddings-do.svg)
 

--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -212,7 +212,7 @@ In the light themes, layers alternate between White and Gray 10.
 </Tabs>
 
 <DoDontRow>
-  <DoDont caption="Gray 10 dropdown on White background." colLg={6}>
+  <DoDont type="do" caption="Gray 10 dropdown on White background." colLg={6}>
 
 ![Gray 10 dropdown on White background.](images/Light_theme_01.png)
 
@@ -290,12 +290,12 @@ times high contrast moments can be achieved through applying
 like a dark UI Shell Header with a light theme page.
 
 <DoDontRow>
-  <DoDont colLg={6}>
+  <DoDont type="do" colLg={6}>
 
 ![High contrast example in a light theme.](images/High_contrast_01.png)
 
   </DoDont>
-  <DoDont colLg={6}>
+  <DoDont type="do" colLg={6}>
 
 ![High contrast example in a dark theme.](images/High_contrast_02.png)
 

--- a/src/pages/guidelines/motion/choreography.mdx
+++ b/src/pages/guidelines/motion/choreography.mdx
@@ -20,7 +20,7 @@ Elements in Carbon dance on the grid. Motion paths trace lines along the grid
 which never run diagonally.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="When expanding or moving elements across the screen, stagger the timing of horizontal and vertical animations to create a path with a rounded corner.">
+<DoDont type="do" colLg={12} colMd={8} caption="When expanding or moving elements across the screen, stagger the timing of horizontal and vertical animations to create a path with a rounded corner.">
 
 <Video title="Paths staggering horizontally" vimeoId="310582887" />
 
@@ -40,7 +40,7 @@ which never run diagonally.
 <br />
 
 <DoDontRow>
-<DoDont aspectRatio="1:1" caption="When removing an item from the grid, thumbnails on the edge existing and re-entering container create a smooth transition.">
+<DoDont type="do" aspectRatio="1:1" caption="When removing an item from the grid, thumbnails on the edge existing and re-entering container create a smooth transition.">
 
 <Video title="Thumbnails with smooth transition" vimeoId="310582738" />
 
@@ -53,7 +53,7 @@ which never run diagonally.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont aspectRatio="1:1"  caption="When sorting or shuffling items on the grid, always using rounded corner paths to visually organize the movements.">
+<DoDont type="do" aspectRatio="1:1"  caption="When sorting or shuffling items on the grid, always using rounded corner paths to visually organize the movements.">
 
 <Video title="organized sort and shuffle" vimeoId="310582816" />
 
@@ -86,7 +86,7 @@ seam. Therefore, they should use the same motion style (productive) and easing
 to their difference in size.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="Comparing data table expansion and dropdown">
+<DoDont type="do" colLg={12} colMd={8} caption="Comparing data table expansion and dropdown">
 
 <Video title="Semantic consistency" vimeoId="310581970" />
 
@@ -100,7 +100,7 @@ information hierarchy. Visually similar elements may need the different motions
 to clarify their respective spatial locations.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="When the new content panel is on a higher layer, motion is “sliding”, moving content within with the panel.  Also always dim the content below when new layer is introduced above.">
+<DoDont type="do" colLg={12} colMd={8} caption="When the new content panel is on a higher layer, motion is “sliding”, moving content within with the panel.  Also always dim the content below when new layer is introduced above.">
 
 <Video title="Spatial consistency" vimeoId="310581999" />
 
@@ -108,7 +108,7 @@ to clarify their respective spatial locations.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="When the new content panel is on the same layer, motion is “pushing”, revealing content within with a mask.">
+<DoDont type="do" colLg={12} colMd={8} caption="When the new content panel is on the same layer, motion is “pushing”, revealing content within with a mask.">
 
 <Video title="new content panel" vimeoId="310582064" />
 
@@ -123,7 +123,7 @@ in the direction of entrance signals affirmation, while reversing entrance
 motion signals cancellation.
 
 <DoDontRow>
-<DoDont aspectRatio="1:1" caption="Use motion to reinforce meaning. Affirmative action here triggers a different exit motion for the modal than negation.">
+<DoDont type="do" aspectRatio="1:1" caption="Use motion to reinforce meaning. Affirmative action here triggers a different exit motion for the modal than negation.">
 
 <Video title="Intentional inconsistency" vimeoId="310582134" />
 
@@ -142,7 +142,7 @@ Pay attention to shared elements across screens, such as title panels or
 buttons, to create a graceful transition.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="Shared elements can effectively guide users through a multi-layered information architecture.">
+<DoDont type="do" colLg={12} colMd={8} caption="Shared elements can effectively guide users through a multi-layered information architecture.">
 
 <Video title="Continuity" vimeoId="310582206" />
 
@@ -168,7 +168,7 @@ reduces the cognitive load. Depending on the number of staggered elements, the
 delay should be adjusted to ensure that total time is still within 500 ms.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="Table with rows loading in at staggered timing.">
+<DoDont type="do" colLg={12} colMd={8} caption="Table with rows loading in at staggered timing.">
 
 <Video title="Sequence and stagger" vimeoId="310582972" />
 
@@ -181,7 +181,7 @@ information, such as the primary button or a calculation result, to focus the
 user’s attention on them.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} caption="Sequencing of this interface prioritizes the primary button, and reserves data visualization for later when users begin to scroll, indicating intention to dive deeper.">
+<DoDont type="do" colLg={12} colMd={8} caption="Sequencing of this interface prioritizes the primary button, and reserves data visualization for later when users begin to scroll, indicating intention to dive deeper.">
 
 <Video title="Sequencing" vimeoId="310582919" />
 

--- a/src/pages/guidelines/motion/overview.mdx
+++ b/src/pages/guidelines/motion/overview.mdx
@@ -99,7 +99,7 @@ meaning. System alerts and the appearance of notification boxes are great cases
 for expressive motion.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} fullWidth caption="Productive moments are labeled in blue, and expressive moments are labeled in magenta.">
+<DoDont type="do" colLg={12} colMd={8} fullWidth caption="Productive moments are labeled in blue, and expressive moments are labeled in magenta.">
 
 <Video title="Expressive motion" vimeoId="310583077" />
 
@@ -114,7 +114,7 @@ light-weight material. "Easing curves" describe the precise amount of
 accelerations in motion. We commonly use one of these three types of easing.
 
 <DoDontRow>
-<DoDont colLg={12} colMd={8} fullWidth caption="Elements on the screen speed up quickly and slow down smoothly, obeying the physics of a light-weight material.">
+<DoDont type="do" colLg={12} colMd={8} fullWidth caption="Elements on the screen speed up quickly and slow down smoothly, obeying the physics of a light-weight material.">
 
 <Video title="Erasing" vimeoId="310582370" />
 
@@ -255,7 +255,7 @@ larger the change in distance (traveled) or size (scaling) of the element, the
 longer the animation takes.
 
 <DoDontRow>
-<DoDont colLg={8} colMd={8} caption="Duration contrast between a taller and a shorter component.">
+<DoDont type="do" colLg={8} colMd={8} caption="Duration contrast between a taller and a shorter component.">
 
 <Video title="Duration" vimeoId="310582312" />
 

--- a/src/pages/guidelines/pictograms/usage.mdx
+++ b/src/pages/guidelines/pictograms/usage.mdx
@@ -108,7 +108,7 @@ strong presence.
 <Caption>Expressive pictogram in context</Caption>
 
 <DoDontRow>
-<DoDont caption="Treat pictograms as illustations with sufficient sizing.">
+<DoDont type="do" caption="Treat pictograms as illustations with sufficient sizing.">
 
 ![Pictogram with sufficient sizing](images/13_Usage_do.svg)
 
@@ -121,7 +121,7 @@ strong presence.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont caption="Use expressive pictograms as large, bold graphics.">
+<DoDont type="do" caption="Use expressive pictograms as large, bold graphics.">
 
 ![Expressive pictogram as hero graphic](images/expressivePictograms_usage_example3.svg)
 
@@ -198,7 +198,7 @@ based on the padding size.
 </ArtDirection>
 
 <DoDontRow>
-<DoDont caption="Keep pictograms at scale and optically center in container when necessary.">
+<DoDont type="do" caption="Keep pictograms at scale and optically center in container when necessary.">
 
 ![keep scale and optically center pictograms](images/16_Containers_3_do.svg)
 
@@ -211,7 +211,7 @@ based on the padding size.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont caption="Do use accepted shapes: circle or square for containers.">
+<DoDont type="do" caption="Do use accepted shapes: circle or square for containers.">
 
 ![use accepted container shapes](images/16_Containers_5_do.svg)
 
@@ -224,7 +224,7 @@ based on the padding size.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont caption="Always optically center align pictograms in their containers.">
+<DoDont type="do" caption="Always optically center align pictograms in their containers.">
 
 ![optically center align pictograms in containers](images/16_Containers_7_do.svg)
 
@@ -276,7 +276,7 @@ on 1/4 of the scaled grid size. The padding can be increased by increments of
 <Caption>Padding is the same for both circle and square containers.</Caption>
 
 <DoDontRow>
-<DoDont caption="Follow the clearance rule to allow for legibility and touch.">
+<DoDont type="do" caption="Follow the clearance rule to allow for legibility and touch.">
 
 ![allow clearance for legibility and touch](images/17_Clearance_4_do.svg)
 
@@ -304,12 +304,12 @@ exceed values 10–20.
 </ArtDirection>
 
 <DoDontRow>
-<DoDont caption="Follow the 5-step color rule and only match tones from the same color family or use grayscale backgrounds.">
+<DoDont type="do" caption="Follow the 5-step color rule and only match tones from the same color family or use grayscale backgrounds.">
 
 ![pictogram background example](/images/10_Backgrounds_2_do.svg)
 
 </DoDont>
-<DoDont caption="Follow gradient rules when placing them on backgrounds.">
+<DoDont type="do" caption="Follow gradient rules when placing them on backgrounds.">
 
 ![pictogram background example](/images/10_Backgrounds_3_do.svg)
 
@@ -363,7 +363,7 @@ corresponds with the pictogram’s background color.
 | 80–100, Black          | Dark                        |
 
 <DoDontRow>
-<DoDont caption="Use dark-theme pictograms on dark backgrounds and light-theme pictograms on light backgrounds.">
+<DoDont type="do" caption="Use dark-theme pictograms on dark backgrounds and light-theme pictograms on light backgrounds.">
 
 ![Expressive pictogram with correct color theme](images/expressivePictograms_usage-colorDo_v2.svg)
 

--- a/src/pages/guidelines/typography/overview.mdx
+++ b/src/pages/guidelines/typography/overview.mdx
@@ -159,7 +159,7 @@ for primary actions.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont color="dark">
+<DoDont type="do" color="dark">
 
 ![Neutral color for text](images/Typography_overview_Type-color-3.svg)
 
@@ -172,12 +172,12 @@ for primary actions.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont caption="Core blue colors are used for text links and primary actions">
+<DoDont type="do" caption="Core blue colors are used for text links and primary actions">
 
 ![Link with icon](images/Typography_overview_Type-color-5.svg)
 
 </DoDont>
-<DoDont caption="Secondary actions use Gray 100 and icons">
+<DoDont type="do" caption="Secondary actions use Gray 100 and icons">
 
 ![Download with icon](images/Typography_overview_Type-color-6.svg)
 
@@ -185,7 +185,7 @@ for primary actions.
 </DoDontRow>
 
 <DoDontRow>
-<DoDont caption="Other use cases for colored type are code snippets, warnings, alerts, etc.">
+<DoDont type="do" caption="Other use cases for colored type are code snippets, warnings, alerts, etc.">
 
 ![Oops, something went wrong! colored text](images/Typography_overview_Type-color-7.svg)
 

--- a/src/pages/patterns/status-indicator-pattern/index.mdx
+++ b/src/pages/patterns/status-indicator-pattern/index.mdx
@@ -311,7 +311,7 @@ example, it may not be necessary to explicitly label an icon as ‘warning,’ o
 is good practice to clarify the status intention in the text label.
 
 <DoDontRow>
-  <DoDont caption="Do left align icons and type in lists and data tables, regardless of whether you’re using the responsive grid or spacers." colLg={6}>
+  <DoDont type="do" caption="Do left align icons and type in lists and data tables, regardless of whether you’re using the responsive grid or spacers." colLg={6}>
 
 ![Aligned status indicator icons.](images/status_indicator_5.png)
 
@@ -541,7 +541,7 @@ Color = Red <br /> Shape = Circle <br /> Symbol = \ <br /> Text = Critical
 <br />
 
 <DoDontRow>
-  <DoDont caption="Do include at least three out of four indicators of status to meet accessibility requirements." colLg={6}>
+  <DoDont type="do" caption="Do include at least three out of four indicators of status to meet accessibility requirements." colLg={6}>
 
 ![Example of accessible status indicators](images/status_indicator_17.png)
 


### PR DESCRIPTION
Adds `type="do"` to `DoDont` components that don't specify type.

Website should look/behave exactly the same, just standardizing here and adding the type since platform is making this a required prop form now on 🙏 .

#### Changelog

**Changed**

- add `type="do"` to a few docs pages that don't specify type in `DoDont` usage 

