### PR TITLE
fix: correct broken vue storybook links

### DIFF
--- a/src/pages/components/UI-shell-left-panel/code.mdx
+++ b/src/pages/components/UI-shell-left-panel/code.mdx
@@ -49,7 +49,7 @@ see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
       subTitle="Vue (Community)"
-      href="https://vue.carbondesignsystem.com/?path=/story/components-cvuishell-header--fixed-side-nav"
+      href="https://vue.carbondesignsystem.com/?path=/story/components-cvuishell--fixed-side-nav"
       >
 
 <MdxIcon name="vue" />

--- a/src/pages/components/link/code.mdx
+++ b/src/pages/components/link/code.mdx
@@ -49,7 +49,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
       subTitle="Vue (Community)"
-      href="http://vue.carbondesignsystem.com/?path=/story/components-cvlink--default"
+      href="http://vue.carbondesignsystem.com/?path=/story/components-cvlink--a"
       >
 
 <MdxIcon name="vue" />

--- a/src/pages/components/tag/code.mdx
+++ b/src/pages/components/tag/code.mdx
@@ -49,7 +49,7 @@ documentation, see the Storybooks for each framework below.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
       subTitle="Vue (Community)"
-      href="http://vue.carbondesignsystem.com/?path=/story/components-cvtag--default"
+      href="http://vue.carbondesignsystem.com/?path=/story/components-cvtag--standard"
       >
 
 <MdxIcon name="vue" />


### PR DESCRIPTION
Closes #3470 

#### Changelog

**Changed**

- Updated Vue storybook links for Link, UI Shell Header and UI Shell Left Panel

**Removed**

Test components' `code` Vue Resource Card link, should direct to correct story
