### PR TITLE
fix: missing FAQ link on wrapping up tutorial page

### DIFF
--- a/src/pages/developing/react-tutorial/wrapping-up.mdx
+++ b/src/pages/developing/react-tutorial/wrapping-up.mdx
@@ -4,7 +4,16 @@ description:
   Welcome to Carbon! This tutorial will guide you in creating a React app using
   Next.js with the Carbon Design System.
 tabs:
-  ['Overview', 'Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5', 'Wrapping up', 'FAQ']
+  [
+    'Overview',
+    'Step 1',
+    'Step 2',
+    'Step 3',
+    'Step 4',
+    'Step 5',
+    'Wrapping up',
+    'FAQ',
+  ]
 ---
 
 <PageDescription>


### PR DESCRIPTION

https://carbondesignsystem.com/developing/react-tutorial/wrapping-up/ is missing FAQ link
#### Changelog

- add missing FAQ link
