### PR TITLE
docs(migration): added type token module

### DIFF
--- a/src/pages/migrating/guide/develop.mdx
+++ b/src/pages/migrating/guide/develop.mdx
@@ -246,6 +246,7 @@ in our package.
 
 | Carbon sass I'm using           | Sass modules to include                                  |
 | ------------------------------- | -------------------------------------------------------- |
+| Type tokens                     | `@use '@carbon/react/scss/type' as *;`                   |
 | Theme tokens                    | `@use '@carbon/react/scss/theme' as *`                   |
 | Theme mixins                    | `@use '@carbon/react/scss/themes' as *`                  |
 | Design language color tokens    | `@use '@carbon/react/scss/colors' as *`                  |


### PR DESCRIPTION
The type tokens were missing from the list.