### PR TITLE
Incorrect reference to Figma property

### DIFF
--- a/src/pages/elements/2x-grid/overview.mdx
+++ b/src/pages/elements/2x-grid/overview.mdx
@@ -400,7 +400,7 @@ it to the top or bottom margin of a box:
 
   </DoDont>
 
-  <DoDont type="dont" caption="In Figma, always use “Auto Height” in the Text panel to ensure the text box fits with the content. Spacer snaps to the text box.">
+  <DoDont type="dont" caption="In Figma, always use “Auto height” in the Text panel to ensure the text box fits with the content. Spacer snaps to the text box.">
 
 ![Always use “Auto” in alignment to ensure the text box fits with the content. Spacer snaps to the text box.](images/Layout_overview_Visual-rhythm-dont.svg)
 

--- a/src/pages/elements/2x-grid/overview.mdx
+++ b/src/pages/elements/2x-grid/overview.mdx
@@ -400,9 +400,9 @@ it to the top or bottom margin of a box:
 
   </DoDont>
 
-  <DoDont type="dont" caption="In Figma, always use “Auto width” in the Text panel to ensure the text box is fitting with the content. Spacer snaps to the text box.">
+  <DoDont type="dont" caption="In Figma, always use “Auto Height” in the Text panel to ensure the text box fits with the content. Spacer snaps to the text box.">
 
-![Always use “Auto” in alignment to ensure the text box is fitting with the content. Spacer snaps to the text box.](images/Layout_overview_Visual-rhythm-dont.svg)
+![Always use “Auto” in alignment to ensure the text box fits with the content. Spacer snaps to the text box.](images/Layout_overview_Visual-rhythm-dont.svg)
 
   </DoDont>
 </DoDontRow>


### PR DESCRIPTION
The caption referenced "Auto Width" when the example was showing "Auto Height".

#### Changelog

**Changed**

-  switched the text to say "Auto Height"
- fixed a few grammatically incorrect phrases in similar captions
