### PR TITLE
chore(codepen): remove codepen embed per cookie compliance

### DIFF
--- a/src/pages/patterns/common-actions/index.mdx
+++ b/src/pages/patterns/common-actions/index.mdx
@@ -220,8 +220,8 @@ Consider inline error notifications for these instances.
 
 ### Content guidelines
 
-Be brief, honest, and supportive. Explain what happened and what the user can
-do to resolve the error.
+Be brief, honest, and supportive. Explain what happened and what the user can do
+to resolve the error.
 
 For full-page and large modals, keep error messages no longer than three
 paragraph lines. For form errors, keep error messages no longer than two lines.

--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -148,7 +148,7 @@ be configured in order to calculate where the truncation will start.
 #### Mid-line truncation
 
 Mid-line truncation does not have its own class as it requires JavaScript. [This
-example in CodePen shows how it is implemented](https://codepen.io/team/carbon/embed/yLyGXQK/).
+example in CodePen shows how it is implemented](https://codepen.io/team/carbon/pen/KRoBQe/).
 
 <br />
 

--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -147,27 +147,8 @@ be configured in order to calculate where the truncation will start.
 
 #### Mid-line truncation
 
-Mid-line truncation does not have its own class as it requires JavaScript. This
-example in CodePen shows how it is implemented.
-
-<Row>
-  <Column colLg={8}>
-    <iframe
-      height="300"
-      scrolling="no"
-      title="Middle Truncation"
-      src="//codepen.io/team/carbon/embed/yLyGXQK/?height=300&theme-id=30962&default-tab=result&embed-version=2"
-      frameborder="no"
-      allowtransparency="true"
-      allowfullscreen="true"
-      style={{ width: '100%' }}>
-      See the Pen{' '}
-      <a href="https://codepen.io/team/carbon/pen/KRoBQe/">Middle Truncation</a>{' '}
-      by Carbon Design System (<a href="https://codepen.io/carbon">@carbon</a>)
-      on <a href="https://codepen.io">CodePen</a>.
-    </iframe>
-  </Column>
-</Row>
+Mid-line truncation does not have its own class as it requires JavaScript. [This
+example in CodePen shows how it is implemented](https://codepen.io/team/carbon/embed/yLyGXQK/).
 
 <br />
 

--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -147,8 +147,8 @@ be configured in order to calculate where the truncation will start.
 
 #### Mid-line truncation
 
-Mid-line truncation does not have its own class as it requires JavaScript. [This
-example in CodePen shows how it is implemented](https://codepen.io/team/carbon/pen/KRoBQe/).
+Mid-line truncation does not have its own class as it requires JavaScript.
+[This example in CodePen shows how it is implemented](https://codepen.io/team/carbon/pen/KRoBQe/).
 
 <br />
 


### PR DESCRIPTION
This removes the embedded codepen example to comply with IBM cookies and tags compliance.

#### Changelog

**Changed**

- changed codepen to link out
