### PR TITLE
docs(project): update v10 website banner to reflect v10 end of support

### DIFF
--- a/src/components/Banner/Banner.js
+++ b/src/components/Banner/Banner.js
@@ -9,7 +9,8 @@ const Banner = () => {
     <div aria-label="banner" className={banner}>
       <p className={bannerText}>
         <strong>
-          Carbon v10 is in maintenance mode. Support will end on Sept. 30, 2024.
+          Carbon v10 reached end of support on September 30, 2024 and will not
+          receive any more updates.
         </strong>
       </p>
       <Button


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon/issues/12497
Related https://github.com/carbon-design-system/carbon-website/pull/4301, https://github.com/carbon-design-system/carbon/pull/17615, https://github.com/carbon-design-system/carbon/pull/17616

#### Changelog

**Changed**

- Update v10 branch/website banner with end-of-support content