### PR TITLE
Added missing anchor link

### DIFF
--- a/src/pages/contributing/get-started.mdx
+++ b/src/pages/contributing/get-started.mdx
@@ -16,6 +16,7 @@ designers and developers. Anyone can contribute code, design, and documentation.
 <AnchorLinks>
 
 <AnchorLink>Get started</AnchorLink>
+<AnchorLink>Contribution gallery</AnchorLink>
 <AnchorLink>Carbon champions</AnchorLink>
 <AnchorLink>Types of contribution</AnchorLink>
 <AnchorLink>The process</AnchorLink>


### PR DESCRIPTION
Just a quick bug fix
- Added missing H2 anchor link for the contribution gallery.

