### PR TITLE
Docs: Updated Homepage contributing link

### DIFF
--- a/src/components/Homepage.js
+++ b/src/components/Homepage.js
@@ -30,7 +30,7 @@ const SecondRightText = () => (
     We welcome all feedback, designs, or ideas in order to produce the best
     possible experience for our users. If you’re interested in contributing,
     check out our contributing guidelines to get started.
-    <a className={calloutLink} href="/contributing/get-started/">
+    <a className={calloutLink} href="/contributing/get-started/overview">
       Start contributing →
     </a>
   </p>


### PR DESCRIPTION
Closes #4544 

#### Changelog

Fixes the URL link for the contributing callout on the Carbon homepage.

**New**

- N/A

**Changed**

- Updated URL for Homepage link in `Homepage.js`

**Removed**

- N/A
