### PR TITLE
feat(live-demo): update all fluid input stories to stable urls

### DIFF
--- a/src/pages/components/date-picker/code.mdx
+++ b/src/pages/components/date-picker/code.mdx
@@ -78,17 +78,17 @@ usage documentation, see the Storybooks for each framework below.
       variant: 'components-datepicker--single-with-calendar',
     },
     {
-      label: 'Fluid Range With Calendar (unstable)',
+      label: 'Fluid Range With Calendar',
       variant:
-        'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
+        'components-fluid-components-fluiddatepicker--range-with-calendar',
     },
     {
-      label: 'Fluid Simple (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
+      label: 'Fluid Simple',
+      variant: 'components-fluid-components-fluiddatepicker--simple',
     },
     {
-      label: 'Fluid Single (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddatepicker--single',
+      label: 'Fluid Single',
+      variant: 'components-fluid-components-fluiddatepicker--single',
     },
     {
       label: 'Single with AI label',

--- a/src/pages/components/date-picker/usage.mdx
+++ b/src/pages/components/date-picker/usage.mdx
@@ -62,17 +62,17 @@ details.
       variant: 'components-datepicker--single-with-calendar',
     },
     {
-      label: 'Fluid Range With Calendar (unstable)',
+      label: 'Fluid Range With Calendar',
       variant:
-        'experimental-fluid-components-unstable-fluiddatepicker--range-with-calendar',
+        'components-fluid-components-fluiddatepicker--range-with-calendar',
     },
     {
-      label: 'Fluid Simple (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddatepicker--simple',
+      label: 'Fluid Simple',
+      variant: 'components-fluid-components-fluiddatepicker--simple',
     },
     {
-      label: 'Fluid Single (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddatepicker--single',
+      label: 'Fluid Single',
+      variant: 'components-fluid-components-fluiddatepicker--single',
     },
     {
       label: 'Single with AI label',

--- a/src/pages/components/dropdown/code.mdx
+++ b/src/pages/components/dropdown/code.mdx
@@ -78,13 +78,12 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-dropdown--inline',
     },
     {
-      label: 'Fluid dropdown (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddropdown--default',
+      label: 'Fluid dropdown',
+      variant: 'components-fluid-components-fluiddropdown--default',
     },
     {
-      label: 'Fluid condensed dropdown (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluiddropdown--condensed',
+      label: 'Fluid condensed dropdown',
+      variant: 'components-fluid-components-fluiddropdown--condensed',
     },
     {
       label: 'Dropdown with AI label',
@@ -103,27 +102,24 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-multiselect--filterable-with-ai-label',
     },
     {
-      label: 'Fluid multiselect (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidmultiselect--default',
+      label: 'Fluid multiselect',
+      variant: 'components-fluid-components-fluidmultiselect--default',
     },
     {
-      label: 'Fluid condensed multiselect (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidmultiselect--condensed',
+      label: 'Fluid condensed multiselect',
+      variant: 'components-fluid-components-fluidmultiselect--condensed',
     },
     {
       label: 'Combobox',
       variant: 'components-combobox--default',
     },
     {
-      label: 'Fluid combobox (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidcombobox--default',
+      label: 'Fluid combobox',
+      variant: 'components-fluid-components-fluidcombobox--default',
     },
     {
-      label: 'Fluid condensed combobox (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidcombobox--condensed',
+      label: 'Fluid condensed combobox',
+      variant: 'components-fluid-components-fluidcombobox--condensed',
     },
     {
       label: 'Combobox with AI label',

--- a/src/pages/components/dropdown/usage.mdx
+++ b/src/pages/components/dropdown/usage.mdx
@@ -62,13 +62,12 @@ section for more details.
       variant: 'components-dropdown--inline',
     },
     {
-      label: 'Fluid dropdown (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluiddropdown--default',
+      label: 'Fluid dropdown',
+      variant: 'components-fluid-components-fluiddropdown--default',
     },
     {
-      label: 'Fluid condensed dropdown (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluiddropdown--condensed',
+      label: 'Fluid condensed dropdown',
+      variant: 'components-fluid-components-fluiddropdown--condensed',
     },
     {
       label: 'Dropdown with AI label',
@@ -87,27 +86,24 @@ section for more details.
       variant: 'components-multiselect--filterable-with-ai-label',
     },
     {
-      label: 'Fluid multiselect (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidmultiselect--default',
+      label: 'Fluid multiselect',
+      variant: 'components-fluid-components-fluidmultiselect--default',
     },
     {
-      label: 'Fluid condensed multiselect (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidmultiselect--condensed',
+      label: 'Fluid condensed multiselect',
+      variant: 'components-fluid-components-fluidmultiselect--condensed',
     },
     {
       label: 'Combobox',
       variant: 'components-combobox--default',
     },
     {
-      label: 'Fluid combobox (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidcombobox--default',
+      label: 'Fluid combobox',
+      variant: 'components-fluid-components-fluidcombobox--default',
     },
     {
-      label: 'Fluid condensed combobox (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidcombobox--condensed',
+      label: 'Fluid condensed combobox',
+      variant: 'components-fluid-components-fluidcombobox--condensed',
     },
     {
       label: 'Combobox with AI label',

--- a/src/pages/components/form/code.mdx
+++ b/src/pages/components/form/code.mdx
@@ -71,8 +71,8 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-form--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-fluidform--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidform--default',
     },
   ]}
 />

