### PR TITLE
docs: fix broken links on form pattern page

### DIFF
--- a/src/pages/patterns/forms-pattern/index.mdx
+++ b/src/pages/patterns/forms-pattern/index.mdx
@@ -222,11 +222,11 @@ Free-form text inputs are the most commonly used components in forms.
 
 <Title> Deciding what to use </Title>
 
-| Control                                                                                            | Usage                                            | Context                                                                 |
-| -------------------------------------------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
-| [Text input](/components/text-input/usage)                                                         | To capture several words maximum                 | Names; phone numbers; addresses                                         |
-| [Password](http://react.carbondesignsystem.com/?path=/story/textinput--toggle-password-visibility) | To collect private data by hiding the characters | Passwords, Social Security Numbers (SSN), PINs, credit card information |
-| [Text area](http://react.carbondesignsystem.com/?path=/story/textarea--default)                    | To capture multiple lines of text                | Feedback; support requests                                              |
+| Control                                                        | Usage                                            | Context                                                                 |
+| -------------------------------------------------------------- | ------------------------------------------------ | ----------------------------------------------------------------------- |
+| [Text input](/components/text-input/usage/#text-input)         | To capture several words maximum                 | Names; phone numbers; addresses                                         |
+| [Password input](/components/text-input/usage/#password-input) | To collect private data by hiding the characters | Passwords, Social Security Numbers (SSN), PINs, credit card information |
+| [Text area](/components/text-input/usage/#text-area)           | To capture multiple lines of text                | Feedback; support requests                                              |
 
 #### Best practices
 
@@ -259,14 +259,14 @@ file uploaders, toggles, and select lists (combo box and multiselect).
 
 <Title> Deciding what to use </Title>
 
-| Control                                                                              | Usage                                                                    | Context                                                                  |
-| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| [Checkbox](/components/checkbox/usage)                                               | To select or deselect one or more choices                                | Agree to terms and conditions, add optional items, select all that apply |
-| [Radio button](/components/radio-button/usage)                                       | To select only one option from two or more choices                       | Pick type, shipping method, etc.                                         |
-| [Toggle](/components/toggle/usage)                                                   | To choose one of two or more binary options                              | Changing user settings; On/off; Show/hide                                |
-| [File uploader](/components/file-uploader/usage)                                     | To upload/attach a file or multiple files to a form                      | Attaching SSl certificates; adding config files to support tickets       |
-| [Combo box](http://react.carbondesignsystem.com/?path=/story/combobox--default)      | To select a single item with type-ahead functionality from a longer list | Choosing a state, country, or language preference                        |
-| [Multiselect](http://react.carbondesignsystem.com/?path=/story/multiselect--default) | To select multiple items from a longer list                              | Add a product example for MultiSelect                                    |
+| Control                                                | Usage                                                                    | Context                                                                  |
+| ------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| [Checkbox](/components/checkbox/usage)                 | To select or deselect one or more choices                                | Agree to terms and conditions, add optional items, select all that apply |
+| [Radio button](/components/radio-button/usage)         | To select only one option from two or more choices                       | Pick type, shipping method, etc.                                         |
+| [Toggle](/components/toggle/usage)                     | To choose one of two or more binary options                              | Changing user settings; On/off; Show/hide                                |
+| [File uploader](/components/file-uploader/usage)       | To upload/attach a file or multiple files to a form                      | Attaching SSl certificates; adding config files to support tickets       |
+| [Combo box](/components/dropdown/usage/#combo-box)     | To select a single item with type-ahead functionality from a longer list | Choosing a state, country, or language preference                        |
+| [Multiselect](/components/dropdown/usage/#multiselect) | To select multiple items from a longer list                              | Add a product example for MultiSelect                                    |
 
 #### Radio buttons:
 
@@ -307,12 +307,12 @@ entries, so field validation isn’t needed.
 
 <Title> Deciding what to use </Title>
 
-| Control                                                                             | Usage                                                                   | Context                                            |
-| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
-| [Number input](/components/number-input/usage)                                      | To increase or decrease incremental values                              | Order quantities                                   |
-| [Slider](/components/slider/usage)                                                  | To select one number from a numerical range                             | Percentages, volume, timelines, data visualization |
-| [Date picker](/components/date-picker/usage)                                        | To input/select a single localized date or a date range from a calendar | Scheduling trips, meetings, and events             |
-| [Time picker](http://react.carbondesignsystem.com/?path=/story/timepicker--default) | To input time in hours/minutes                                          | Scheduling meetings and travel times               |
+| Control                                                    | Usage                                                                   | Context                                            |
+| ---------------------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------- |
+| [Number input](/components/number-input/usage)             | To increase or decrease incremental values                              | Order quantities                                   |
+| [Slider](/components/slider/usage)                         | To select one number from a numerical range                             | Percentages, volume, timelines, data visualization |
+| [Date picker](/components/date-picker/usage)               | To input/select a single localized date or a date range from a calendar | Scheduling trips, meetings, and events             |
+| [Time picker](/components/date-picker/usage/#time-pickers) | To input time in hours/minutes                                          | Scheduling meetings and travel times               |
 
 ### Offering help
 
@@ -899,16 +899,12 @@ in-depth accessibility guidance for each form element.
 
 - [Button](/components/button/usage) <br/>
 - [Checkbox](/components/checkbox/usage) <br/>
-- [Combo box](http://react.carbondesignsystem.com/?path=/story/combobox--default)
-  <br />
-- [Multiselect](http://react.carbondesignsystem.com/?path=/story/multiselect--default)
-  <br />
-- [Password input](http://react.carbondesignsystem.com/?path=/story/textinput--toggle-password-visibility)
-  <br />
+- [Combo box](/components/dropdown/usage/#combo-box) <br />
+- [Multiselect](/components/dropdown/usage/#multiselect) <br />
+- [Password input](/components/text-input/usage/#password-input) <br />
 - [Radio button](/components/radio-button/usage) <br/>
-- [Text area](http://react.carbondesignsystem.com/?path=/story/textarea--default)
-  <br />
-- [Text input](/components/text-input/usage) <br/>
+- [Text area](/components/text-input/usage/#text-area) <br />
+- [Text input](/components/text-input/usage/#text-input) <br/>
 - [Toggle](/components/toggle/usage) <br/>
 
 </Column>


### PR DESCRIPTION
Closes #4516 

This PR corrects all broken links that are currently on the Form patterns page.

-----

**Changed**

- Fixed broken links
