### PR TITLE
docs(grid): update grid notification

### DIFF
--- a/src/pages/guidelines/2x-grid/implementation.mdx
+++ b/src/pages/guidelines/2x-grid/implementation.mdx
@@ -15,9 +15,12 @@ with five default breakpoints and dozens of predefined classes.
 
 <InlineNotification>
 
-If you're using `@carbon/react`, you probably don't need need to install the
-grid package separately. See our [Carbon React](/developing/frameworks/react/)
-guide to start building.
+The documentation regarding our grid system on this page is partially outdated
+and refers to the
+[FlexGrid](https://react.carbondesignsystem.com/?path=/docs/elements-flexgrid--auto-columns#grid)
+implementation. Our latest version, v11, includes a
+[CSS Grid](https://react.carbondesignsystem.com/?path=/docs/elements-grid--default#grid)
+implementation which will be documented soon.
 
 </InlineNotification>
 
@@ -45,7 +48,7 @@ If you’re new to Flexbox, this
 [CSS Tricks Flexbox guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
 will provide more detail around everything from basic terminology to code.
 
-## Getting started
+## Get started
 
 ### With `@carbon/styles`
 


### PR DESCRIPTION
Closes #12954



#### Changelog

**Changed**

- update notification copy on grid implementation page
- small copy change so anchor links work for get started

