### PR TITLE
fix(nav): re-add react tutorial to left nav

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -33,6 +33,8 @@
       path: /developing/community-frameworks/angular/
     - title: Developer resources
       path: /developing/dev-resources/resources/
+    - title: React tutorial
+      path: /developing/react-tutorial/overview/
 - title: Contributing
   pages:
     - title: Get started


### PR DESCRIPTION
This reinstates the react tutorial as a link in the left nav that was removed in https://github.com/carbon-design-system/carbon-website/pull/4418. I believe the removal was a mistake, the intent was to just remove the community-maintained framework information/tutorials from the left nav.

A link to the web components tutorial should be added alongside this react one in #4347

#### Changelog

**Changed**

- modify nav-items.yml to include react tutorial