### PR TITLE
fix(carbon-platform): remove import statement from treeview usage doc

### DIFF
--- a/src/pages/components/tree-view/usage.mdx
+++ b/src/pages/components/tree-view/usage.mdx
@@ -64,8 +64,6 @@ child nodes.
 
 ## Live demo
 
-import { Document, Folder } from '@carbon/icons-react';
-
 <ComponentDemo
   components={[
     {


### PR DESCRIPTION
Closes #https://github.com/carbon-design-system/carbon-platform/issues/1611

Loaded locally: 
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/40550942/223248686-214b6343-9cc2-48f5-8bda-6d782655044c.png">
