### PR TITLE
docs(frameworks): clarify install instructions & peer dependencies for @carbon/react (#4419)

### DIFF
--- a/src/pages/developing/frameworks/react.mdx
+++ b/src/pages/developing/frameworks/react.mdx
@@ -60,7 +60,7 @@ behavior in prototype and production work.
 <Title> Using npm: </Title>
 
 ```bash
-npm install --save @carbon/react
+npm install --save @carbon/react react react-dom
 ```
 
 <Title>
@@ -68,8 +68,12 @@ npm install --save @carbon/react
 </Title>
 
 ```bash
-yarn add @carbon/react
+yarn add @carbon/react react react-dom
 ```
+
+> **Note:**  
+> `@carbon/react` requires `react` and `react-dom` as peer dependencies.  
+> Please ensure both are installed in your project to avoid errors.
 
 ## Getting started
 
@@ -115,6 +119,7 @@ function MyComponent() {
   return <Add />;
 }
 ```
+
 
 A full list of available icons is provided in the
 [icon library](/elements/icons/library/).


### PR DESCRIPTION
Closes #4419

This PR updates the installation section of the React frameworks documentation to explicitly list all required dependencies: `@carbon/react`, `react`, and `react-dom`. A note has been added clarifying that `react` and `react-dom` are peer dependencies that must be installed in the consuming project making the install process clearer for new users.
