### PR TITLE
docs: update vanilla framework docs

### DIFF
--- a/src/pages/developing/frameworks/other-frameworks.mdx
+++ b/src/pages/developing/frameworks/other-frameworks.mdx
@@ -37,7 +37,7 @@ components by following the guidelines below.
 ## Using just the styles
 
 Developers wanting to build in different ways, follow the instructions for the
-[vanilla JS](/get-started/develop/vanilla) library to access the styles and
+[vanilla JS](/developing/frameworks/vanilla/) library to access the styles and
 build out their own components.
 
 ## Wrapping a component

--- a/src/pages/developing/frameworks/other-frameworks.mdx
+++ b/src/pages/developing/frameworks/other-frameworks.mdx
@@ -37,7 +37,7 @@ components by following the guidelines below.
 ## Using just the styles
 
 Developers wanting to build in different ways, follow the instructions for the
-[vanilla JS](/developing/frameworks/vanilla/) library to access the styles and
+[Vanilla JS](/developing/frameworks/vanilla/) library to access the styles and
 build out their own components.
 
 ## Wrapping a component

--- a/src/pages/developing/frameworks/vanilla.mdx
+++ b/src/pages/developing/frameworks/vanilla.mdx
@@ -36,23 +36,26 @@ for more info. For support,
 
 </InlineNotification>
 
+## Resources
+
+<Row className="resource-card-group">
+  <Column colMd={4} colLg={4} noGutterSm>
+    <ResourceCard
+      subTitle="Carbon styles"
+      href="https://github.com/carbon-design-system/carbon/tree/main/packages/styles"
+    >
+      <MdxIcon name="github" />
+    </ResourceCard>
+  </Column>
+</Row>
+
 ## Getting started
-
-<AnchorLinks small>
-
-<AnchorLink>CodePen</AnchorLink>
-<AnchorLink>SCSS</AnchorLink>
-
-</AnchorLinks>
-
-### CodePen
-
-We have individual [CodePens](https://codepen.io/collection/XqRbEz/) for all of
-our components which you can easily fork and play around with.
 
 ### SCSS
 
-As of v11, Carbon only provides styles for Vanilla JS.
+As of v11, Carbon only provides
+[styles](https://github.com/carbon-design-system/carbon/tree/main/packages/styles)
+for Vanilla JS.
 
 A minified css bundle is not included, you'll need to add sass compiliation to
 your project's build to use v11.
@@ -75,3 +78,10 @@ prefixes are automatically added to your output CSS.
 Carbon Components are built to be included individually and not clobber global
 styles - all `class` attributes are prefixed by the `cds--` moniker. You can
 specify your own prefix by changing the SCSS variable `$prefix`.
+
+## Legacy
+
+### CodePen
+
+We have individual [CodePens](https://codepen.io/collection/XqRbEz/) for all of
+our v10 components which you can easily fork and play around with.


### PR DESCRIPTION
Confusing docs around styles/vanilla pointed out in [slack](https://ibm-studios.slack.com/archives/C0M053VPT/p1686063440073279)

- Update broken link to vanilla docs
- add resource card / link to @carbon/styles package
- add legacy section for v10 codepen examples
