### PR TITLE
fix: typo for live demo size

### DIFF
--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -77,7 +77,7 @@ independently, but the components were designed to work together.
       src="https://codesandbox.io/embed/header-with-actions-and-nav-m0lo2?fontsize=14&hidenavigation=1&view=preview"
       title="header-with-actions-and-nav"
       allow="geolocation; microphone; camera; midi; vr; accelerometer; gyroscope; payment; ambient-light-sensor; encrypted-media"
-      sstyle={{
+      style={{
         width: '100%',
         height: '500px',
         border: '0',


### PR DESCRIPTION
Closes #3181 


#### Changelog

**Changed**

- fix typo

Live demo on https://carbondesignsystem.com/components/UI-shell-header/usage/ page should now show 100% width / 500px height
