### PR TITLE
Bug: Add H2 for Formatting

### DIFF
--- a/src/pages/components/toggletip/usage.mdx
+++ b/src/pages/components/toggletip/usage.mdx
@@ -113,6 +113,8 @@ Don't use to present critical information or request required input needed to
 complete a workflow. Use the [modal component](/components/modal/usage/)
 instead.
 
+## Formatting
+
 ### Anatomy
 
 <Row>


### PR DESCRIPTION
The H2 heading for the formatting section was missing on the Toggletip page.
