### PR TITLE
fix: update typo on tile usage tab

### DIFF
--- a/src/pages/components/tile/usage.mdx
+++ b/src/pages/components/tile/usage.mdx
@@ -187,7 +187,7 @@ feature flag information, refer to the [Code](/components/tile/code/) tab. These
 current variants of tile are not being deprecated, but teams are encouraged to
 use the feature flag tile for their products moving forward.
 
-The following are the feature flag changes made to structured list.
+The following are the feature flag changes made to tile.
 
 - A border has been added to the clickable, selectable, and expandable variants
   of tile to visually indicate they are operable.


### PR DESCRIPTION
This PR updates a typo on the Tile Usage tab page.