### PR TITLE
Update get-started.mdx

### DIFF
--- a/src/pages/developing/get-started.mdx
+++ b/src/pages/developing/get-started.mdx
@@ -109,7 +109,7 @@ And be sure to sign up for the latest Carbon news at
 ### Learn about what we're doing
 
 You can find out about Carbon's latest changes and future plans on the
-[Releases](/whats-happening/releases) page.
+[Releases](/all-about-carbon/releases) page.
 
 If you have questions, here are all the ways to [contact us](/help/contact-us).
 


### PR DESCRIPTION
fixed broken releases link

#### Changelog

**Changed**

- release link pointed to old release page in the what's happening section. updated it to link to the all about carbon section.
