### PR TITLE
docs: remove mention of idl playbacks on the meetups page

### DIFF
--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -214,10 +214,10 @@ of the situation and quickly know what to do next.
 
 ### Overflow
 
-If a toast or inline notification requires a message that is longer than two lines, use
-an actionable notification and include a short message with a “View more” link
-that takes the user to a view of the full notification message. This destination
-can be either a full page with more details or a modal.
+If a toast or inline notification requires a message that is longer than two
+lines, use an actionable notification and include a short message with a “View
+more” link that takes the user to a view of the full notification message. This
+destination can be either a full page with more details or a modal.
 
 ### Further guidance
 

--- a/src/pages/whats-happening/meetups/index.mdx
+++ b/src/pages/whats-happening/meetups/index.mdx
@@ -20,34 +20,6 @@ peers, and getting reviews on work in progress.
 <Row className="meetups-list">
 <Column colLg={4} colMd={2}>
 
-![](/images/events_design_playback.png)
-
-</Column>
-<Column colLg={7} colMd={5}>
-
-{/* prettier-ignore */}
-<h2>Carbon and IDL bi-weekly design playbacks<span>Fridays, 12pm–1pm Central</span></h2>
-
-_For IBMers only:_ You’ve got some work in progress and you’re ready to open it
-up and share it with a broader audience for honest (and caring!) feedback.
-Verify that you’re working with the grid correctly, that you’re using the right
-components, that you’re using the correct language. Sign up to share, or come
-along to see other work in progress and learn that way.
-
-<Row>
-  <Button
-    kind="tertiary"
-    renderIcon={Launch}
-    href="https://ec.yourlearning.ibm.com/w3/series/10163237">
-    Subscribe
-  </Button>
-</Row>
-
-</Column>
-</Row>
-<Row className="meetups-list">
-<Column colLg={4} colMd={2}>
-
 ![](/images/meetups_data_viz.png)
 
 </Column>


### PR DESCRIPTION
This PR removes a mention about joining IDL playbacks on the Meetups page, which we no longer host anymore. If at some point we decide to host this meeting again, we can add it back, but for now it is misleading information.

---

**Removed**

- Image, button, and content 
