### PR TITLE
docs: Fix broken links in Live demos

### DIFF
--- a/src/pages/components/date-picker/code.mdx
+++ b/src/pages/components/date-picker/code.mdx
@@ -79,15 +79,16 @@ usage documentation, see the Storybooks for each framework below.
     },
     {
       label: 'Fluid Range With Calendar (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--range-with-calendar',
+      variant:
+        'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
     },
     {
       label: 'Fluid Simple (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--simple',
+      variant: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
     },
     {
       label: 'Fluid Single (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--single',
+      variant: 'experimental-fluid-components-unstable-fluiddatepicker--single',
     },
     {
       label: 'Single with AI Label',

--- a/src/pages/components/date-picker/usage.mdx
+++ b/src/pages/components/date-picker/usage.mdx
@@ -63,15 +63,16 @@ details.
     },
     {
       label: 'Fluid Range With Calendar (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--range-with-calendar',
+      variant:
+        'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
     },
     {
       label: 'Fluid Simple (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--simple',
+      variant: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
     },
     {
       label: 'Fluid Single (unstable)',
-      variant: 'experimental-unstable-fluiddatepicker--single',
+      variant: 'experimental-fluid-components-unstable-fluiddatepicker--single',
     },
     {
       label: 'Single with AI Label',

--- a/src/pages/components/form/code.mdx
+++ b/src/pages/components/form/code.mdx
@@ -72,7 +72,7 @@ documentation, see the Storybooks for each framework below.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-fluidform--default',
+      variant: 'experimental-fluid-components-fluidform--default',
     },
   ]}
 />

--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -53,7 +53,7 @@ the [AI presence](/components/form/usage/#ai-presence) section for more details.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-fluidform--default',
+      variant: 'experimental-fluid-components-fluidform--default',
     },
   ]}
 />

--- a/src/pages/components/number-input/code.mdx
+++ b/src/pages/components/number-input/code.mdx
@@ -70,7 +70,8 @@ usage documentation, see the Storybooks for each framework below.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidnumberinput--default',
+      variant:
+        'experimental-fluid-components-unstable-fluidnumberinput--default',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/number-input/usage.mdx
+++ b/src/pages/components/number-input/usage.mdx
@@ -52,7 +52,8 @@ details.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidnumberinput--default',
+      variant:
+        'experimental-fluid-components-unstable-fluidnumberinput--default',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/search/code.mdx
+++ b/src/pages/components/search/code.mdx
@@ -78,7 +78,7 @@ documentation, see the Storybooks for each framework below.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidsearch--default',
+      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
     },
   ]}
 />

--- a/src/pages/components/search/usage.mdx
+++ b/src/pages/components/search/usage.mdx
@@ -47,7 +47,7 @@ without navigation.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidsearch--default',
+      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
     },
   ]}
 />

--- a/src/pages/components/select/code.mdx
+++ b/src/pages/components/select/code.mdx
@@ -74,7 +74,7 @@ documentation, see the Storybooks for each framework below.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidselect--default',
+      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/select/usage.mdx
+++ b/src/pages/components/select/usage.mdx
@@ -54,7 +54,7 @@ details.
     },
     {
       label: 'Fluid (unstable)',
-      variant: 'experimental-unstable-fluidselect--default',
+      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/tag/code.mdx
+++ b/src/pages/components/tag/code.mdx
@@ -69,16 +69,16 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-tag--read-only',
     },
     {
-      label: 'Dismissible (unstable)',
-      variant: 'experimental-unstable-interactivetag--dismissible',
+      label: 'Dismissible',
+      variant: 'components-tag--dismissible',
     },
     {
-      label: 'Selectable (unstable)',
-      variant: 'experimental-unstable-interactivetag--selectable',
+      label: 'Selectable',
+      variant: 'components-tag--selectable',
     },
     {
-      label: 'Operational (unstable)',
-      variant: 'experimental-unstable-interactivetag--operational',
+      label: 'Operational',
+      variant: 'components-tag--operational',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/tag/usage.mdx
+++ b/src/pages/components/tag/usage.mdx
@@ -52,16 +52,16 @@ introduces an AI explainability feature when AI is present in the component.
       variant: 'components-tag--read-only',
     },
     {
-      label: 'Dismissible (unstable)',
-      variant: 'experimental-unstable-interactivetag--dismissible',
+      label: 'Dismissible',
+      variant: 'components-tag--dismissible',
     },
     {
-      label: 'Selectable (unstable)',
-      variant: 'experimental-unstable-interactivetag--selectable',
+      label: 'Selectable',
+      variant: 'components-tag--selectable',
     },
     {
-      label: 'Operational (unstable)',
-      variant: 'experimental-unstable-interactivetag--operational',
+      label: 'Operational',
+      variant: 'components-tag--operational',
     },
     {
       label: 'with AI Label',

--- a/src/pages/components/text-input/code.mdx
+++ b/src/pages/components/text-input/code.mdx
@@ -77,8 +77,8 @@ usage documentation, see the Storybooks for each framework below.
       variant: 'components-textinput--read-only',
     },
     {
-      label: 'Toggle password with visibility',
-      variant: 'components-textinput--toggle-password-visibility',
+      label: 'Password Input',
+      variant: 'components-passwordinput--default',
     },
     {
       label: 'Fluid (unstable)',

--- a/src/pages/components/text-input/usage.mdx
+++ b/src/pages/components/text-input/usage.mdx
@@ -62,8 +62,8 @@ section for more details.
       variant: 'components-textinput--read-only',
     },
     {
-      label: 'Toggle password with visibility',
-      variant: 'components-textinput--toggle-password-visibility',
+      label: 'Password Input',
+      variant: 'components-passwordinput--default',
     },
     {
       label: 'Fluid (unstable)',


### PR DESCRIPTION
Closes #4518 

#### Changelog

**Changed**

Fixed several broken links in the live demos (fluid states) across component pages in the Usage and Code tabs for:     
- Date picker
- Form 
- Number input
- Select
- Search
- Tag
- Text input