### PR TITLE
docs(text-input): update password input read-only documentation

### DIFF
--- a/src/pages/components/text-input/style.mdx
+++ b/src/pages/components/text-input/style.mdx
@@ -87,7 +87,6 @@ structure, size, and AI presence.
 |           | Field text (default) | text color    | `$text-primary`     |
 |           | Field text (fluid)   | text color    | `$text-secondary`   |
 |           | Field                | border-bottom | `$border-subtle` \* |
-|           | Password toggle icon | state         | disabled            |
 
 <Caption fullWidth>
   \* Denotes a contextual color token that will change values based on the layer


### PR DESCRIPTION
Closes #4757

Updated the Password Input documentation to reflect that the visibility toggle is disabled in the read-only state and added a corresponding Storybook demo variant.

Changelog
New

Added "Password Input (Read only)" variant to the Storybook demo in 
code.mdx
.
Changed

Updated 
usage.mdx
 to explicitly state that the password visibility toggle is disabled when the input is read-only.
Removed

None