### PR TITLE
docs: react tutorial typo + link fixes

### DIFF
--- a/src/pages/developing/react-tutorial/step-2.mdx
+++ b/src/pages/developing/react-tutorial/step-2.mdx
@@ -799,7 +799,7 @@ export default RepoTable;
 
 This component uses two props, `rows` and `headers`, and returns a Carbon
 `DataTable`. As for where the various `Table*` components came from? The
-[DataTable story](https://react.carbondesignsystem.com/?path=/story/components-datatable-expansion--usage)
+[DataTable story](https://react.carbondesignsystem.com/?path=/story/components-datatable-expansion--default)
 in Storybook was used to put together the data table structure.
 
 <InlineNotification>

--- a/src/pages/developing/react-tutorial/step-3.mdx
+++ b/src/pages/developing/react-tutorial/step-3.mdx
@@ -509,8 +509,7 @@ rows for the current "page". Update
 <InlineNotification>
 
 **Note:** We only pass the rows that we want our table to display. We can do
-this by slicing the our array of rows depending on the first item and the page
-size.
+this by slicing the array of rows depending on the first item and the page size.
 
 </InlineNotification>
 

--- a/src/pages/developing/react-tutorial/step-5.mdx
+++ b/src/pages/developing/react-tutorial/step-5.mdx
@@ -36,7 +36,6 @@ have not been updated to reflect changes for our next major version.
 
 <AnchorLink>Fork, clone and branch</AnchorLink>
 <AnchorLink>Create IBM Cloud account</AnchorLink>
-<AnchorLink>Optimize Sass</AnchorLink>
 <AnchorLink>Build for production</AnchorLink>
 <AnchorLink>Create manifest file</AnchorLink>
 <AnchorLink>Create static file</AnchorLink>


### PR DESCRIPTION
This commit fixes three "typos" in the React Tutorial section.
- 1 text related
- 2 link related

#### Changelog

**New**

n/a

**Changed**

- Step 2: update DataTable Story link w/newer url
  - code sample nearby has Table _Expansion_ tags, so I'm guessing that was still the desired link to keep, otherwise it could be changed to the default for all tables?
- Step 3: fix typo in pagination Note
  - "the our"

**Removed**

- Step 5: rm unused <AnchorLink> Optimize Sass
  - unable to find appropriate reference, this may have been an old step
