### PR TITLE
fix: 404 page links and styles

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -3,7 +3,7 @@ import { FourOhFour } from 'gatsby-theme-carbon';
 
 const links = [
   { href: '/all-about-carbon/what-is-carbon', text: 'All about Carbon' },
-  { href: '/components/overview', text: 'Components overview' },
+  { href: '//omponents/overview/components', text: 'Components overview' },
   { href: '/designing/get-started', text: 'Get started designing' },
   { href: '/developing/get-started', text: 'Get started developing' },
 ];

--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -2,12 +2,6 @@
   margin-top: 3rem;
 }
 
-[class^='FourOhFour-module--container'],
-[class^='FourOhFour-module--link'],
-[class^='FourOhFour-module--link']:before {
-  color: $text-inverse !important;
-}
-
 // allow tooltips to be visible outside edge of table
 // table needs overflow at mobile to scroll
 .page-table__container {


### PR DESCRIPTION
Reported in slack


#### Changelog

- remove style overrides that were causing 404 page to render with inverse text color
- update link to component overview on 404 page