### PR TITLE
docs: remove unused anchor link for content switcher

### DIFF
--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -24,7 +24,6 @@ within the same space on the screen.
 <AnchorLink>Behaviors</AnchorLink>
 <AnchorLink>Modifiers</AnchorLink>
 <AnchorLink>Related</AnchorLink>
-<AnchorLink>References</AnchorLink>
 <AnchorLink>Feedback</AnchorLink>
 
 </AnchorLinks>


### PR DESCRIPTION
- Removes the "References" anchor link from the Content Switcher Usage tab page, because there is not a References section.

---

**Changed**
- Removed unused anchor link.