### PR TITLE
chore: modify update-carbon-gatsby-deps.yml

### DIFF
--- a/.github/workflows/update-carbon-gatsby-deps.yml
+++ b/.github/workflows/update-carbon-gatsby-deps.yml
@@ -24,11 +24,8 @@ jobs:
       - name: Update dependencies
         run: |
           yarn up \
-            @carbon/react@next \
-            @carbon/elements@next \
             @carbon/pictograms@next \
             @carbon/pictograms-react@next \
-            @carbon/icons@next \
             @carbon/icons-react@next \
             gatsby-theme-carbon@latest \
       - name: Generate token


### PR DESCRIPTION
Update the [update-carbon-gatsby-deps workflow](https://github.com/carbon-design-system/carbon-website/actions/workflows/update-carbon-gatsby-deps.yml) to remove react, elements and icons packages. These are all included as part of the gatsby theme after the latest upgrade. 