### PR TITLE
chore: update with new syntax tokens

### DIFF
--- a/src/data/guidelines/color-tokens.js
+++ b/src/data/guidelines/color-tokens.js
@@ -2414,6 +2414,24 @@ const colorTokens = {
         g100: { name: 'Blue 50', hex: '#4589ff' },
       },
     },
+    '$syntax-deleted': {
+      role: ['Color literal'],
+      value: {
+        white: { name: 'Red 20', hex: '#ffd7d9' },
+        g10: { name: 'Red 20', hex: '#ffd7d9' },
+        g90: { name: 'Red 70', hex: '#a2191f' },
+        g100: { name: 'Red 70', hex: '#a2191f' },
+      },
+    },
+    '$syntax-inserted': {
+      role: ['Color literal'],
+      value: {
+        white: { name: 'Green 20', hex: '#a7f0ba' },
+        g10: { name: 'Green 20', hex: '#a7f0ba' },
+        g90: { name: 'Green 60', hex: '#198038' },
+        g100: { name: 'Green 60', hex: '#198038' },
+      },
+    },
   },
 
   'icon-tokens': {


### PR DESCRIPTION
This PR adds 2 new syntax tokens

`syntax-inserted` + `syntax-deleted` for diff markdown background colors

Corresponding core [PR](https://github.com/carbon-design-system/carbon/pull/22037)

<img  height="848" alt="Screenshot 2026-04-17 at 1 16 34 PM" src="https://github.com/user-attachments/assets/3c006f08-aaa0-461c-8c01-74c96588f475" />


#### Changelog

**New**

- 2 new syntax tokens