### PR TITLE
fix: overflow menu and switcher styles

### DIFF
--- a/src/components/TypesetStyle/typeset-example.scss
+++ b/src/components/TypesetStyle/typeset-example.scss
@@ -1,7 +1,6 @@
 @use '@carbon/react/scss/breakpoint' as *;
 @use '@carbon/react/scss/spacing' as *;
 @use '@carbon/react/scss/colors' as *;
-@use '@carbon/react/scss/components/copy-button' as *;
 
 .cds--copy-btn {
   background-color: var(--cds-layer);


### PR DESCRIPTION
Remove unnecessary @use  statement. 

This should fix the weird blue background on the overflow menu, and switcher styles. 


Double check that `/guidelines/typography/type-sets `page is rendering correctly. 

