### PR TITLE
docs: remove nonexistent anchor link in file uploader docs

### DIFF
--- a/src/pages/components/file-uploader/usage.mdx
+++ b/src/pages/components/file-uploader/usage.mdx
@@ -21,7 +21,6 @@ location.
 <AnchorLink>Overview</AnchorLink>
 <AnchorLink>Formatting</AnchorLink>
 <AnchorLink>Content</AnchorLink>
-<AnchorLink>Universal behaviors</AnchorLink>
 <AnchorLink>File uploader</AnchorLink>
 <AnchorLink>Drag and drop file uploader</AnchorLink>
 <AnchorLink>References</AnchorLink>


### PR DESCRIPTION

- Removes an anchor link to a section that does not exist on the File uploader docs on the Usage tab.

---

#### Changelog

**Removed**

- removed anchor link
