### PR TITLE
fix: update broken link on form component usage tab

### DIFF
--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -455,7 +455,7 @@ pattern.
 | Topic                                                                             | Overview                                                                                                        |
 | --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
 | [Buttons in forms](/patterns/forms-pattern/#buttons])                             | Provides guidance on button alignment, emphasis, placement, and naming in relation to a form.                   |
-| [Errors and validation](/forms-pattern/#errors-and-validation)                    | Effective and immediate error messaging can help the user to understand the problem and how to fix it.          |
+| [Errors and validation](/patterns/forms-pattern/#errors-and-validation)           | Effective and immediate error messaging can help the user to understand the problem and how to fix it.          |
 | [Form layout](/patterns/forms-pattern/#designing-a-form)                          | Additional guidance around layout, spacing, and columns in a form.                                              |
 | [Designing for longer forms](/patterns/forms-pattern/#designing-for-longer-forms) | Techniques to help make longer forms less overwhelming, including guidance for accordion and multistep forms.   |
 | [Form variants](/patterns/forms-pattern/#variants)                                | Forms may be presented as dedicated pages, side panels, or dialogs depending on the use case and the situation. |


### PR DESCRIPTION
Closes #3601 

Fixes the broken link in the "Additional guidance" section on the Form component usage tab for Errors and validation.

**Changed**

- Updated link.

