### PR TITLE
fix(notification): remove links from live demo examples

### DIFF
--- a/src/pages/components/notification/code.mdx
+++ b/src/pages/components/notification/code.mdx
@@ -92,7 +92,7 @@ usage documentation, see the Storybooks for each framework below.
       <ToastNotification
         caption="00:00:00 AM"
         iconDescription="describes the close button"
-        subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+        subtitle={<span>Subtitle text goes here.</span>}
         timeout={0}
         title="Notification title"
       />
@@ -120,7 +120,7 @@ usage documentation, see the Storybooks for each framework below.
       kind="info"
       actions={<NotificationActionButton>Action</NotificationActionButton>}
       iconDescription="describes the close button"
-      subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+      subtitle={<span>Subtitle text goes here.</span>}
       title="Notification title"
     />
   </div>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -97,7 +97,7 @@ although some product teams also support banners and notification centers.
       <ToastNotification
         caption="00:00:00 AM"
         iconDescription="describes the close button"
-        subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+        subtitle={<span>Subtitle text goes here.</span>}
         timeout={0}
         title="Notification title"
       />
@@ -125,7 +125,7 @@ although some product teams also support banners and notification centers.
       kind="info"
       actions={<NotificationActionButton>Action</NotificationActionButton>}
       iconDescription="describes the close button"
-      subtitle={<span>Subtitle text goes here. <a href="#example">Example link</a></span>}
+      subtitle={<span>Subtitle text goes here.</span>}
       title="Notification title"
     />
   </div>


### PR DESCRIPTION
[Surfaced in slack](https://ibm-studios.slack.com/archives/C2K6RFJ1G/p1692817241277449) - the examples in the live demo for notifications include links in ToastNotification and InlineNotification which are inaccessible and shouldn't be there.

#### Changelog

**Changed**

- remove links from notification live demo