### PR TITLE
fix: a11y status for menu button

### DIFF
--- a/src/components/A11yStatus/A11yStatus.js
+++ b/src/components/A11yStatus/A11yStatus.js
@@ -87,9 +87,18 @@ const A11yStatus = ({ components, layout }) => {
           .includes(componentName.toLowerCase().replace(' ', ''));
       });
 
-      const githubUrl = `https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/${componentName
-        .replace(/\b\w/g, (char) => char.toUpperCase())
-        .replace(/\s+/g, '')}`;
+      let githubUrl = '';
+      if (componentName === 'Menu buttons') {
+        const githubComponentName = 'Menu button';
+        githubUrl = `https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/${githubComponentName
+          .replace(/\b\w/g, (char) => char.toUpperCase())
+          .replace(/\s+/g, '')}`;
+      }
+      else {
+        githubUrl = `https://github.com/carbon-design-system/carbon/tree/main/packages/react/src/components/${componentName
+          .replace(/\b\w/g, (char) => char.toUpperCase())
+          .replace(/\s+/g, '')}`;
+      }
 
       // Function to check if the spec has a specific tag and
       // if the status is skipped

--- a/src/pages/components/menu-buttons/accessibility.mdx
+++ b/src/pages/components/menu-buttons/accessibility.mdx
@@ -208,4 +208,4 @@ custom component.
 - When the combo button menu is open, the element (`div`) wrapping the entire
   combo button is given `aria-owns` with a value of the menu `id`.
 
-<A11yStatus layout="table" components="Menu buttons" />
+<A11yStatus layout="table" components={["Menu buttons", "Combo button", "Overflow menu"]}/>


### PR DESCRIPTION
Closes #4241 

Added Combo button and Overflow menu to a11y tab in menubuttons and fixed github link for menu button

#### Changelog

**New**

Added Combo button and Overflow menu to a11y tab in menubuttons and fixed github link for menu button

