### PR TITLE
fix(IconLibrary): hide ai icon from icon library search

### DIFF
--- a/src/components/SVGLibraries/IconLibrary/IconCategory.js
+++ b/src/components/SVGLibraries/IconLibrary/IconCategory.js
@@ -13,19 +13,23 @@ import {
 
 const IconCategory = ({ category, icons, columnCount }) => {
   const [subCategoryRef, containerIsVisible] = useIntersectionObserver();
+  const hiddenIcons = ['AI'];
+
   return (
     <section className={svgCategory}>
       <h2 className={cx(h2, categoryTitle)}>{category}</h2>
       <ul ref={subCategoryRef}>
         <ul className={svgGrid}>
-          {icons.map((icon, i) => (
-            <SvgCard
-              isLastCard={(i + 1) % columnCount === 0}
-              containerIsVisible={containerIsVisible}
-              key={icon.name}
-              icon={icon}
-            />
-          ))}
+          {icons
+            .filter((icon) => !hiddenIcons.includes(icon.name))
+            .map((icon, i) => (
+              <SvgCard
+                isLastCard={(i + 1) % columnCount === 0}
+                containerIsVisible={containerIsVisible}
+                key={icon.name}
+                icon={icon}
+              />
+            ))}
         </ul>
       </ul>
     </section>

--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -16,23 +16,19 @@ import {
 
 const IconCategory = ({ category, pictograms, columnCount }) => {
   const [sectionRef, containerIsVisible] = useIntersectionObserver();
+  const hiddenPictograms = [
+    'ibm--z',
+    'ibm--z--partition',
+    'ibm--z-and-linuxone-multi-frame',
+    'ibm--z-and-linuxone-single-frame',
+  ];
 
   return (
     <section ref={sectionRef} className={svgCategory}>
       <h2 className={cx(h2, categoryTitle)}>{category}</h2>
       <ul className={cx(svgGrid, pictogramList)}>
         {pictograms
-          .filter((pictogram) => {
-            if (
-              pictogram.name === 'ibm--z' ||
-              pictogram.name === 'ibm--z--partition' ||
-              pictogram.name === 'ibm--z-and-linuxone-multi-frame' ||
-              pictogram.name === 'ibm--z-and-linuxone-single-frame'
-            ) {
-              return false;
-            }
-            return true;
-          })
+          .filter((pictogram) => !hiddenPictograms.includes(pictogram.name))
           .map((pictogram, i) => (
             <SvgCard
               isLastCard={(i + 1) % columnCount === 0}


### PR DESCRIPTION
Closes #4164
related https://github.com/carbon-design-system/carbon/pull/16927

This PR hides the AI icon from the icon library and refactors the logic of the pictogram library exclusions to match the logic in the icon pibrary

#### Changelog

**Changed**

- exclude AI icon
- refactor pictogram exclusion logic to match icons
