### PR TITLE
fix: tooltip docs typo and bug

### DIFF
--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -337,8 +337,8 @@ or link.
 ### Best practices
 
 - The content within a standard tooltip should be purely additional information
-  that is not critical for a user to read to complete a task. If the content is essential for the user to interpret concerning
-  their workflow, use a
+  that is not critical for a user to read to complete a task. If the content is
+  essential for the user to interpret concerning their workflow, use a
   [toggletip](https://carbondesignsystem.com/components/toggletip/usage/) for
   this information instead.
 

--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -176,6 +176,7 @@ interactive elements, such as a button, that a user needs to interact with.
     },
   ]}
 />
+
 ## Formatting
 
 ### Standard tooltip anatomy
@@ -336,9 +337,7 @@ or link.
 ### Best practices
 
 - The content within a standard tooltip should be purely additional information
-  that is not critical for a user to read to complete a task.
-- Standard tooltips appear on hover and are not focusable or read by screen
-  readers. If the content is essential for the user to interpret concerning
+  that is not critical for a user to read to complete a task. If the content is essential for the user to interpret concerning
   their workflow, use a
   [toggletip](https://carbondesignsystem.com/components/toggletip/usage/) for
   this information instead.


### PR DESCRIPTION
**Changed**

- Fixed a sentence where there was incorrect information about screenreaders.
- Fixed a spacing bug with a heading being too close to the live demo, causing it to stylistically break.