### PR TITLE
docs: remove broken links from releases page

### DIFF
--- a/src/pages/all-about-carbon/releases.mdx
+++ b/src/pages/all-about-carbon/releases.mdx
@@ -72,9 +72,9 @@ As of September 30, 2024, all v10 assets have been deprecated.
 | -------------------- | ------------------- | --------------- | ----------------- | ------------ | ------------ |
 | [Carbon v11](https://www.carbondesignsystem.com)<br />— 31 Mar 2022<br />— Improves token and prop naming<br />— Adds light/dark mode support<br />— Uses CSS grid | [IDL v2](https://www.ibm.com/design/language) | [v11.x](https://www.npmjs.com/package/@carbon/elements/v/latest) | v11.x | [v8.x](https://www.npmjs.com/package/carbon-components-react/v/latest) | [v1.x](https://www.npmjs.com/package/@carbon/react/v/latest) |
 | [Carbon v10](https://v10.carbondesignsystem.com)<br />— 29 Mar 2019<br />— Updates assets to IDL v2<br />— Updates grid to 16 columns<br />— Adds Carbon Elements package | [IDL v2](https://www.ibm.com/design/language) | v10.x | [v10.x](https://www.npmjs.com/package/carbon-components/v/latest) | v7.x | — |
-| [Carbon v9](https://v9.carbondesignsystem.com)<br />— 4 June 2018 | IDL v1 | — | [v9.x](https://www.npmjs.com/package/carbon-components/v/9.x) | [v6.x](https://www.npmjs.com/package/carbon-components-react/v/6.x) | — |
-| [Carbon v8](https://v8.carbondesignsystem.com)<br />— 26 Oct 2017 | IDL v1 | — | [v8.23.1](https://www.npmjs.com/package/carbon-components/v/8.23.1) | [v5.x](https://www.npmjs.com/package/carbon-components-react/v/5.x) | — |
-| [Carbon v7](https://v7.carbondesignsystem.com)<br />— 30 Mar 2017 | IDL v1 | — | [v7.26.10](https://www.npmjs.com/package/carbon-components/v/7.26.10) | [v4.2.2](https://www.npmjs.com/package/carbon-components-react/v/4.2.2) | — |
-| [Carbon v6](https://v6.carbondesignsystem.com) | IDL v1 | — | [v6.20.1](https://www.npmjs.com/package/carbon-components/v/6.20.1) | [v3.14.0](https://www.npmjs.com/package/carbon-components-react/v/3.14.0) | — |
+| Carbon v9 <br />— 4 June 2018 | IDL v1 | — | [v9.x](https://www.npmjs.com/package/carbon-components/v/9.x) | [v6.x](https://www.npmjs.com/package/carbon-components-react/v/6.x) | — |
+| Carbon v8 <br />— 26 Oct 2017 | IDL v1 | — | [v8.23.1](https://www.npmjs.com/package/carbon-components/v/8.23.1) | [v5.x](https://www.npmjs.com/package/carbon-components-react/v/5.x) | — |
+| Carbon v7 <br />— 30 Mar 2017 | IDL v1 | — | [v7.26.10](https://www.npmjs.com/package/carbon-components/v/7.26.10) | [v4.2.2](https://www.npmjs.com/package/carbon-components-react/v/4.2.2) | — |
+| Carbon v6 | IDL v1 | — | [v6.20.1](https://www.npmjs.com/package/carbon-components/v/6.20.1) | [v3.14.0](https://www.npmjs.com/package/carbon-components-react/v/3.14.0) | — |
 
 {/* prettier-ignore-end */}


### PR DESCRIPTION
Closes #4706 

Remove old website links for v6-v9 from the Releases page in the Release history section since those links don't work anymore.

---

**Removed**

- Removed old broken links
