### PR TITLE
fix broken aspect ratio link

### DIFF
--- a/src/pages/elements/2x-grid/usage.mdx
+++ b/src/pages/elements/2x-grid/usage.mdx
@@ -195,7 +195,7 @@ through a product. Although images are used much less frequently in products
 than in digital experiences, aspect ratios come into play often in product with
 the tile component, which is used frequently in catalogs and dashboards.
 
-Refer back to the [aspect ratios](/guidelines/2x-grid/overview/#aspect-ratio)
+Refer back to the [aspect ratios](/elements/2x-grid/overview/#aspect-ratio)
 section on the 2x Grid Overview tab to see a list of the most commonly used
 aspect ratios across the Carbon ecosystem. We understand that it’s not always
 possible for every image or container to be one of these sizes. However it’s


### PR DESCRIPTION
aspect ratio link does not currently go to direct aspect ratio section. updated link to go directly to correct anchor link.
