### PR TITLE
Fix link to TimePicker usage in DatePicker usage.mdx

### DIFF
--- a/src/pages/components/date-picker/usage.mdx
+++ b/src/pages/components/date-picker/usage.mdx
@@ -46,7 +46,7 @@ You can customize the time picker's format depending on location or need.
 | -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | [Simple date input](/components/date-picker/usage#simple-date-input) | Use if the date can be remembered by the user easily, such as a date of birth, and they don’t need a calendar to anticipate the dates. It consists only of input fields.                                                                   |
 | [Calendar picker](/components/date-picker/usage#calendar-pickers)    | Use a calendar picker (single or range) when the user needs to know a date's relationship to other days or when a date could be variable. The user can view and pick dates from a calendar widget or manually type them in the text field. |
-| [Time picker](/date-picker/usage#time-pickers)                       | Use when asking the user to input a specific time.                                                                                                                                                                                         |
+| [Time picker](/components/date-picker/usage#time-pickers)            | Use when asking the user to input a specific time.                                                                                                                                                                                         |
 
 ## Live demo
 


### PR DESCRIPTION
Current link is missing the `/components` portion of the link and instead takes the user to a 404 page

#### Changelog

**Changed**

- date-picker usage link to `time-pickers` fragment within page
