### PR TITLE
revised first sentence under Typography

### DIFF
--- a/src/pages/components/notification/style.mdx
+++ b/src/pages/components/notification/style.mdx
@@ -57,8 +57,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Typography
 
-Write notifications in sentence case, which means only the first word
-is capitalized. Notification titles should be concise and to the point.
+Write notifications in sentence case, which means only the first word is
+capitalized. Notification titles should be concise and to the point.
 
 | Element  | Font-size (px/rem) | Font-weight    | Type token            |
 | -------- | ------------------ | -------------- | --------------------- |

--- a/src/pages/components/notification/style.mdx
+++ b/src/pages/components/notification/style.mdx
@@ -57,8 +57,8 @@ tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 
 ## Typography
 
-Notification text should be set in sentence case with only the first word
-capitalized. Notification titles should be concise and to the point.
+Write notifications in sentence case, which means only the first word
+is capitalized. Notification titles should be concise and to the point.
 
 | Element  | Font-size (px/rem) | Font-weight    | Type token            |
 | -------- | ------------------ | -------------- | --------------------- |


### PR DESCRIPTION
Closes #

Changed 

`Notification text should be set in sentence case with only the first word capitalized.`

to be more direct and prescriptive:

`Write notifications in sentence case, which means only the first word is capitalized.`
