### PR TITLE
docs: fix broken charts links

### DIFF
--- a/src/pages/data-visualization/chart-types/index.mdx
+++ b/src/pages/data-visualization/chart-types/index.mdx
@@ -230,7 +230,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm>
  <OverviewCard
     title="Tree map"
-    href="/data-visualization/complex-charts#tree-maps"
+    href="/data-visualization/spatial-charts/#tree-maps"
     >
 
 ![GATSBY_EMPTY_ALT](images/treemap.svg)
@@ -241,7 +241,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm>
  <OverviewCard
     title="Circle pack"
-    href="/data-visualization/complex-charts#circle-packs"
+    href="/data-visualization/spatial-charts/#circle-packs"
     >
 
 ![GATSBY_EMPTY_ALT](images/circle-pack.svg)
@@ -267,7 +267,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Heat map"
-    href="/data-visualization/complex-charts#heat-maps"	       
+    href="/data-visualization/spatial-charts/#heat-maps"	       
     >
 
 ![GATSBY_EMPTY_ALT](images/heatmap.svg)
@@ -277,7 +277,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Parallel coordinates"
-    href="/data-visualization/complex-charts#parallel-coordinates"	       
+    href="/data-visualization/flow-charts/#parallel-coordinates"	       
     tag="Design only"
     >
 
@@ -293,7 +293,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Alluvial diagram"
-    href="/data-visualization/complex-charts#alluvialsankey-diagrams"
+    href="/data-visualization/flow-charts/#alluvialsankey-diagrams"
     >
 
 ![GATSBY_EMPTY_ALT](images/alluvial.svg)
@@ -304,7 +304,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Network diagram"
-    href="/data-visualization/complex-charts#network-diagrams"
+    href="/data-visualization/flow-charts/#network-diagrams"
     >
 
 ![GATSBY_EMPTY_ALT](images/network-diagram.svg)
@@ -315,7 +315,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Tree diagram"
-    href="/data-visualization/complex-charts#tree-diagrams"
+    href="/data-visualization/flow-charts/#tree-diagrams"
     >
 
 ![GATSBY_EMPTY_ALT](images/treediagram.svg)
@@ -330,7 +330,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Choropleth map"
-    href="/data-visualization/complex-charts#geographic-overlays"
+    href="/data-visualization/spatial-charts/#geospatial-charts"
     tag="Design only"
     >
 
@@ -341,7 +341,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Proportional symbol"
-    href="/data-visualization/complex-charts#proportional-symbol-map"
+    href="/data-visualization/spatial-charts/#proportional-symbol-map"
     tag="Design only"
     >
 
@@ -352,7 +352,7 @@ appropriate chart type.
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
     title="Connecting lines"
-    href="/data-visualization/complex-charts#connection-map"
+    href="/data-visualization/spatial-charts/#connection-map"
     tag="Design only"
     >
 

--- a/src/pages/data-visualization/chart-types/index.mdx
+++ b/src/pages/data-visualization/chart-types/index.mdx
@@ -351,7 +351,7 @@ appropriate chart type.
 </Column>
 <Column  colMax={3} colXl={3} colLg={4} colMd={4} colSm={2} noGutterSm >
  <OverviewCard
-    title="Connecting lines"
+    title="Connection map"
     href="/data-visualization/spatial-charts/#connection-map"
     tag="Design only"
     >


### PR DESCRIPTION
Closes  #3910 

- Fixes a broken link mentioned in the issue specifically for the "Network diagrams"card on the Data visualizations > [Chart types page](https://carbondesignsystem.com/data-visualization/chart-types/)
- Fixes several other broken links for these cards on this page:
  - Tree map
  - Circle pak
  - Heat map
  - Parallel coordinates
  - Alluvial diagram
  - Tree diagram
  - Choropleth map
  - Proportional symbol
  - Connecting lines

------

**Changed**

- Fixed links that were 404ing

