### PR TITLE
chore(husky): fix pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx --no-install lint-staged

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write 'src/**/*.{css,scss,json,html,yaml,md,mdx,js}'",
     "format:check": "prettier --check 'src/**/*.{css,scss,json,html,yaml,md,mdx,js}'",
     "update-browserslist": "npx browserslist-ga",
-    "postinstall": "husky"
+    "prepare": "husky"
   },
   "engines": {
     "node": ">=18.x"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "lint:js": "NODE_ENV=test eslint . --fix",
     "format": "prettier --write 'src/**/*.{css,scss,json,html,yaml,md,mdx,js}'",
     "format:check": "prettier --check 'src/**/*.{css,scss,json,html,yaml,md,mdx,js}'",
-    "update-browserslist": "npx browserslist-ga"
+    "update-browserslist": "npx browserslist-ga",
+    "postinstall": "husky"
   },
   "engines": {
     "node": ">=18.x"
@@ -68,11 +69,6 @@
     "markdown-loader": "^8.0.0",
     "prettier": "^2.0.2",
     "typescript": "^4.8.4"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   },
   "lint-staged": {
     "*.js": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -13488,11 +13488,11 @@ __metadata:
   linkType: hard
 
 "husky@npm:^9.0.11":
-  version: 9.0.11
-  resolution: "husky@npm:9.0.11"
+  version: 9.1.6
+  resolution: "husky@npm:9.1.6"
   bin:
-    husky: bin.mjs
-  checksum: 2c787dcf74a837fc9a4fea7da907509d4bd9a289f4ea10ecc9d86279e4d4542b0f5f6443a619bccae19e265f2677172cc2b86aae5c932a35a330cc227d914605
+    husky: bin.js
+  checksum: 705673db4a247c1febd9c5df5f6a3519106cf0335845027bb50a15fba9b1f542cb2610932ede96fd08008f6d9f49db0f15560509861808b0031cdc0e7c798bac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Update `husky` pre-commit hook to prevent it trying to run commands that don't exist.

#### Changelog

**New**

- add `prepare` script for Husky

**Changed**

- update husky command in `pre-commit` script

**Removed**

- `husky` entry in package.json
