### PR TITLE
Update who-uses-carbon.mdx

### DIFF
--- a/src/pages/all-about-carbon/who-uses-carbon.mdx
+++ b/src/pages/all-about-carbon/who-uses-carbon.mdx
@@ -200,8 +200,8 @@ Here are some ways marketers can begin engaging with Carbon:
   drive IBM's portfolio of products and experiences.
 
 - The majority of marketing experiences use Carbon web components. Visit
-  [Carbon for IBM.com](https://www.ibm.com/standards/carbon/)
-  to ensure that these experiences are adhering to Carbon guidance.
+  [Carbon for IBM.com](https://www.ibm.com/standards/carbon/) to ensure that
+  these experiences are adhering to Carbon guidance.
 
 - Familiarize yourself with
   [IBM.com web standards](https://www.ibm.com/standards/web/) to assess the

--- a/src/pages/all-about-carbon/who-uses-carbon.mdx
+++ b/src/pages/all-about-carbon/who-uses-carbon.mdx
@@ -200,7 +200,7 @@ Here are some ways marketers can begin engaging with Carbon:
   drive IBM's portfolio of products and experiences.
 
 - The majority of marketing experiences use Carbon web components. Visit
-  [Carbon for IBM.com](https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/)
+  [Carbon for IBM.com](https://www.ibm.com/standards/carbon/)
   to ensure that these experiences are adhering to Carbon guidance.
 
 - Familiarize yourself with


### PR DESCRIPTION
The link to carbon for ibm.com was 404ing.
On the page, the link points to https://www.ibm.com/standards/web/carbon-for-ibm-dotcom/?_gl=1*g1kxqm*_ga*MTkzMjY0MTU3NC4xNjkyODI2ODcz*_ga_FYECCCS21D*MTczMTYyMjI4OC40NzMuMS4xNzMxNjIzOTE0LjAuMC4w 
although this long string is not appearing in the code. No idea what's going on there, but the link was incorrect even without it, so I have updated the link

Closes #

{{short description}}

#### Changelog

**New**

- {{new thing}}

**Changed**

- {{change thing}}

**Removed**

- {{removed thing}}
