### PR TITLE
chore: Update title of the resource card and link, resolves 2/3 of #4502

### DIFF
--- a/src/pages/guidelines/accessibility/color.mdx
+++ b/src/pages/guidelines/accessibility/color.mdx
@@ -118,8 +118,8 @@ you're working in Figma, we recommend the
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
 <ResourceCard
-    subTitle="IBM Equal Access Toolkit"
-    href="https://www.ibm.com/able/toolkit"
+    subTitle="IBM Equal Access Tools"
+    href="https://www.ibm.com/able/toolkit/tools/"
      >
 
 ![IBM bee icon](images/bee.svg)

--- a/src/pages/guidelines/accessibility/overview.mdx
+++ b/src/pages/guidelines/accessibility/overview.mdx
@@ -267,7 +267,7 @@ Functional cognitive disabilities can result in difficulties with:
 <Row className="resource-card-group">
 <Column colMd={4} colLg={4} noGutterSm>
   <ResourceCard
-    subTitle="IBM Accessibility Checklist"
+    subTitle="IBM Accessibility Requirements"
     href="https://www.ibm.com/able/requirements/requirements/"
     >
 


### PR DESCRIPTION
Closes #

2/3 of #4502 

#### Changelog

**Changed**


1. On the Carbon site guidelines-->accessibility-->  "IBM Equal Access Toolkit" resource card

-       Rename to say "IBM Equal Access Tools"
-       Redirect this resource card to the following link: https://www.ibm.com/able/toolkit/tools/

2.On the Carbon site guidelines-->accessibility-->  Resources section

-  Rename to say "IBM Accessibility Requirements"
