### PR TITLE
bugs: content switcher docs

### DIFF
--- a/src/pages/components/content-switcher/style.mdx
+++ b/src/pages/components/content-switcher/style.mdx
@@ -145,30 +145,22 @@ Each container that makes up the content switcher is equal in size.
 | Icon (lg)  | padding-left, padding-right | 14 / 0.875 | –             |
 | Divider    | border                      | 1px        | –             |
 
-### Text content switcher
+### Default structure
 
 The width of a text container is determined by the length of the longest label
 text within its content switcher.
 
 <div className="image--fixed">
 
-![Text content switcher structure and spacing measurements](images/content-switcher-style-1.png)
+![Text content switcher structure and spacing measurements](images/content-switcher-style-structure-text.png)
 
 </div>
-
-<Row>
-<Column colLg={8}>
-
-![Example of a content switcher](images/content-switcher-usage-1.png)
-
-</Column>
-</Row>
 
 <Caption>
   Structure and spacing measurements for the text content switcher | px / rem
 </Caption>
 
-### Icon content switcher
+### Icon-only structure
 
 The width of an icon container is determined by the fixed size within its
 content switcher.
@@ -183,7 +175,7 @@ content switcher.
   Structure and spacing measurements for the icon content switcher | px / rem
 </Caption>
 
-### Size
+## Size
 
 There are three content switcher sizes—small (32px), medium (40px), and large
 (48px).

--- a/src/pages/components/content-switcher/usage.mdx
+++ b/src/pages/components/content-switcher/usage.mdx
@@ -70,7 +70,7 @@ tool may use a content switcher to divide messages into three views such as
 
 ### When not to use
 
-### Distinct content areas
+#### Distinct content areas
 
 When navigating between distinct content areas like subpages, use
 [tabs](/components/tabs/usage) instead of a content switcher. Tabs follow the


### PR DESCRIPTION
Closes #

There were several formatting bugs on the content switcher page. 

#### Changelog

**Changed**

- Updated broken image
- Updated formatting bugs

**Removed**

- incorrect image
