### PR TITLE
docs: update slider style tab with correct range structure images

### DIFF
--- a/src/pages/components/notification/usage.mdx
+++ b/src/pages/components/notification/usage.mdx
@@ -214,10 +214,10 @@ of the situation and quickly know what to do next.
 
 ### Overflow
 
-If a toast or inline notification requires a message that is longer than two lines, use
-an actionable notification and include a short message with a “View more” link
-that takes the user to a view of the full notification message. This destination
-can be either a full page with more details or a modal.
+If a toast or inline notification requires a message that is longer than two
+lines, use an actionable notification and include a short message with a “View
+more” link that takes the user to a view of the full notification message. This
+destination can be either a full page with more details or a modal.
 
 ### Further guidance
 

--- a/src/pages/components/slider/style.mdx
+++ b/src/pages/components/slider/style.mdx
@@ -175,13 +175,13 @@ The width of a slider varies based on page content and layout.
 
 <div className="image--fixed">
 
-![Structure and spacing measurements for range slider enabled state](images/slider-style-structure-default-enabled.png)
+![Structure and spacing measurements for range slider enabled state](images/slider-style-structure-range-enabled.png)
 
 </div>
 
 <div className="image--fixed">
 
-![Structure and spacing measurements for range slider error state](images/slider-style-structure-default-error.png)
+![Structure and spacing measurements for range slider error state](images/slider-style-structure-range-error.png)
 
 </div>
 


### PR DESCRIPTION
Closes #4535 

This PR updates the range slider "Structure" section on the Slider Style tab. Incorrect images were appearing in this section and this PR fixes it.

-----

#### Changelog

**Changed**

- Updated incorrect images with the correct ones.


