### PR TITLE
add dataviz kit Figma link

### DIFF
--- a/src/pages/data-visualization/getting-started/index.mdx
+++ b/src/pages/data-visualization/getting-started/index.mdx
@@ -40,9 +40,8 @@ requests to the
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
-    subTitle="Figma kit coming soon"
-    href=""
-    disabled
+    subTitle="Figma kit"
+    href="https://www.figma.com/community/file/1342888187036080999"
     actionIcon="launch"
   >
     <MdxIcon name="figma" />


### PR DESCRIPTION
![image](https://github.com/carbon-design-system/carbon-website/assets/14989804/79c04af6-23e6-4236-9a18-8888a5187f4e)

enables the 3rd item here and adds the kit link to it