### PR TITLE
[Website] Add carbon native mobile Figma kit link

### DIFF
--- a/src/pages/designing/design-resources/index.mdx
+++ b/src/pages/designing/design-resources/index.mdx
@@ -200,9 +200,8 @@ project underway.
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="Figma kit coming soon"
-    disabled
-    href=""
+    subTitle="(Beta) Carbon Native"
+    href="https://www.figma.com/file/O3KSDu2TWpMaazGkgsKqLA/(Beta)-Carbon-Native---Carbon-Design-System?type=design&node-id=58%3A2763&mode=design&t=tXtq2rcaczpgvPSa-1"
     actionIcon="launch">
     <MdxIcon name="figma" />
   </ResourceCard>


### PR DESCRIPTION
Closes #[#3879](https://github.com/carbon-design-system/carbon-website/issues/3879)

Update the new Beta Carbon Native link for mobile on our Website https://carbondesignsystem.com/designing/design-resources/#native-mobile
