### PR TITLE
docs: fix incorrect image name for tag docs

### DIFF
--- a/src/pages/components/tag/usage.mdx
+++ b/src/pages/components/tag/usage.mdx
@@ -216,7 +216,7 @@ middle, or end, depending on what is best for the given use case.
 <Row>
 <Column colLg={8}>
 
-![Truncated tag title disclosed in a tooltip on hover by mouse and on focus by keyboard.](images/tag-usage-placement.png)
+![Truncated tag title disclosed in a tooltip on hover by mouse and on focus by keyboard.](images/tag-usage-overflow.png)
 
 </Column>
 </Row>


### PR DESCRIPTION
In the [Overflow content](https://carbondesignsystem.com/components/tag/usage/#overflow-content) section on the Tag usage tab docs, an incorrect image name was triggering the wrong image for the section. This PR corrects the name in the code to show the correct image. 

#### Changed
- Changed name of image.