### PR TITLE
Tabs: Update docs with new props

### DIFF
--- a/src/pages/components/tabs/usage.mdx
+++ b/src/pages/components/tabs/usage.mdx
@@ -18,11 +18,7 @@ between groups of information that appear within the same context.
 <InlineNotification>
 
 **v11 update:** The tab component variant names have changed. Default tabs has
-become _Line tabs_ and Container tabs has become _Contained tabs_. The tabs
-component has also been refactored and now includes a composable component API
-which allows for additional style modifications like icons in tabs and secondary
-labels. For v10 implementation guidance, go to
-[v10 Tabs](https://v10.carbondesignsystem.com/components/tabs/usage/).
+become _Line tabs_ and Container tabs has become _Contained tabs_. The updated tabs component has new modifiers that allow for icons and secondary labels. For v10 implementation guidance, go to[v10 Tabs](https://v10.carbondesignsystem.com/components/tabs/usage/).
 
 </InlineNotification>
 
@@ -172,7 +168,6 @@ are always at least two tabs and one is selected by default. Icons are optional.
 
 </Column>
 </Row>
-<Caption>Note: The close icon button pattern is not a configurable prop, it is instead enabled through the composable component API. This requires additional styling and configuration.</Caption>
 
 <Row>
 <Column colSm={2} colMd={4} colLg={4}>
@@ -204,7 +199,6 @@ B. Indicator <br /> C. Icon
 
 </Column>
 </Row>
-<Caption>Note: The optional secondary label and icon patterns are not configurable props, but are instead enabled through the composable component API. This requires additional styling and configuration.</Caption>
 
 <Row>
 <Column colSm={2} colMd={4} colLg={4}>
@@ -424,12 +418,6 @@ label.
 </Column>
 </Row>
 
-<Caption>
-  Note: Tabs with an icon is an example of a pattern. It is not currently
-  implemented by default in the component, it is instead enabled through the
-  composable component API. This requires additional styling and configuration.
-</Caption>
-
 ### Icon-only tabs
 
 You may use icon-only tabs with both line and contained tabs. Icons must be
@@ -457,7 +445,6 @@ secondary labels with line tabs or auto-width contained tabs.
 
 </Column>
 </Row>
-<Caption>Note: The secondary label is an example of a pattern. It is not currently implemented in the component.</Caption>
 
 ## Related
 


### PR DESCRIPTION
Closes [#13389](https://github.com/carbon-design-system/carbon/issues/13389)

Updating docs to reflect the new additions to the tab component

#### Changelog

**Changed**

- Updated v11 notification—took out part about composable component API now that we have props available 

**Removed**

- Removed caption under Anatomy of line tabs image
- Removed caption under Anatomy of contained tabs image
- Removed caption under Tabs with icon image
- Removed cation under Secondary labels image
