### PR TITLE
fix(pictograms): hide watsonx pictograms from carbon-website

### DIFF
--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -27,7 +27,10 @@ const IconCategory = ({ category, pictograms, columnCount }) => {
               pictogram.name === 'ibm--z' ||
               pictogram.name === 'ibm--z--partition' ||
               pictogram.name === 'ibm--z-and-linuxone-multi-frame' ||
-              pictogram.name === 'ibm--z-and-linuxone-single-frame'
+              pictogram.name === 'ibm--z-and-linuxone-single-frame' ||
+              pictogram.name === 'watsonx--ai' ||
+              pictogram.name === 'watsonx--data' ||
+              pictogram.name === 'watsonx--governance'
             ) {
               return false;
             }


### PR DESCRIPTION
[Internal issue here](https://github.ibm.com/brand/Pictograms/issues/192)

> These three may or may not be replaced by new artwork, which is why we don't want to fully deprecate them just yet.

https://ibm-studios.slack.com/archives/C06110G3J9E/p1696868173709569

#### To Review

- Verify `watsonx--ai.svg`, `watsonx--data.svg`, and `watsonx--governance.svg` do not show on the pictogram index/library
