### PR TITLE
Remove v11 banner

### DIFF
--- a/src/pages/components/UI-shell-header/usage.mdx
+++ b/src/pages/components/UI-shell-header/usage.mdx
@@ -16,16 +16,6 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** The UI shell is now themeable and has been updated to use inline
-theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each theme's styles. For v10 implementation
-guidance, go to
-[v10 UI Shell–Header](https://v10.carbondesignsystem.com/components/UI-shell-header/usage).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/UI-shell-left-panel/usage.mdx
+++ b/src/pages/components/UI-shell-left-panel/usage.mdx
@@ -16,16 +16,6 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** The UI shell is now themeable and has been updated to use inline
-theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each theme's styles. For v10 implementation
-guidance, go to
-[v10 UI Shell–Left panel](https://v10.carbondesignsystem.com/components/UI-shell-left-panel/usage/).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/UI-shell-right-panel/usage.mdx
+++ b/src/pages/components/UI-shell-right-panel/usage.mdx
@@ -16,16 +16,6 @@ interaction patterns that persist between and across products.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** The UI shell is now themeable and has been updated to use inline
-theming. The UI shell uses Carbon theme tokens instead of component specific
-tokens and the color will follow each theme's styles. For v10 implementation
-guidance, go to
-[v10 UI Shell–Right panel](https://v10.carbondesignsystem.com/components/UI-shell-right-panel/usage/).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/menu-buttons/usage.mdx
+++ b/src/pages/components/menu-buttons/usage.mdx
@@ -15,14 +15,6 @@ menu with a list of interactive options.
 
 </PageDescription>
 
-<InlineNotification>
-
-**New in Carbon v11!** Apart from the overflow menu, the menu button and combo
-button components have been added to our system and they are only available in
-v11.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/menu/usage.mdx
+++ b/src/pages/components/menu/usage.mdx
@@ -15,13 +15,6 @@ element or perform a specific action.
 
 </PageDescription>
 
-<InlineNotification>
-
-**New in Carbon v11!** Menu is a new component we have added to our system and
-is only available in v11.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -17,16 +17,6 @@ actionable notifications.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** An actionable variant has been added to the notification
-component. Actionable notifications allow for interactive elements within a
-notification, like buttons. Toast and inline notification no longer allow any
-interactive elements. For v10 implementation guidance, go to
-[v10 Notification](https://v10.carbondesignsystem.com/components/notification/usage/).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/toggletip/usage.mdx
+++ b/src/pages/components/toggletip/usage.mdx
@@ -18,14 +18,6 @@ element and can contain interactive elements.
 
 </PageDescription>
 
-<InlineNotification>
-
-**New in v11:** Toggletip should be used in place of tooltip if your content
-will contain interactive elements. If it does not have any interactive content,
-consider using [Tooltip](/components/tooltip/usage/) instead.
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/components/tooltip/usage.mdx
+++ b/src/pages/components/tooltip/usage.mdx
@@ -16,17 +16,6 @@ clarity to a user.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** The tooltip component has been refactored to use the
-[popover](/components/popover/usage/) component under the hood to improve
-accessibility. Interactive tooltips now use the
-[toggletip](/components/toggletip/usage/) component to achieve accessibility
-standards. For v10 implementation guidance, see the
-[v10 tooltip](https://v10.carbondesignsystem.com/components/tooltip/usage/).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Live demo</AnchorLink>

--- a/src/pages/elements/color/tokens.mdx
+++ b/src/pages/elements/color/tokens.mdx
@@ -8,17 +8,6 @@ tabs: ['Overview', 'Usage', 'Tokens', 'Code']
 
 import ColorTokenTable from 'components/ColorTokenTable';
 
-<InlineNotification>
-
-**v11 update:** Color tokens underwent a major renaming in version 11. Visually
-components and styles look the same across v10 and v11, but the token names have
-changed significantly to improve usability and extend theming functionality.
-This website and page contain only the v11 tokens. Helpful links:
-[v10 color tokens](https://v10.carbondesignsystem.com/guidelines/color/usage) |
-[Color token migration guide](/migrating/guide/design#color-tokens-breaking).
-
-</InlineNotification>
-
 ## Tokens by theme
 
 <ColorTokenTable />

--- a/src/pages/elements/color/usage.mdx
+++ b/src/pages/elements/color/usage.mdx
@@ -82,13 +82,8 @@ layer 03. Layers stack one on top of the other in a set order. Each step in UI
 color (excluding interaction colors) is another layer and will require the use
 of a different set of layering tokens.
 
-<InlineNotification>
-
-**Migration note:** Previously, in v10 most color tokens had numeral endings,
-now in v11 only layering tokens will have this distinction. For more
-information, see the [migration guide](/migrating/guide/design#color-tokens).
-
-</InlineNotification>
+For more information about how color token migration works, see the
+[migration guide](/migrating/guide/design#color-tokens).
 
 #### Layer sets
 
@@ -224,15 +219,6 @@ Spec each component variant with its corresponding layering set. For elements
 that are not part of the layer sets like type or icons, apply color tokens as
 you normally would. Non-layer tokens will be the same across variants because
 they have enough contrast not to need a change with each layer.
-
-<InlineNotification>
-
-**Migration note:** In v10, the additional color variants were known as
-the light prop variants. The `light` variants now use the 02 layer set. These
-new tokens also allow for a third color variant using the 03 layer set in
-components that was not possible in v10.
-
-</InlineNotification>
 
 <Row>
 <Column colLg={8}>

--- a/src/pages/elements/typography/type-sets.mdx
+++ b/src/pages/elements/typography/type-sets.mdx
@@ -21,17 +21,6 @@ sets: expressive and productive.
 
 </PageDescription>
 
-<InlineNotification>
-
-**v11 update:** The two v10 type sets—Productive and Expressive—have been
-blended together to work as a unified collection in v11. As a result of this
-convergence, type token names have been renamed to better define their
-relationship to one another and reflect its styling. Helpful links:
-[v10 type tokens](https://v10.carbondesignsystem.com/guidelines/typography/overview)
-| [Type token migration guide](/migrating/guide/design#type-tokens-breaking).
-
-</InlineNotification>
-
 <AnchorLinks>
 
 <AnchorLink>Overview</AnchorLink>


### PR DESCRIPTION
Closes #[#4112](https://github.com/carbon-design-system/carbon-website/issues/4112)

Removed v11 notifications

#### Additional changes

- _Color usage tab_
-- Kept the migration link in the Usage tab
-- Removed the migration note of v10
