### PR TITLE
docs: update Vanilla JS deprecation notice

### DIFF
--- a/src/pages/developing/community-frameworks/vanilla.mdx
+++ b/src/pages/developing/community-frameworks/vanilla.mdx
@@ -19,8 +19,8 @@ prototype and production work.
 <InlineNotification>
 
 The vanilla JS library is deprecated since v11 and has been replaced by
-[Carbon Web Components](/developing/frameworks/web-components/). We advise to
-migrate at the next possible opportunity. For legacy details, visit the
+[Carbon Web Components](/developing/frameworks/web-components/). We advise
+migrating at the next possible opportunity. For legacy details, visit the
 [v10 documentation](https://v10.carbondesignsystem.com/developing/frameworks/vanilla).
 For support,
 [open an issue on GitHub](https://github.com/carbon-design-system/carbon/issues/new/choose).


### PR DESCRIPTION
Closes #4805

Update the Vanilla community frameworks documentation notice.

For: 
```
The vanilla JS library is deprecated since v11 and has been replaced by
[Carbon Web Components](/developing/frameworks/web-components/). We advise to
migrate at the next possible opportunity. For legacy details, visit the
[v10 documentation](https://v10.carbondesignsystem.com/developing/frameworks/vanilla).
For support,
[open an issue on GitHub](https://github.com/carbon-design-system/carbon/issues/new/choose).
```


#### Changelog

**New**

- ~None.~

**Changed**

- [community-frameworks/vanilla.mdx](https://github.com/carbon-design-system/carbon-website/blob/main/src/pages/developing/community-frameworks/vanilla.mdx#:~:text=The%20vanilla%20JS%20library%20is%20maintained%20by%20members%20of%20the%20Carbon%20community.%20Vanilla%20JS%20is%20only%20supported%20in%20v10.%20Please%20visit%20our%20v10%20documentation%20for%20more%20info.%20For%20support%2C%20open%20an%20issue%20on%20GitHub.)

**Removed**

- ~None~