### PR TITLE
fix: broken faq link

### DIFF
--- a/src/pages/help/contact-us/index.mdx
+++ b/src/pages/help/contact-us/index.mdx
@@ -33,7 +33,7 @@ documented.
 ### Frequently asked questions
 
 Answers to the most common questions about the design system can be found in the
-[Carbon FAQs](faqs).
+[Carbon FAQs](/help/faq/).
 
 ## Provide a suggestion or contribution
 

--- a/src/pages/help/contact-us/index.mdx
+++ b/src/pages/help/contact-us/index.mdx
@@ -33,7 +33,7 @@ documented.
 ### Frequently asked questions
 
 Answers to the most common questions about the design system can be found in the
-[Carbon FAQs](/help/faq/).
+[Carbon FAQs](/help/faq).
 
 ## Provide a suggestion or contribution
 


### PR DESCRIPTION
Broken FAQ link reported in [slack](https://ibm-studios.slack.com/archives/C0M053VPT/p1680767943748399) on Contact Us page -> FAQs