### PR TITLE
Update Figma link for IBM UI Icon Library

### DIFF
--- a/src/pages/elements/icons/usage.mdx
+++ b/src/pages/elements/icons/usage.mdx
@@ -25,7 +25,7 @@ important information.
 <Column colLg={4} colMd={4}  noGutterSm>
   <ResourceCard
     subTitle="IBM® UI Icon Library"
-    href="https://www.figma.com/design/J5c0d85dSJn9JnBhSYYLmD/IBM%C2%AE-UI-Icon-Library?m=auto"
+    href="https://www.figma.com/community/file/1089055340263947620/ibm-ui-icon-library"
     >
       <MdxIcon name="figma" />
  </ResourceCard>


### PR DESCRIPTION
The link doesn't work for non-IBM losers like me
