### PR TITLE
docs: typos and wording in patterns common actions

### DIFF
--- a/src/pages/patterns/common-actions/index.mdx
+++ b/src/pages/patterns/common-actions/index.mdx
@@ -106,7 +106,7 @@ element. Do not use close in a button.
 <Row>
 <Column colLg={8}>
 
-![Example of close in an toast notification](images/common-action-3.png)
+![Example of close in a toast notification](images/common-action-3.png)
 
 </Column>
 </Row>
@@ -220,8 +220,8 @@ Consider inline error notifications for these instances.
 
 ### Content guidelines
 
-Be brief, honest, and supportive. Explain what happened and what can the user do
-to resolve the error.
+Be brief, honest, and supportive. Explain what happened and what the user can
+do to resolve the error.
 
 For full-page and large modals, keep error messages no longer than three
 paragraph lines. For form errors, keep error messages no longer than two lines.


### PR DESCRIPTION
Closes #

Fixed a typo and changed wording.

#### Changelog

**Changed**

- [Common actions](https://carbondesignsystem.com/patterns/common-actions/)

