### PR TITLE
Table not displaying correctly on Pagination component docs

### DIFF
--- a/src/pages/components/pagination/usage.mdx
+++ b/src/pages/components/pagination/usage.mdx
@@ -96,9 +96,9 @@ Pagination can be used with a data table or on a page.
 ### Variants
 
 | Variant                           | Usage                                                                                                                           |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --- |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | [Pagination](#pagination)         | The pagination variant is typically connected at the bottom of the data table component to help paginate large amounts of data. |
-| [Pagination nav](#pagination-nav) | The pagination nav variant is mainly used in on-page situations to help paginate either a whole page or sections of a page.     |     |
+| [Pagination nav](#pagination-nav) | The pagination nav variant is mainly used in on-page situations to help paginate either a whole page or sections of a page.     |
 
 ## Formatting
 


### PR DESCRIPTION
Extra column dividers were breaking the variants table on this page

<img width="904" alt="Screenshot 2024-09-23 at 1 20 41 PM" src="https://github.com/user-attachments/assets/467e4305-c4ae-47a2-85f1-8ab2b9b4219e">

