### PR TITLE
fix: updated feature flag react link

### DIFF
--- a/src/pages/components/overview/feature-flags.mdx
+++ b/src/pages/components/overview/feature-flags.mdx
@@ -56,7 +56,7 @@ updates related to all available feature flags.
 <Title>React</Title>
 
 The development specifics for feature flags in React can be found in the
-[@carbon/react](https://react.carbondesignsystem.com/?path=/docs/experimental-feature-flags--overview)
+[@carbon/react](https://react.carbondesignsystem.com/?path=/docs/getting-started-feature-flags--overview)
 framework.
 
 ### Design


### PR DESCRIPTION
This PR updates the React link on the feature flag overview page.