### PR TITLE
fix(website-pictograms): unhide watsonx pictograms

### DIFF
--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -27,10 +27,7 @@ const IconCategory = ({ category, pictograms, columnCount }) => {
               pictogram.name === 'ibm--z' ||
               pictogram.name === 'ibm--z--partition' ||
               pictogram.name === 'ibm--z-and-linuxone-multi-frame' ||
-              pictogram.name === 'ibm--z-and-linuxone-single-frame' ||
-              pictogram.name === 'watsonx--ai' ||
-              pictogram.name === 'watsonx--data' ||
-              pictogram.name === 'watsonx--governance'
+              pictogram.name === 'ibm--z-and-linuxone-single-frame'
             ) {
               return false;
             }


### PR DESCRIPTION
Continuation of https://github.com/carbon-design-system/carbon/pull/15116 to unhide pictograms that were previously hidden.