### PR TITLE
fix: color token page breaks on switching themes to gray 90 and 100

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -4136,6 +4136,14 @@ const colorTokens = {
           name: 'White',
           hex: '#ffffff',
         },
+        g90: {
+          name: 'Gray 80 hover',
+          hex: '#474747',
+        },
+        g100: {
+          name: 'Gray 90 hover',
+          hex: '#333333',
+        },
       },
     },
     '$notification-action-tertiary-inverse': {


### PR DESCRIPTION
Closes #4239 

Color token pages break when switching themes

**New**

added color token for notification Gray 90 and Gray 100
