### PR TITLE
Update in step-1.mdx

### DIFF
--- a/src/pages/developing/react-tutorial/step-1.mdx
+++ b/src/pages/developing/react-tutorial/step-1.mdx
@@ -184,8 +184,8 @@ re-compile. Once finished re-compiling the Carbon base styling is applied (IBM
 Plex Sans font family, font size, weight, colors, etc.)
 
 Re-compiling all of the Carbon Sass takes a while, even on fast systems. Let's
-speed this up by moving our custom app Sass into a separate file, `app.scss` in
-the 'src' directory, and import that from `App.js`.
+speed this up by moving our custom app Sass into a separate file. Create an empty file `app.scss` in
+the 'src' directory, and then import it in `App.js`.
 
 ```javascript path=src/App.js
 import './app.scss';


### PR DESCRIPTION
Closes #

Just adding some detail to instructions about creating an empty `app.scss` file. 
The parts in the tutorial about recompiling starting on `line 182` are still unclear to me as their meaning. 
So, I hope the creation of this empty file is the right way to go and it seems a good idea to make it explicit.

#### Changelog

**New**

- Included "(...) a separate file. Create an empty file `app.scss` in the 'src' directory, and then import it in (...)"

**Changed**

- The line "speed this up by moving our custom app Sass into a separate file, `app.scss` in
the 'src' directory, and import that from `App.js`."

**Removed**

- Some words and punctuation.
