### PR TITLE
fix: broken link in chatbot pattern docs

### DIFF
--- a/src/pages/community/patterns/chatbot/content.mdx
+++ b/src/pages/community/patterns/chatbot/content.mdx
@@ -88,7 +88,7 @@ Ensure the success of your bot by following these principles:
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="IBM Design for AI: Conversation"
-      href="http://ai-design.eu-de.mybluemix.net/design/ai/conversation/planning"
+      href="https://www.ibm.com/design/ai/conversation/planning"
     >
       <MdxIcon name="bee" />
     </ResourceCard>


### PR DESCRIPTION
Closes #3812 

Fixes a broken resource card link on the: Patterns > Chatbot > Content tab > `Resources section`

---

**Changed**

- fixed broken resource card link