### PR TITLE
ci(dco): allow kodiak to pass DCO check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -19,7 +19,7 @@ jobs:
           path-to-signatures: "dco-signatures.json"
           path-to-document: "https://github.com/carbon-design-system/carbon-dco/blob/main/dco.md"
           branch: "main"
-          allowlist: bot*
+          allowlist: bot*,kodiakhq
           remote-organization-name: carbon-design-system
           remote-repository-name: carbon-dco
           create-file-commit-message: "chore: create file to store dco signatures"


### PR DESCRIPTION
No issue

Adds kodiak to the allowlist to fix an issue where the DCO check would fail when `kodiakhq` authored a commit

#### Changelog

**New**

- Added `kodiakhq` to the allowlist
