### PR TITLE
fix(docs): URL - /designing/tutorials/ is broken (404) added v10 

### DIFF
--- a/src/pages/all-about-carbon/who-uses-carbon.mdx
+++ b/src/pages/all-about-carbon/who-uses-carbon.mdx
@@ -58,7 +58,7 @@ Here are some ways designers can begin engaging with Carbon.
 - Familiarize yourself with usage and style guidance for all of Carbon's
   [components](/components/overview/) and [patterns](/patterns/overview/).
 
-- Check out [design tutorials](https://v10.carbondesignsystem.com/designing/tutorials/) to learn more about some
+- Check out [design tutorials](/designing/get-started/) to learn more about some
   of the foundational pieces of the design system.
 
 #### Get the tools

--- a/src/pages/all-about-carbon/who-uses-carbon.mdx
+++ b/src/pages/all-about-carbon/who-uses-carbon.mdx
@@ -58,7 +58,7 @@ Here are some ways designers can begin engaging with Carbon.
 - Familiarize yourself with usage and style guidance for all of Carbon's
   [components](/components/overview/) and [patterns](/patterns/overview/).
 
-- Check out [design tutorials](/designing/tutorials/) to learn more about some
+- Check out [design tutorials](https://v10.carbondesignsystem.com/designing/tutorials/) to learn more about some
   of the foundational pieces of the design system.
 
 #### Get the tools


### PR DESCRIPTION
url is broken - https://carbondesignsystem.com/designing/tutorials/ updated the url to - version 10 - https://v10.carbondesignsystem.com/designing/tutorials/

Closes #

url is broken - https://carbondesignsystem.com/designing/tutorials/ updated the url to - version 10 - https://v10.carbondesignsystem.com/designing/tutorials/

#### Changelog

**New**

- updated the url to - version 10 - https://v10.carbondesignsystem.com/designing/tutorials/

**Changed**

- /designing/tutorials/ 

