### PR TITLE
docs[Color]: fixing broken links

### DIFF
--- a/src/pages/guidelines/color/overview.mdx
+++ b/src/pages/guidelines/color/overview.mdx
@@ -181,8 +181,7 @@ There are two light themes in Carbon: White and Gray 10. For enabled UI colors
 light themes primarily use the color range of White to Gray 20, and for text and
 icons uses the color range between Gray 100 and Gray 60.
 
-All of the themes are available in
-[Design kits](https://carbondesignsystem.com/designing/kits/sketch/).
+All of the themes are available in [Design kits](/designing/kits/figma/).
 
 #### Layering model
 
@@ -232,8 +231,7 @@ There are two dark themes: Gray 90 and Gray 100. For enabled UI colors, dark
 themes primarily use the color range of Gray 100 through Gray 70, and for text
 and icons uses the color range between White and Gray 50.
 
-All of the themes are available in
-[Design kits](https://carbondesignsystem.com/designing/kits/sketch/).
+All of the themes are available in [Design kits](/designing/kits/figma/).
 
 #### Layering model
 
@@ -287,8 +285,8 @@ dark components to light backgrounds. This technique is useful to focus
 attention or create visual tension. Some high contrast moments are baked into
 the themes by using the `inverse` tokens, like the tooltip component. Other
 times high contrast moments can be achieved through applying
-[inline theming](/guidelines/color/implementation#inline-theming) for instances
-like a dark UI Shell Header with a light theme page.
+[inline theming](/guidelines/color/usage#inline-theming) for instances like a
+dark UI Shell Header with a light theme page.
 
 <DoDontRow>
   <DoDont type="do" colLg={6}>
@@ -307,12 +305,12 @@ like a dark UI Shell Header with a light theme page.
 
 ## Tokens
 
-Tokens are method of applying color in a consistent, reusable, and scalable way.
-They help us abstract how we use color from the values themselves. They are used
-in place of hard coded values, like hex codes. Tokens allow for value changes to
-be made at scale, making design language changes easy to implement, as well as
-making possible color functionalities like inline theming and light or dark
-mode.
+Tokens are a method of applying color in a consistent, reusable, and scalable
+way. They help us abstract how we use color from the values themselves. They are
+used in place of hard coded values, like hex codes. Tokens allow for value
+changes to be made at scale, making design language changes easy to implement,
+as well as making possible color functionalities like inline theming and light
+or dark mode.
 
 Each token is assigned a role and a value. The role determines what element to
 apply a token too and the value is the actual color (hex code) that appears in
@@ -321,7 +319,7 @@ the assigned value will change with the theme. For example, under the hood
 the `$text-secondary` token can dynamically map to `Gray 70` or `Gray 30`
 depending on the theme.
 
-See the [color usage](/guidelines/color/usage) tab for the full list of color
+See the [tokens](/guidelines/color/tokens) tab for the full list of color
 tokens.
 
 ### Token names
@@ -361,8 +359,7 @@ and `$interactive`.
 
 Some core tokens are part of an additional token group called _layering tokens_.
 These tokens are used to implement the layering model onto components. For more
-information, see the
-[Implementation tab](/guidelines/color/implementation#layer-tokens).
+information, see the [usage tab](/guidelines/color/usage#layering-tokens).
 
 | Token group | Applied to                                                                          |
 | ----------- | ----------------------------------------------------------------------------------- |
@@ -385,7 +382,7 @@ Some components have their own specific color tokens, known as _component
 tokens_. They represent the properties associated with a particular component.
 They are not global tokens like the core tokens and should never be used for
 anything other than their own component. For a full list for component tokens
-see the [color usage](/guidelines/color/usage) tab.
+see the [tokens](/guidelines/color/tokens)tab.
 
 To see how the tokens are applied in the components themselves, visit the
 component’s style page.


### PR DESCRIPTION
I noticed after we updated the tab names on the color page, a lot of the cross-reference links were broken or going to the wrong page.

#### Changelog

**Changed**

- fixed typo
- updated links
