### PR TITLE
fix: figma guidance content bug

### DIFF
--- a/src/pages/designing/kits/figma.mdx
+++ b/src/pages/designing/kits/figma.mdx
@@ -224,7 +224,7 @@ following view-only link.
 </Column>
 </Row>
 
-#### 3. Bring in additional colors and icons
+#### 5. Bring in additional colors and icons
 
 Use these additional IBM Design Language libraries to have access to color
 styles, hover color styles, text styles, icons, and pictograms.


### PR DESCRIPTION

Fixes a bullet content bug on the `Designing` --> ` Design Kits (Figma tab)`

---

**Changed**
- Fixed a bullet number in the External section.