### PR TITLE
fix: h3 heading spacing on a11y component pages

### DIFF
--- a/src/components/A11yStatus/A11yStatus.js
+++ b/src/components/A11yStatus/A11yStatus.js
@@ -373,32 +373,30 @@ const A11yStatus = ({ components, layout }) => {
   } else {
     return (
       <>
-        <Row>
-          <Column colLg={12}>
-            {components ? (
-              <H3>
-                <span id="accessibility-testing-status">
-                  Accessibility testing status
-                </span>
-                {helpTooltip}
-              </H3>
-            ) : (
-              <>
-                <span
-                  id="all-component-accessibility-status-anchor"
-                  className={headingLink}></span>
-                <H2>All component accessibility status{helpTooltip}</H2>
-                <p>
-                  This table reflects the current AVT status of stable
-                  components within @carbon/react.
-                </p>
-              </>
-            )}
-            <p className={version}>
-              <strong>Latest version:</strong> {reactVersion} |{' '}
-              <strong>Framework:</strong> React (@carbon/react)
+        {components ? (
+          <H3>
+            <span id="accessibility-testing-status">
+              Accessibility testing status
+            </span>
+            {helpTooltip}
+          </H3>
+        ) : (
+          <>
+            <span
+              id="all-component-accessibility-status-anchor"
+              className={headingLink}></span>
+            <H2>All component accessibility status{helpTooltip}</H2>
+            <p>
+              This table reflects the current AVT status of stable components
+              within @carbon/react.
             </p>
-          </Column>
+          </>
+        )}
+        <p className={version}>
+          <strong>Latest version:</strong> {reactVersion} |{' '}
+          <strong>Framework:</strong> React (@carbon/react)
+        </p>
+        <Row>
           <Column
             colLg={12}
             noGutterSm

--- a/src/components/A11yStatus/A11yStatus.module.scss
+++ b/src/components/A11yStatus/A11yStatus.module.scss
@@ -27,11 +27,6 @@
   }
 }
 
-// table view
-.table {
-  margin-top: $spacing-06;
-}
-
 // card view
 .dropdown {
   :global(.cds--dropdown) {


### PR DESCRIPTION
Closes #3920

h3 was getting double the margin because it was nested inside a row it didn't need to be in. This moves it outside of the row and removes the spacing override.

### Testing
Check that spacing looks correct above the h3 on component a11y pages
https://carbondesignsystem-git-fork-alisonj-2cc420-carbon-design-system.vercel.app/components/breadcrumb/accessibility
