### PR TITLE
docs(migration): re-add more docs around v11 codemods

### DIFF
--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -731,7 +731,16 @@ our
 
 If you were using specific variables, mixins, or functions from Carbon, it may
 be that you will need to update their name in v11. In general, all `carbon--`
-prefixed names have been renamed to drop the `carbon--` prefix.
+prefixed names have been renamed to drop the `carbon--` prefix. To remove the
+`carbon--` prefix and update it perform a find and replace operation, as
+illustrated in the following example.
+
+```diff
+- @include carbon--breakpoint(lg) {
++ @include breakpoint(lg) {
+      width: 42%;
+  }
+```
 
 For a full list of the changes to variables, mixins, and functions that have
 changed, check out our

--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -54,9 +54,12 @@ around in v11 but they will only be re-exports of `@carbon/styles` and
 `@carbon/react` respectively.
 
 <InlineNotification>
-  Some of the migration steps below can be automated using the `@carbon/upgrade`
-  CLI. For full details, see the [`@carbon/upgrade` package
-  documentation](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+
+Some of the migration steps below can be automated using the `@carbon/upgrade`
+CLI. For full details, see the
+[`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+package documentation
+
 </InlineNotification>
 
 ## carbon-components-react
@@ -234,10 +237,19 @@ longer necessary.
 ### Step 6: Update JavaScript imports
 
 <InlineNotification>
-  This step can be automated using the `@carbon/upgrade` CLI. For full details,
-  see the [`@carbon/upgrade` package
-  documentation](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+
+This step can be automated using the `@carbon/upgrade` CLI. For full details,
+see the
+[`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+package documentation
+
 </InlineNotification>
+
+**Rewrite imports from** `carbon-components-react` **to** `@carbon/react`.
+
+```bash
+npx @carbon/upgrade migrate update-carbon-components-react-import-to-scoped
+```
 
 After updating how you bring in styles, you will need to update your import
 paths from `carbon-components-react` to `@carbon/react` for components that
@@ -253,9 +265,12 @@ import { Accordion, AccordionItem } from '@carbon/react';
 ### Step 7: Update icon imports
 
 <InlineNotification>
-  This step can be automated using the `@carbon/upgrade` CLI. For full details,
-  see the [`@carbon/upgrade` package
-  documentation](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+
+This step can be automated using the `@carbon/upgrade` CLI. For full details,
+see the
+[`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+package documentation
+
 </InlineNotification>
 
 The `@carbon/icons-react` package has been updated to minimize the number of
@@ -381,6 +396,22 @@ size options fall under the following values:
 | `2xl`      | 80px |
 
 **Note:** the default size in v11 is `md` (`40px`).
+
+<InlineNotification>
+
+This step can be automated using the `@carbon/upgrade` CLI. For full details,
+see the
+[`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade)
+package documentation
+
+</InlineNotification>
+
+Automate size prop changes.
+
+```bash
+npx @carbon/upgrade migrate small-to-size-props
+npx @carbon/upgrade migrate size-prop-updates
+```
 
 The following components all have size variants that may be affected in your
 code. To update, you will need to switch to one of the size options above.
@@ -700,16 +731,7 @@ our
 
 If you were using specific variables, mixins, or functions from Carbon, it may
 be that you will need to update their name in v11. In general, all `carbon--`
-prefixed names have been renamed to drop the `carbon--` prefix. To remove the
-`carbon--` prefix and update it perform a find and replace operation, as
-illustrated in the following example.
-
-```diff
-- @include carbon--breakpoint(lg) {
-+ @include breakpoint(lg) {
-      width: 42%;
-  }
-```
+prefixed names have been renamed to drop the `carbon--` prefix.
 
 For a full list of the changes to variables, mixins, and functions that have
 changed, check out our
@@ -869,6 +891,68 @@ their replacement, if available, in v11.
 | glyph--incomplete               | GlyphIncomplete             | Incomplete                  |
 | glyph--square-fill              | GlyphSquareFill             | SquareFill                  |
 | glyph--undefined                | GlyphUndefined              | Undefined                   |
+
+### Migration
+
+Most use-cases of the icons from the `@carbon/icons-react` package will be
+covered by an automated codemod. To run this codemod, follow the instructions in
+[`@carbon/upgrade`](https://github.com/carbon-design-system/carbon/tree/main/packages/upgrade).
+
+Update imports and size usage for @carbon/icons-react
+
+```bash
+npx @carbon/upgrade migrate icons-react-size-prop
+```
+
+However, in certain situations, we will be unable to infer what the correct
+update should be for a certain usage of the icon component. We have written the
+codemod to work for most situations, but you will see console warnings for files
+that will require you to manually review them to make sure the transforms were
+applied correctly.
+
+The most common manual update that teams will need to make is if a `prop` where
+the icon is passed to places a `ref` on the icon. For example,
+
+```jsx
+function MyComponent({ renderIcon: Icon }) {
+  const ref = useRef(null);
+  return <Icon ref={ref} />;
+}
+
+// Before
+<MyComponent renderIcon={Search16} />
+
+// After the codemod
+<MyComponent renderIcon={props => <Search size={16} {...props} />} />
+```
+
+In this situation, you will need to update your code to use `React.forwardRef`:
+
+```jsx
+<MyComponent
+  renderIcon={React.forwardRef((props, ref) => (
+    <Search ref={ref} size={16} {...props} />
+  ))}
+/>;
+
+// Or, alternatively:
+const Search16 = React.forwardRef((props, ref) => {
+  return <Search ref={ref} size={16} {...props} />;
+});
+
+<MyComponent renderIcon={Search16} />;
+```
+
+### Manual migration
+
+In addition to the automated codemods above, there are several patterns in your
+codebase that you will need to update manually:
+
+- If you use the name `ForwardRef(IconName16)` in a test you will need to
+  manually change this. Prefer to use the component directly if using enzyme
+- If you use snapshot tests, the structure will change and include a `size`
+  prop. Make sure that the `size` prop value matches what your icon name used to
+  be. For example, `<Add16 />` should become `<Add size={16} />`
 
 ## carbon-icons
 


### PR DESCRIPTION
Somehow these changes aren't showing up anymore https://github.com/carbon-design-system/carbon-website/pull/3541

this re-adds the updates to the Migration > Develop page