### PR TITLE
docs: remove community patterns from left hand nav

### DIFF
--- a/src/data/nav-items.yaml
+++ b/src/data/nav-items.yaml
@@ -212,8 +212,6 @@
       path: /community/overview/
     - title: Component index
       path: /community/component-index/
-    - title: Patterns
-      path: /community/patterns/
     - title: Domain guidance
       path: /community/domain-guidance/
 - title: Data visualization


### PR DESCRIPTION
Closes #4467 

This PR removes the Community > Patterns page from the left hand nav of the website.

---

**Removed**

- Removed the Patterns page under the Community section from the left hand nav. 
