### PR TITLE
fix: remove table to fix warning

### DIFF
--- a/src/components/A11yStatus/A11yStatus.js
+++ b/src/components/A11yStatus/A11yStatus.js
@@ -24,7 +24,6 @@ import {
   help,
   hidden,
   moreLink,
-  table,
   variant,
   version,
   headingLink,


### PR DESCRIPTION
Fixes warning that was being displayed when running yarn dev or building
```
warn ./src/components/A11yStatus/A11yStatus.js
Attempted import error: 'table' is not exported from './A11yStatus.module.scss' (imported as 'table').
```

### Testing
make sure warning message is gone