### PR TITLE
chore(pictograms): hide tokyo--volcano

### DIFF
--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -21,6 +21,7 @@ const IconCategory = ({ category, pictograms, columnCount }) => {
     'ibm--z--partition',
     'ibm--z-and-linuxone-multi-frame',
     'ibm--z-and-linuxone-single-frame',
+    'tokyo--volcano',
   ];
 
   return (


### PR DESCRIPTION
Stemming from https://github.com/carbon-design-system/carbon/pull/18128, this ensures culturally insensitive `tokyo--volcano` is no longer shown on the site. It's replacement `japan--mt-fuji` will be available in the next release of Carbon (today).

Sibling: https://github.com/carbon-design-system/design-language-website/pull/1384

#### Changelog

**Changed**

- add `tokyo--volcano` to pictogram ignore list