### PR TITLE
[Doc] Update Radio Button Website: Selectable Components

### DIFF
--- a/src/pages/components/radio-button/accessibility.mdx
+++ b/src/pages/components/radio-button/accessibility.mdx
@@ -40,10 +40,11 @@ other accessibility considerations, some of which are described below.
 
 ### Keyboard interaction
 
-A group of radio buttons takes a single tab stop. Carbon requires an item to be
-selected by default, and this item will always take focus. The user changes the
-selected radio button using the arrow keys (up/down or left/right). Pressing
-`Tab` again will move focus out of the radio button group to the next component.
+A group of radio buttons takes a single tab stop. Carbon does not requires any
+item to be selected by default, and the first item will always take focus in
+case of no selection. The user changes the selected radio button using the arrow
+keys (up/down or left/right). Pressing `Tab` again will move focus out of the
+radio button group to the next component.
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/components/radio-button/usage.mdx
+++ b/src/pages/components/radio-button/usage.mdx
@@ -103,7 +103,7 @@ buttons, a group label can be added.
 1. **Group label (optional):** Describes the group of options or provides
    guidance for making a selection.
 2. **Radio button input:** A radio button indicating the appropriate state. By
-   default an option is selected.
+   default no option will be preselected.
 3. **Radio button label:** Describes the information you want to select or
    unselect.
 
@@ -232,9 +232,11 @@ For further content guidance, see Carbon's
 ### States
 
 The radio button input allows for two states: **unselected** and **selected**.
-The default view of a radio button is having at least one radio button
-preselected. Only one radio button should be selected at a time. When a user
-chooses a new item, the previous choice is automatically deselected.
+The default view of a radio button is having no radio button preselected. Only
+one radio button should be selected at a time. When a user chooses a new item,
+the previous choice is automatically deselected. If the user has already
+selected an item but wanted to deselect it, consider adding alternatives such as
+an "other" or "none" option.
 
 <Row>
 <Column colLg={8}>
@@ -289,7 +291,7 @@ accessible click target.
 
 #### Keyboard
 
-One radio button should be selected by default. Users can navigate between radio
+By default, no option will be preselected. Users can navigate between radio
 button inputs by pressing `Up` or `Down` arrow keys. If a user lands on a radio
 button set without a default indicator, they can press `Space` to select the
 radio button or they can press an arrow key to select the next radio button. For


### PR DESCRIPTION
Closes #

### Updating the Radio Button website documentation with what came out of our https://github.com/carbon-design-system/carbon/issues/14766.

Change our guidance to not mention we have radio button items preselected by default. This occurs in the "Behavior" section and "Accessibility", also check if it is anywhere else.

--- 
Ref:
- [Related Issue](https://github.com/carbon-design-system/carbon-website/issues/3863#issue-2064491421)
- [Figma File](https://www.figma.com/file/w4QA4bnNZAiySPskA5qZMW/Selectable-Components?type=design&node-id=723-4941&mode=design&t=4MRKVtTycBZOqLzJ-4)