### PR TITLE
ci(deploy): remove ibm cloud deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,38 +14,6 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v2-beta
-        with:
-          node-version: 16.x
-
-      - name: Install packages
-        run: yarn install --frozen-lockfile --network-timeout 300000
-
-      - name: Build site
-        run: yarn build:clean
-
-      - name: Install IBM Cloud CLI
-        run: curl -fsSL https://clis.cloud.ibm.com/install/osx | sh
-
-      - name: Install Cloud Foundry CLI
-        run: ibmcloud cf install -v 6.51.0
-
-      - name: Login to ibmcloud
-        env:
-          API_KEY: ${{ secrets.API_KEY }}
-        run:
-          ibmcloud login -a "https://cloud.ibm.com" -u apikey -p "$API_KEY" -o
-          "carbon-design-system" -s "production" -r "us-south"
-
-      - name: Deploy website
-        run: |
-          ibmcloud cf v3-zdt-push carbon-website -b https://github.com/cloudfoundry/nginx-buildpack.git
-
   gh-pages:
     if: github.repository == 'carbon-design-system/carbon-website'
     runs-on: ubuntu-latest

--- a/src/pages/components/select/accessibility.mdx
+++ b/src/pages/components/select/accessibility.mdx
@@ -82,5 +82,5 @@ custom component.
 - Carbon uses the combined attributes `disabled`, `hidden`, and `selected` in
   order to make a default prompt such as “Choose an option” not appear in the
   list of options when the select is open.
-- The component is built on the HTML `select` element and has limited
-  styling, with most of the visual appearance coming from the browser.
+- The component is built on the HTML `select` element and has limited styling,
+  with most of the visual appearance coming from the browser.


### PR DESCRIPTION
Ref https://github.com/carbon-design-system/carbon/issues/10834

We haven't been using the ibm cloud deployment for quite some time and we can remove this. I have also stopped the cloudfoundry app in IBM Cloud