### PR TITLE
Fix: Broken links and incorrect notification color tokens

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -4054,7 +4054,7 @@ const colorTokens = {
         },
         g90: {
           name: 'Gray 80',
-          hex: '#8d8d8d',
+          hex: '#393939',
         },
         g100: {
           name: 'Gray 90',
@@ -4075,7 +4075,7 @@ const colorTokens = {
         },
         g90: {
           name: 'Gray 80',
-          hex: '#8d8d8d',
+          hex: '#393939',
         },
         g100: {
           name: 'Gray 90',
@@ -4096,7 +4096,7 @@ const colorTokens = {
         },
         g90: {
           name: 'Gray 80',
-          hex: '#8d8d8d',
+          hex: '#393939',
         },
         g100: {
           name: 'Gray 90',
@@ -4108,16 +4108,16 @@ const colorTokens = {
       role: ['Warning low contrast notification background'],
       value: {
         white: {
-          name: 'Yellow 30, White',
-          hex: '#f1c21b, #ffffff',
+          name: 'Yellow 10',
+          hex: '#fcf4d6',
         },
         g10: {
-          name: 'Yellow 30, White',
-          hex: '#f1c21b, #ffffff',
+          name: 'Yellow 10',
+          hex: '#fcf4d6',
         },
         g90: {
           name: 'Gray 80',
-          hex: '#8d8d8d',
+          hex: '#393939',
         },
         g100: {
           name: 'Gray 90',

--- a/src/pages/designing/get-started.mdx
+++ b/src/pages/designing/get-started.mdx
@@ -40,18 +40,19 @@ guidance and components.
 
 _For IBMers only:_
 
-IBMers should get a license for Figma, our primary design kit tool. You may also
-access tools we no longer support, Sketch, Adobe XD, and Axure, by heading to
-the [Design Toolbox](https://w3.ibm.com/design/toolbox/). However, we no longer
-maintain or update the kits for these tools. We recommend you migrate to Figma
-to get the most updated kits we offer.
+IBMers should get a license for Figma, our primary design kit tool. We no longer
+maintain or support the libraries in Sketch, Adobe XD, and Axure, but you can
+view the
+[w3 Apps Software Licenses](https://ibm.service-now.com/slm?id=toolbox_ibm&sys_id=823b779e1b047c508c6099f9bc4bcb4a)
+page to see license availability for these design tools if needed. We recommend
+you migrate to Figma to get our most updated kits.
 
 <Row className="resource-card-group">
 
 <Column colLg={4} colMd={4} noGutterSm>
   <ResourceCard
     subTitle="Get Figma"
-    href="https://w3.ibm.com/design/toolbox/?&_ga=2.49792614.1500760159.1682969477-2020417520.1680805833#/ui-design-tools/figma/README"
+    href="https://ibmtest.service-now.com/slm?id=toolbox_ibm&sys_id=f850fa5f4758dd10d9607351e36d43b8"
     actionIcon="launch">
     <MdxIcon name="figma" />
   </ResourceCard>


### PR DESCRIPTION
Closes #4244 & #4187 

This PR addresses and fixes a few bugs on the website.

#### Changelog

**Changed**

- Fixed a few broken links on the Designing's [Get started](https://carbondesignsystem.com/designing/get-started/#step-2:-access-the-tools) page.

- Updated some Notification color tokens that were incorrect:
  > In both White and Gray 10 themes:
  > 
  > |Token                                                |White theme            |Gray 10 theme        | 
  > |----------------------------------|--------------------|-------------------|
  > |$notification-background-warning|Yellow 10 (#fcf4d6)|Yellow 10 (#fcf4d6)|

  > In the Gray 90 theme:
  > 
  > |Token                                                  |Gray 90 theme        | 
  > |-----------------------------------|--------------------|
  > |$notification-background-error      |Gray 80 (#393939)| 
  > |$notification-background-success|Gray 80 (#393939)| 
  > |$notification-background-info       |Gray 80 (#393939)| 
  > |$notification-background-warning|Gray 80 (#393939)| 