### PR TITLE
bug: incorrect chat kit link

### DIFF
--- a/src/pages/guidelines/carbon-for-ai/index.mdx
+++ b/src/pages/guidelines/carbon-for-ai/index.mdx
@@ -317,7 +317,7 @@ components, and generals chat usage guidelines.
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Chat component library"
-    href="https://www.figma.com/file/tOT3OKhwLm7xObQPy3pHtc/(Alpha)-Carbon-Charts-Library?type=design&node-id=2511-2877&mode=design&t=6DRCuLLwambWGN5P-0"
+    href="https://www.figma.com/design/j6Wh5Ud6cDLwlx1i4pmQo7/Chat-Component-Library---Carbon-for-AI?m=auto"
     actionIcon="launch">
     <MdxIcon name="figma" />
   </ResourceCard>


### PR DESCRIPTION
The chat library was linking to the charts kit instead of the chat one. Updated to link to the correct "Chat component library" figma file. 