### PR TITLE
Update link to 2x grid page

### DIFF
--- a/src/pages/patterns/forms-pattern/index.mdx
+++ b/src/pages/patterns/forms-pattern/index.mdx
@@ -735,7 +735,7 @@ precise, but, you can add a short description of the group if necessary.
 Users will be confused if inputs are too close together. To ensure sufficient
 spacing between single form elements as well as groups of inputs, use margins,
 spacers, gutters, and key alignments to guide you. See the
-[2x Grid](/guidelines/2x-grid) for more information.
+[2x Grid](/guidelines/2x-grid/overview) for more information.
 
 #### Form context
 


### PR DESCRIPTION
The form patterns page currently uses an outdated link to the 2x grid page, resulting in a 404 not found.
This patch updates the link to the correct route.

#### Changelog

**Changed**

- Updated outdated link for 2x grid from form patterns page
