### PR TITLE
Fix: Content switcher styling bug on Color tokens page

### DIFF
--- a/src/components/ColorTokenTable/color-token-table.scss
+++ b/src/components/ColorTokenTable/color-token-table.scss
@@ -63,7 +63,7 @@
 }
 
 .color-token-table__theme-switcher
-  .cds--content-switcher-btn:not(:last-of-type)::after {
+  .cds--content-switcher-btn:not(:first-of-type)::before {
   height: 24px;
   right: -1px;
   top: 12px;


### PR DESCRIPTION
Closes #4604

Fixed an issue with the content switcher styling on the Color tokens page

Before:
![Screenshot 2025-05-30 at 4 28 00 PM](https://github.com/user-attachments/assets/0c0cf016-37d6-46fd-abbc-e51cac2421e5)

After:
![Screenshot 2025-05-30 at 4 27 46 PM](https://github.com/user-attachments/assets/864ba674-7cf9-435e-8c2b-33fd19aadc4a)



#### Changelog

**New**

- Nothing new


**Changed**

- `.cds--content-switcher-btn::after` is used in both the custom styles for `color-token-table` and `context-switcher`, so the styles were overlapping. Therefore, `:not(:last-of-type)::after` was changed to `:not(:first-of-type)::before`


**Removed**

- Nothing removed
