### PR TITLE
Update icon to "Download" in the RGB color palette resource card under Color

### DIFF
--- a/src/pages/elements/color/overview.mdx
+++ b/src/pages/elements/color/overview.mdx
@@ -641,6 +641,7 @@ to achieve commonly used contrast ratios between any two colors.
   <ResourceCard
     subTitle="RGB color palettes (.ase and .clr)"
     href="https://github.com/carbon-design-system/carbon/raw/refs/heads/main/packages/colors/artifacts/IBM_Colors.zip"
+    actionIcon="download"
     >
 
 <MdxIcon name="ase" />


### PR DESCRIPTION
Closes #4537 

#### Changelog

**Changed**
- Updated the icon in the "RGB color palette (.ase and .clr)" resource card to use the Download icon instead of the external link icon.