--- a/src/pages/components/form/usage.mdx
+++ b/src/pages/components/form/usage.mdx
@@ -52,8 +52,8 @@ the [AI presence](/components/form/usage/#ai-presence) section for more details.
       variant: 'components-form--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-fluidform--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidform--default',
     },
   ]}
 />

--- a/src/pages/components/number-input/code.mdx
+++ b/src/pages/components/number-input/code.mdx
@@ -69,9 +69,8 @@ usage documentation, see the Storybooks for each framework below.
       variant: 'components-numberinput--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidnumberinput--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidnumberinput--default',
     },
     {
       label: 'With AI label',

--- a/src/pages/components/number-input/usage.mdx
+++ b/src/pages/components/number-input/usage.mdx
@@ -51,9 +51,8 @@ details.
       variant: 'components-numberinput--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidnumberinput--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidnumberinput--default',
     },
     {
       label: 'With AI label',

--- a/src/pages/components/search/code.mdx
+++ b/src/pages/components/search/code.mdx
@@ -77,8 +77,8 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-search--expandable',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidsearch--default',
     },
   ]}
 />

--- a/src/pages/components/search/usage.mdx
+++ b/src/pages/components/search/usage.mdx
@@ -46,8 +46,8 @@ without navigation.
       variant: 'components-search--expandable',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidsearch--default',
     },
   ]}
 />

--- a/src/pages/components/select/code.mdx
+++ b/src/pages/components/select/code.mdx
@@ -73,8 +73,8 @@ documentation, see the Storybooks for each framework below.
       variant: 'components-select--inline',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidsearch--default',
     },
     {
       label: 'With AI label',

--- a/src/pages/components/select/usage.mdx
+++ b/src/pages/components/select/usage.mdx
@@ -53,8 +53,8 @@ details.
       variant: 'components-select--inline',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidsearch--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidsearch--default',
     },
     {
       label: 'With AI label',

--- a/src/pages/components/text-input/code.mdx
+++ b/src/pages/components/text-input/code.mdx
@@ -81,18 +81,17 @@ usage documentation, see the Storybooks for each framework below.
       variant: 'components-passwordinput--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidtextinput--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidtextinput--default',
     },
     {
-      label: 'Fluid with tooltip (unstable)',
+      label: 'Fluid with tooltip',
       variant:
-        'experimental-fluid-components-unstable-fluidtextinput--default-with-tooltip',
+        'components-fluid-components-fluidtextinput--default-with-tooltip',
     },
     {
-      label: 'Fluid with password input (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidpasswordinput--default',
+      label: 'Fluid with password input',
+      variant: 'components-fluid-components-fluidpasswordinput--default',
     },
     {
       label: 'Text area with AI label',

--- a/src/pages/components/text-input/usage.mdx
+++ b/src/pages/components/text-input/usage.mdx
@@ -66,18 +66,17 @@ section for more details.
       variant: 'components-passwordinput--default',
     },
     {
-      label: 'Fluid (unstable)',
-      variant: 'experimental-fluid-components-unstable-fluidtextinput--default',
+      label: 'Fluid',
+      variant: 'components-fluid-components-fluidtextinput--default',
     },
     {
-      label: 'Fluid with tooltip (unstable)',
+      label: 'Fluid with tooltip',
       variant:
-        'experimental-fluid-components-unstable-fluidtextinput--default-with-tooltip',
+        'components-fluid-components-fluidtextinput--default-with-tooltip',
     },
     {
-      label: 'Fluid with password input (unstable)',
-      variant:
-        'experimental-fluid-components-unstable-fluidpasswordinput--default',
+      label: 'Fluid with password input',
+      variant: 'components-fluid-components-fluidpasswordinput--default',
     },
     {
       label: 'Text area with AI label',


### PR DESCRIPTION
Related to https://github.com/carbon-design-system/carbon/pull/20351

#### Changelog


**Changed**

- Update all StorybookDemo component variant urls and labels 

@tay1orjones We actually don't need to merge this into the release PR, these are unrelated to the version of the website because the iframe in directly from Storybook, so as soon as the new storybook is deployed the urls will change. 

> [!IMPORTANT]
> Wait to merge until `v1.91.0` React Storybook is live 
