### PR TITLE
fix(overflow-pattern): replace codepen embed with link

### DIFF
--- a/src/pages/patterns/overflow-content/index.mdx
+++ b/src/pages/patterns/overflow-content/index.mdx
@@ -147,29 +147,9 @@ be configured in order to calculate where the truncation will start.
 
 #### Mid-line truncation
 
-Mid-line truncation does not have its own class as it requires JavaScript. This
-example in CodePen shows how it is implemented.
-
-<Row>
-  <Column colLg={8}>
-    <iframe
-      height="300"
-      scrolling="no"
-      title="Middle Truncation"
-      src="//codepen.io/team/carbon/embed/yLyGXQK/?height=300&theme-id=30962&default-tab=result&embed-version=2"
-      frameborder="no"
-      allowtransparency="true"
-      allowfullscreen="true"
-      style={{ width: '100%' }}>
-      See the Pen{' '}
-      <a href="https://codepen.io/team/carbon/pen/KRoBQe/">Middle Truncation</a>{' '}
-      by Carbon Design System (<a href="https://codepen.io/carbon">@carbon</a>)
-      on <a href="https://codepen.io">CodePen</a>.
-    </iframe>
-  </Column>
-</Row>
-
-<br />
+Mid-line truncation does not have its own class as it requires JavaScript.
+[This example in CodePen](https://codepen.io/team/carbon/pen/KRoBQe/) shows how
+it is implemented.
 
 ### "Show more" buttons
 


### PR DESCRIPTION
Due to lack of 3rd party cookie compliance we have to remove codepen embeds from the site and replace them with link(s)

[Slack reference](https://ibm-studios.slack.com/archives/C06NNG5U7TJ/p1749477094845549)

#### Changelog

**Changed**

- update overflow content pattern to no longer have codepen embed