### PR TITLE
docs: update carbon champions for 2025

### DIFF
--- a/src/pages/contributing/get-started/overview.mdx
+++ b/src/pages/contributing/get-started/overview.mdx
@@ -126,29 +126,30 @@ the design system.
 <Row className="mobile-columns">
 <Column className="one" colSm={2} colMd={2} colLg={3}>
 
-**Drew Glapa**<br /> Carbon Labs animated header<br /><br /> **Manuel Ramos Gonzalez**<br /> Carbon MCP Baseline Participant<br /><br /> **Ryan Downs**<br />
-Carbon MCP Baseline Participant
+**Drew Glapa**<br /> Carbon Labs animated header<br /><br /> **Manuel Ramos
+Gonzalez**<br /> Carbon MCP Baseline Participant<br /><br /> **Ryan
+Downs**<br /> Carbon MCP Baseline Participant
 
 </Column>
 
 <Column className="one" colSm={2} colMd={2} colLg={3}>
 
-**Jigar Thakor**<br /> Carbon MCP Baseline Participant<br /><br />
-**Marion Hekeler**<br /> Carbon Labs animated header
+**Jigar Thakor**<br /> Carbon MCP Baseline Participant<br /><br /> **Marion
+Hekeler**<br /> Carbon Labs animated header
 
 </Column>
 
 <Column className="one" colSm={2} colMd={2} colLg={3}>
 
-**Joseph Stowers**<br /> Carbon MCP Baseline Participant<br /><br /> **Mike Olasov**<br />
-Carbon Labs animated header
+**Joseph Stowers**<br /> Carbon MCP Baseline Participant<br /><br /> **Mike
+Olasov**<br /> Carbon Labs animated header
 
 </Column>
 
 <Column className="one" colSm={2} colMd={2} colLg={3}>
 
-**Juan Encalada**<br /> Future Carbon Figma strategy<br /><br /> **Mudita Bhatia**<br />
-Carbon MCP Baseline Participant
+**Juan Encalada**<br /> Future Carbon Figma strategy<br /><br /> **Mudita
+Bhatia**<br /> Carbon MCP Baseline Participant
 
 </Column>
 </Row>


### PR DESCRIPTION
Closes #4793 

This PR updates the Carbon Champions list on our website to reflect last years contributors (2025). Also included the people who contributed and participated for the Carbon MCP Baseline workstream.

---

**Changed**

- Updated contributor names for 2025

