### PR TITLE
Update overview.mdx

### DIFF
--- a/src/pages/guidelines/content/overview.mdx
+++ b/src/pages/guidelines/content/overview.mdx
@@ -90,8 +90,8 @@ and a different sentence structure, the style and tone adapts.
 ## Writing for accessibility
 
 For detailed guidance about writing for all users, please read the
-[Content design section](https://www.ibm.com/able/toolkit/design/content)
-of the IBM Accessibility site.
+[Content design section](https://www.ibm.com/able/toolkit/design/content) of the
+IBM Accessibility site.
 
 It provides detailed guidance on the following topics:
 

--- a/src/pages/guidelines/content/overview.mdx
+++ b/src/pages/guidelines/content/overview.mdx
@@ -90,7 +90,7 @@ and a different sentence structure, the style and tone adapts.
 ## Writing for accessibility
 
 For detailed guidance about writing for all users, please read the
-[Content design section](https://www.ibm.com/able/toolkit/design/content/text-equivalents)
+[Content design section](https://www.ibm.com/able/toolkit/design/content)
 of the IBM Accessibility site.
 
 It provides detailed guidance on the following topics:


### PR DESCRIPTION
Updating the link, which was not only pointing to too specific a topic instead of a page, but had a very long string appended to the end of the link

On the published page, the current link's target displays as [https://www.ibm.com/able/toolkit/design/content/text-equivalents?_gl=1*v6fjg9*_ga*[…]Dcz*_ga_FYECCCS21D*MTczMjU1MTI0OS40ODguMS4xNzMyNTUxNjc2LjAuMC4w](https://www.ibm.com/able/toolkit/design/content/text-equivalents?_gl=1*v6fjg9*_ga*MTkzMjY0MTU3NC4xNjkyODI2ODcz*_ga_FYECCCS21D*MTczMjU1MTI0OS40ODguMS4xNzMyNTUxNjc2LjAuMC4w)