### PR TITLE
fix(web-components): correct codesandbox links

### DIFF
--- a/src/pages/developing/frameworks/web-components.mdx
+++ b/src/pages/developing/frameworks/web-components.mdx
@@ -54,7 +54,7 @@ Info on Carbon Web Components v1 can be found
   <Column colMd={4} colLg={4} noGutterSm>
     <ResourceCard
       subTitle="Try web components with CodeSandbox"
-      href="https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/feat/cwc-v2/packages/carbon-web-components/examples/codesandbox/basic"
+      href="https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components/examples/codesandbox/basic"
     >
       <MdxIcon name="codesandbox" />
     </ResourceCard>
@@ -186,7 +186,7 @@ directly used once the script tag has been added to the page. For example:
 Our example at [CodeSandbox](https://codesandbox.io) shows usage with only CDN
 artifacts:
 
-[![Edit @carbon/web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/feat/cwc-v2/packages/carbon-web-components/examples/codesandbox/cdn)
+[![Edit @carbon/web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components/examples/codesandbox/cdn)
 
 ### Using ES imports
 
@@ -210,7 +210,7 @@ yarn add @carbon/web-components
 
 Our example at [CodeSandbox](https://codesandbox.io) shows the most basic usage:
 
-[![Edit @carbon/web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/feat/cwc-v2/packages/carbon-web-components/examples/codesandbox/basic)
+[![Edit @carbon/web-components](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/github/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components/examples/codesandbox/basic)
 
 The first thing you need to do is **set up a module bundler** to resolve
 ECMAScript `import`s. The above example uses [Webpack](https://webpack.js.org)
@@ -266,7 +266,7 @@ Angular, Carbon Vue).
 
 If you experience any issues while getting set up with Carbon Web Components,
 please head over to the
-[GitHub repo](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/feat/cwc-v2/packages/carbon-web-components)
+[GitHub repo](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/tree/main/packages/carbon-web-components)
 for more guidelines and support. Please
 [create an issue](https://github.com/carbon-design-system/carbon-for-ibm-dotcom/issues)
 if your issue does not already exist.


### PR DESCRIPTION
Closes #

The codesandbox links in the [Web Components Framework page](https://carbondesignsystem.com/developing/frameworks/web-components/#using-es-imports) are out of date, pointing to the no longer existing `feat/cwc-v2` branch. This should be pointing to `main` now that v2 has been released

#### Changelog

**Changed**

- Codesandbox links should point to `main` branch
