### PR TITLE
add missing contributor to `gantt charts` page

### DIFF
--- a/src/pages/data-visualization/gantt-charts/index.mdx
+++ b/src/pages/data-visualization/gantt-charts/index.mdx
@@ -26,7 +26,19 @@ our roadmap, make feature requests, or contribute, please go to the
   <Column colLg={4} colMd={4} noGutterSm>
     <ResourceCard
       subTitle="Gantt Chart Kit (Alpha)"
-      href="https://www.figma.com/file/nQJ9Y5u3s7zPHGjceT4eLY/Gantt-Chart-Figma-Kit-(Alpha)?type=design&node-id=2511%3A2877&mode=design&t=sezx9sBtLyWdcPbE-1"
+      href="https://www.figma.com/file/nQJ9Y5u3s7zPHGjceT4eLY/(Alpha)-Carbon-Gantt-Chart-Library?type=design&node-id=5284%3A423754&mode=design&t=8kurHvxJyiVziXNz-1"
+      actionIcon="launch"
+      target="_blank"
+      rel="noopener"
+    >
+      <MdxIcon name="figma" />
+    </ResourceCard>
+  </Column>
+
+  <Column colLg={4} colMd={4} noGutterSm>
+    <ResourceCard
+      subTitle="Documentation"
+      href="https://www.figma.com/file/FurnT9pJvtQn9G2GnuWK2T/(Alpha)-Carbon-Gantt-Chart-Kit?type=design&node-id=3711%3A6208&mode=design&t=lI1ZAzzbSfjt4OTN-1"
       actionIcon="launch"
       target="_blank"
       rel="noopener"

--- a/src/pages/data-visualization/gantt-charts/index.mdx
+++ b/src/pages/data-visualization/gantt-charts/index.mdx
@@ -69,3 +69,4 @@ instrumental in bringing these insightful resources to fruition.
 - Amaya Mali
 - Valerie Garza
 - Dana Paslaru
+- Juan Encalada


### PR DESCRIPTION
Missed Juan Encalada's name here in the doc, now it's added