### PR TITLE
docs: remove reference to carbon-components slack channel

### DIFF
--- a/src/pages/designing/get-started.mdx
+++ b/src/pages/designing/get-started.mdx
@@ -146,7 +146,6 @@ fellow designers. Chances are someone has had a similar problem to you and will
 jump in to help you out.
 
 - [#carbon-design-system](https://ibm-studios.slack.com/messages/C0M053VPT/)
-- [#carbon-components](https://ibm-studios.slack.com/archives/C046Y0YUD)
 - [#carbon-tutorial](https://ibm-studios.slack.com/archives/CJUGA7P6H)
 
 And be sure to sign up for the latest Carbon news at


### PR DESCRIPTION
On the Designing > [Get started page](https://carbondesignsystem.com/designing/get-started/#join-us-and-the-carbon-community)

- Removes a link to the [#carbon-components](https://ibm-studios.slack.com/archives/C046Y0YUD) slack channel which we have recently archived.

---

**Removed**

- Removed link.
