### PR TITLE
Update themes/overview.mdx

### DIFF
--- a/src/pages/guidelines/themes/overview.mdx
+++ b/src/pages/guidelines/themes/overview.mdx
@@ -97,7 +97,7 @@ There are several token categories:
 The full list of tokens available can be found in the source of the
 `@carbon/themes` package per theme for
 [white](https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/white.js),
-[g10](<(https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/g10.js)>),
+[g10](https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/g10.js),
 [g90](https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/g90.js),
 and
 [g100](https://github.com/carbon-design-system/carbon/blob/main/packages/themes/src/g100.js).

--- a/src/pages/guidelines/themes/overview.mdx
+++ b/src/pages/guidelines/themes/overview.mdx
@@ -49,7 +49,7 @@ Carbon provides four themes as shown in the
 and installed, the components are preset to use the default (White) theme.
 
 To use the Gray 10, Gray 90, or Gray 100 theme as your default instead of White,
-configure the sass module usign `with`.
+configure the sass module using `with`.
 
 ```scss
 @use '@carbon/react/scss/themes';


### PR DESCRIPTION
Correct typo on line 52: 'usign' -> 'using'
Fix broken link on line 100

#### Changelog


**Changed**

- Line 52 of `src/pages/guidelines/themes/overview.mdx`
- Line 100 of `src/pages/guidelines/themes/overview.mdx`
