### PR TITLE
fix: motion page tabs

### DIFF
--- a/src/pages/elements/motion/overview.mdx
+++ b/src/pages/elements/motion/overview.mdx
@@ -7,7 +7,6 @@ description:
 tabs: ['Overview', 'Choreography', 'Code']
 ---
 
-import { Tab } from '@carbon/react';
 import KalturaVideo from 'components/KalturaVideo';
 
 <PageDescription>


### PR DESCRIPTION


Tabs are rendering incorrectly on the Motion page

#### Changelog


**Removed**

- remove Tab import from Carbon React, will default to Gatsby theme tab like all other pages