### PR TITLE
docs: fix broken link on content page

### DIFF
--- a/src/pages/guidelines/content/overview.mdx
+++ b/src/pages/guidelines/content/overview.mdx
@@ -72,8 +72,8 @@ IBM Brand Center offers the following guidelines on voice.
 - It elevates facts and outcomes.
 - It engages the thinker by speaking like the thinker.
 
-For additional guidance, please read the IBM Brand Center
-[voice guidelines](https://www.ibm.com/brand/expression#voice).
+For more information, see the IBM Brand Center
+[verbal expression](https://www.ibm.com/brand/expression/verbal-expression) guidelines.
 
 ### Tone
 


### PR DESCRIPTION
Closes #4594

Fixes a broken link out to the IBM Brand center on our Content > Overview page in the Voice section.

---

**Changed**

- Inserted correct link
- Renamed link to match the new terminology used on the Brand site.

