### PR TITLE
fix: increase live demo size for ailabel to tall

### DIFF
--- a/src/pages/components/ai-label/code.mdx
+++ b/src/pages/components/ai-label/code.mdx
@@ -40,6 +40,7 @@ documentation, see the Storybooks for each framework below.
 
 <StorybookDemo
   themeSelector
+  tall
   url="https://react.carbondesignsystem.com"
   variants={[
     {

--- a/src/pages/components/ai-label/usage.mdx
+++ b/src/pages/components/ai-label/usage.mdx
@@ -39,6 +39,7 @@ been changed to better reflect its usage.
 
 <StorybookDemo
   themeSelector
+  tall
   url="https://react.carbondesignsystem.com"
   variants={[
     {


### PR DESCRIPTION
- update live demo for AI Label to tall size on code and usage pages
https://carbondesignsystem-git-fork-alisonj-075b5d-carbon-design-system.vercel.app/components/ai-label/usage/