### PR TITLE
doc(contribution): Updated the Usage & Style tab Accessibility content template

### DIFF
--- a/src/pages/contributing/documentation.mdx
+++ b/src/pages/contributing/documentation.mdx
@@ -1628,6 +1628,8 @@ accessible. The published information helps users understand all the
 accessibility considerations that are baked into Carbon. Refer to our guidance
 on creating the
 [keyboard interaction visuals](https://github.com/hiraaeth/component-contribution-accessibility/wiki/High-fidelity-keyboard-interaction-visuals).
+Also check out Button's [Accessbility](/components/breadcrumb/button/) tab for
+additional references.
 
 ```markdown
 ---
@@ -1635,6 +1637,8 @@ title: Component name (you won't need to write this)
 description: Component description (you won't need to write this)
 tabs: ['Usage', 'Style', 'Code', 'Accessibility']
 ---
+
+import A11yStatus from 'components/A11yStatus';
 
 <PageDescription>
 
@@ -1692,7 +1696,7 @@ for the overflow menu is in the tab order. See [overflow menu]((https://carbonde
 **Images**
 Use one image to document keyboard navigation. If the component has limited operation functionality, it may also be incorporated in the same image. Otherwise, the operation should be dealt with in a separate image.
 Normally these images go across 8 columns.
-images should follow the naming convention (component_name-accessibility-1.png
+images should follow the naming convention (component_name-accessibility-1.png)
 The ALT text text for the first image can be fairly generic, since the image is just restating information in the prior paragraph.
 The caption should likewise summarize something already described in the preceding paragraph. No new information should be given in the caption. Due to technology constraints, keystroke names in the captions are not given any markdown styling.
 Example:
@@ -1740,7 +1744,7 @@ Carbon accordions are not set as headings by default. For improved accessibility
 ## Development considerations
 
 Keep these considerations in mind if you are modifying Carbon or creating a
-custom component.
+custom component:
 
 <!--
 Provide a bulleted list of implementation considerations for ensuring accessibility. If there is the ability to reference the IBM toolkit or the ARIA authoring practices, that should be done.
@@ -1751,6 +1755,8 @@ following symbols: <element>, 'variable' and "value".
 
 Example:
 - See the [ARIA authoring practices](https://w3c.github.io/aria-practices/#tooltip) for more considerations.
+
+<A11yStatus layout="table" components="Component name" />
 
 -->
 ```


### PR DESCRIPTION
Closes #3984

Updated the [Accessibility template](https://carbondesignsystem.com/contributing/documentation/#accessibility-template) to include the new "Accessibility testing status" section.

#### Changelog

**New**

- Included code for the new "Accessibility testing status" section.

**Changed**

- Minor punctuation fix: changed full stop to a colon.
