### PR TITLE
ci: Use gatsby-cache action to cache gatsby build outputs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,24 +57,13 @@ jobs:
           node-version: 16.x
       - name: Install packages
         run: yarn install --frozen-lockfile --network-timeout 300000
-      - name: Gatsby Cache Folder
-        uses: actions/cache@v3
-        id: gatsby-cache-folder
+      - uses: jongwooo/gatsby-cache@v1.2.1
         with:
-          path: .cache
-          key: ${{ runner.os }}-cache-gatsby
+          key: ${{ runner.os }}-gatsby-build
           restore-keys: |
-            ${{ runner.os }}-cache-gatsby
-      - name: Gatsby Public Folder
-        uses: actions/cache@v3
-        id: gatsby-public-folder
-        with:
-          path: public/
-          key: ${{ runner.os }}-public-gatsby
-          restore-keys: |
-            ${{ runner.os }}-public-gatsby
+            ${{ runner.os }}-gatsby-build
       - name: Build site
-        run: yarn build:clean
+        run: yarn build
         env:
           GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES: true
           NODE_ENV: production


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

I created an action to cache Gatsby's build outputs. This action is easy to set up. 

**AS-IS**

```yaml
- name: Gatsby Cache Folder
  uses: actions/cache@v3
  id: gatsby-cache-folder
  with:
    path: .cache
    key: ${{ runner.os }}-cache-gatsby
    restore-keys: |
      ${{ runner.os }}-cache-gatsby
- name: Gatsby Public Folder
  uses: actions/cache@v3
  id: gatsby-public-folder
  with:
    path: public/
    key: ${{ runner.os }}-public-gatsby
    restore-keys: |
      ${{ runner.os }}-public-gatsby
- name: Build site
  run: yarn build:clean
```

**TO-BE**

```yaml
- uses: jongwooo/gatsby-cache@v1.2.1
  with:
    key: ${{ runner.os }}-gatsby-build
    restore-keys: |
      ${{ runner.os }}-gatsby-build
- name: Build site
  run: yarn build
```

## References

- [https://github.com/jongwooo/gatsby-cache](https://github.com/jongwooo/gatsby-cache)