### PR TITLE
docs(usage): removed duplicated text

### DIFF
--- a/src/pages/components/modal/usage.mdx
+++ b/src/pages/components/modal/usage.mdx
@@ -194,7 +194,7 @@ might be needed instead.
 
 ### Alignment
 
-In a modal that has larger breakpoints and
+In a modal that has
 [larger breakpoints](/components/modal/style#margin-right), body copy, including
 titles, use a 20% margin-right. However, form inputs and other components expand
 the entire width of a modal.


### PR DESCRIPTION
Removed duplicate mention of "larger breakpoints". Changelog
Changed

Old text:
"In a modal that has larger breakpoints and larger breakpoints, body copy, including titles, use a 20% margin-right. However, form inputs and other components expand the entire width of a modal."

New text:
"In a modal that has larger breakpoints, body copy, including titles, use a 20% margin-right. However, form inputs and other components expand the entire width of a modal."

#### Changelog

**Removed**

- "In a modal that has larger breakpoints ~~and larger breakpoints~~, body copy, including titles, use a 20% margin-right. However, form inputs and other components expand the entire width of a modal."
