### PR TITLE
chore(pictogram): update package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   "dependencies": {
     "@carbon/charts-react": "0.55.0",
     "@carbon/icons-react": "^11.53.0",
-    "@carbon/pictograms": "^12.44.0",
-    "@carbon/pictograms-react": "^11.70.0",
+    "@carbon/pictograms": "^12.45.1",
+    "@carbon/pictograms-react": "^11.71.1",
     "@loadable/babel-plugin": "^5.16.1",
     "@loadable/component": "^5.16.4",
     "codesandbox": "^2.2.3",

--- a/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
+++ b/src/components/SVGLibraries/PictogramLibrary/PictogramCategory.js
@@ -17,7 +17,6 @@ import {
 const IconCategory = ({ category, pictograms, columnCount }) => {
   const [sectionRef, containerIsVisible] = useIntersectionObserver();
   const hiddenPictograms = [
-    'ibm--z',
     'ibm--z--partition',
     'ibm--z-and-linuxone-multi-frame',
     'ibm--z-and-linuxone-single-frame',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2669,12 +2669,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/pictograms@npm:^12.44.0":
-  version: 12.44.0
-  resolution: "@carbon/pictograms@npm:12.44.0"
+"@carbon/pictograms-react@npm:^11.71.1":
+  version: 11.71.1
+  resolution: "@carbon/pictograms-react@npm:11.71.1"
+  dependencies:
+    "@carbon/icon-helpers": "npm:^10.54.0"
+    "@ibm/telemetry-js": "npm:^1.5.0"
+    prop-types: "npm:^15.7.2"
+  peerDependencies:
+    react: ">=16"
+  checksum: b94f884c4a8a97b9f5cdac58cd3b18c90b9f18f72d47932004ce54457d850840175fb3206fc2d65aa4c8fcfa2d03b14ad71b23f7dfa96e8231bf359de61ec660
+  languageName: node
+  linkType: hard
+
+"@carbon/pictograms@npm:^12.45.1":
+  version: 12.45.1
+  resolution: "@carbon/pictograms@npm:12.45.1"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: dfd6a7fb0280b080639c43e9cfb197e033062e42228d6c53cdef0d843032ed24dd771834c48879c33710c1afc3e22d61a106e5a9f93ec63951957accdc11ab26
+  checksum: 1d07b9de0ecba2e4e050e2da14acdfdf441c86962ba1d7c8830de7d89c7626dbb92d3f905497c108d7056dfe056b4672961f4cd81db299623026e7211a1380c4
   languageName: node
   linkType: hard
 
@@ -6748,8 +6761,8 @@ __metadata:
   dependencies:
     "@carbon/charts-react": "npm:0.55.0"
     "@carbon/icons-react": "npm:^11.53.0"
-    "@carbon/pictograms": "npm:^12.44.0"
-    "@carbon/pictograms-react": "npm:^11.70.0"
+    "@carbon/pictograms": "npm:^12.45.1"
+    "@carbon/pictograms-react": "npm:^11.71.1"
     "@loadable/babel-plugin": "npm:^5.12.0"
     "@loadable/component": "npm:^5.16.4"
     babel-preset-carbon: "npm:^0.0.14"


### PR DESCRIPTION
Closes #4438

Update pictogram version to show show ibm z pictograms
<img width="857" alt="Screenshot 2025-02-03 at 9 55 49 AM" src="https://github.com/user-attachments/assets/87a021f0-aa95-4ef4-a986-5c1e62d03be4" />

#### Changelog

**Changed**

- update pictogram version
- un-hide ibm -z pictograms
