### PR TITLE
chore: update deploy command to force override

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,6 @@ jobs:
       - name: Deploy
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
-          npx gh-pages -d public -u "github-actions <github-actions@github.com>"
+          npx gh-pages -d public -u "github-actions <github-actions@github.com>" -f
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This came up in slack conversation.
>The website repo is absolutely huge, takes 30 min to clone on a colleague laptop. Have you considered looking what's clogging it? From my experience I could think that might be the gh-pages branch. Adding a -f parameter to the gh-pages command would basically remove references to previous commits, which means that git would discard those data from the repo after a month.

#### Changelog
 - add `-f` to deployment command

