### PR TITLE
Update get-started.mdx

### DIFF
--- a/src/pages/contributing/get-started.mdx
+++ b/src/pages/contributing/get-started.mdx
@@ -82,7 +82,7 @@ bandwidth.
 This work involves enhancing our components in code, like adding new features or
 variants. Designers are often responsible for researching UX and visual
 solutions and then creating a design spec for developers.
-[Here are issues](https://github.com/carbon-design-system/carbon/issues?q=is%3Aissue+is%3Aopen+label%3A%22proposal%3A+accepted%22+label%3A%22community+contribution%22+label%3A%22type%3A+enhancement+%F0%9F%92%A1%22+)
+[Here are issues](https://github.com/carbon-design-system/carbon/issues?q=is%3Aopen+is%3Aissue+label%3A%22needs%3A+community+contribution%22+)
 in our enhancement backlog that need design or development work.
 
 ### Design kits


### PR DESCRIPTION
Replaced link to Github Issues

Since we changed a tag in our Github issues from 'community contribution' to 'needs: community contribution' the link needed to be updated.
