### PR TITLE
chore(deps): bump carbon icons/pictograms to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   ],
   "dependencies": {
     "@carbon/charts-react": "0.55.0",
-    "@carbon/icons-react": "^11.78.0",
-    "@carbon/pictograms": "^12.73.0",
-    "@carbon/pictograms-react": "^11.99.0",
+    "@carbon/icons-react": "^11.81.0",
+    "@carbon/pictograms": "^12.76.0",
+    "@carbon/pictograms-react": "^11.102.0",
     "@loadable/babel-plugin": "^5.16.1",
     "@loadable/component": "^5.16.4",
     "codesandbox": "^2.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,21 +2730,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.28.5":
-  version: 10.72.0
-  resolution: "@carbon/icon-helpers@npm:10.72.0"
+"@carbon/icon-helpers@npm:^10.28.5, @carbon/icon-helpers@npm:^10.76.0":
+  version: 10.76.0
+  resolution: "@carbon/icon-helpers@npm:10.76.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/98408f4d27406a05e02b713134a738b1c348430d43c07e35415ad106b65ac81448c3e7e40bb80c12d974ee1afa2660f23310a4b52c9ab3f9dd264b915e83379b
-  languageName: node
-  linkType: hard
-
-"@carbon/icon-helpers@npm:^10.74.0":
-  version: 10.74.0
-  resolution: "@carbon/icon-helpers@npm:10.74.0"
-  dependencies:
-    "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/8b5cc67d284d136fea71627f285e1c0826f672f75cdd6a2a3740d6e14c6c9ac7e138543a7d316db2a1bdfb42463f6ae5ec4bb3ef3765ca98c064504e32068859
+  checksum: 10c0/1529764f94a492b9dfcdc269c3a3d7a9ce13e8778581666849b4f24b69f4643c999902bce2771e9655942287d2b3a28d61034da8709ba562df8802c5829846ed
   languageName: node
   linkType: hard
 
@@ -2761,16 +2752,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.78.0":
-  version: 11.78.0
-  resolution: "@carbon/icons-react@npm:11.78.0"
+"@carbon/icons-react@npm:^11.78.0, @carbon/icons-react@npm:^11.81.0":
+  version: 11.81.0
+  resolution: "@carbon/icons-react@npm:11.81.0"
   dependencies:
-    "@carbon/icon-helpers": "npm:^10.74.0"
+    "@carbon/icon-helpers": "npm:^10.76.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     react: ">=16"
-  checksum: 10c0/9ca9caa2e7761191a58554968a04538f87a1f46fcce44334df14bce35d2458187eec9c0f64df2b4ab56d2e08e10c6448e0415c73dd79289e2bc2136093e0a164
+  checksum: 10c0/eb6e2e8c91e3d652f103a17d4ceafdffdf1c28449177d8a7419f69067e38c4b4ef73e99e19f7847fd923faf9ce0c31e54f083f1775a7efebedae2555bbe16374
   languageName: node
   linkType: hard
 
@@ -2801,25 +2792,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/pictograms-react@npm:^11.99.0":
-  version: 11.99.0
-  resolution: "@carbon/pictograms-react@npm:11.99.0"
+"@carbon/pictograms-react@npm:^11.102.0, @carbon/pictograms-react@npm:^11.99.0":
+  version: 11.102.0
+  resolution: "@carbon/pictograms-react@npm:11.102.0"
   dependencies:
-    "@carbon/icon-helpers": "npm:^10.74.0"
+    "@carbon/icon-helpers": "npm:^10.76.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     prop-types: "npm:^15.8.1"
   peerDependencies:
     react: ">=16"
-  checksum: 10c0/9b07bb276340ff82534c1839ca910b6ebb608d3d1517a73809562179d88397982dc438e819d0dc5cf6f02338bd7d7ea6c14be87dd86acb15c9b341d54a518130
+  checksum: 10c0/7d33201c93753240d6486754f8f6925e785933a743da5b7d3e3f354821c7c4bac4b79c0b73a2bba0f407b7c084d6bec5b7c46f3a3aed1ab798161abd37201afc
   languageName: node
   linkType: hard
 
-"@carbon/pictograms@npm:^12.73.0":
-  version: 12.73.0
-  resolution: "@carbon/pictograms@npm:12.73.0"
+"@carbon/pictograms@npm:^12.76.0":
+  version: 12.76.0
+  resolution: "@carbon/pictograms@npm:12.76.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/e25d35a5184b4095c6fea2052fd54e8c817bb52d6f6658640b99eb149dbac9a74ea7ced34ef1c6581f83bc471598636e70be11ba7e384c3bfca2703a28b0ac0c
+  checksum: 10c0/543a2cf5cb52c9875cf2138e26733ab250e20064ac7c7e54a22cf22a1cc3a4df95a15f169c7465fef5dfe7d3e08bab6ae90cfcefd7064bd0646d2957b24be4d8
   languageName: node
   linkType: hard
 
@@ -3511,17 +3502,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint-community/regexpp@npm:^4.12.1":
+"@eslint-community/regexpp@npm:^4.12.1, @eslint-community/regexpp@npm:^4.4.0":
   version: 4.12.2
   resolution: "@eslint-community/regexpp@npm:4.12.2"
   checksum: 10c0/fddcbc66851b308478d04e302a4d771d6917a0b3740dc351513c0da9ca2eab8a1adf99f5e0aa7ab8b13fa0df005c81adeee7e63a92f3effd7d367a163b721c2d
-  languageName: node
-  linkType: hard
-
-"@eslint-community/regexpp@npm:^4.4.0":
-  version: 4.12.1
-  resolution: "@eslint-community/regexpp@npm:4.12.1"
-  checksum: 10c0/a03d98c246bcb9109aec2c08e4d10c8d010256538dcb3f56610191607214523d4fb1b00aa81df830b6dffb74c5fa0be03642513a289c567949d3e550ca11cdf6
   languageName: node
   linkType: hard
 
@@ -9157,9 +9141,9 @@ __metadata:
   resolution: "carbondesignsystem@workspace:."
   dependencies:
     "@carbon/charts-react": "npm:0.55.0"
-    "@carbon/icons-react": "npm:^11.78.0"
-    "@carbon/pictograms": "npm:^12.73.0"
-    "@carbon/pictograms-react": "npm:^11.99.0"
+    "@carbon/icons-react": "npm:^11.81.0"
+    "@carbon/pictograms": "npm:^12.76.0"
+    "@carbon/pictograms-react": "npm:^11.102.0"
     "@eslint/compat": "npm:^1.4.1"
     "@eslint/eslintrc": "npm:^3.3.1"
     "@eslint/js": "npm:^9.39.2"
@@ -11899,14 +11883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.3.47":
-  version: 1.5.76
-  resolution: "electron-to-chromium@npm:1.5.76"
-  checksum: 10c0/5a977be9fd5810769a7b4eae0e4b41b6beca65f2b3f3b7442819f6c93366d767d183cfbf408714f944a9bf3aa304f8c9ab9d0cdfd8e878ab8f2cbb61f8b22acd
-  languageName: node
-  linkType: hard
-
-"electron-to-chromium@npm:^1.5.263":
+"electron-to-chromium@npm:^1.3.47, electron-to-chromium@npm:^1.5.263":
   version: 1.5.286
   resolution: "electron-to-chromium@npm:1.5.286"
   checksum: 10c0/5384510f9682d7e46f98fa48b874c3901d9639de96e9e387afce1fe010fbac31376df0534524edc15f66e9902bfacee54037a5e598004e9c6a617884e379926d
@@ -13272,16 +13249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esquery@npm:^1.4.0, esquery@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "esquery@npm:1.6.0"
-  dependencies:
-    estraverse: "npm:^5.1.0"
-  checksum: 10c0/cb9065ec605f9da7a76ca6dadb0619dfb611e37a81e318732977d90fab50a256b95fee2d925fba7c2f3f0523aa16f91587246693bc09bc34d5a59575fe6e93d2
-  languageName: node
-  linkType: hard
-
-"esquery@npm:^1.5.0":
+"esquery@npm:^1.4.0, esquery@npm:^1.5.0, esquery@npm:^1.6.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
   dependencies:
@@ -14470,17 +14438,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.9
-  resolution: "follow-redirects@npm:1.15.9"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/5829165bd112c3c0e82be6c15b1a58fa9dcfaede3b3c54697a82fe4a62dd5ae5e8222956b448d2f98e331525f05d00404aba7d696de9e761ef6e42fdc780244f
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.15.11":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.11":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -21337,21 +21295,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.8":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
   checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
-  languageName: node
-  linkType: hard
-
-"nanoid@npm:^3.3.8":
-  version: 3.3.8
-  resolution: "nanoid@npm:3.3.8"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/4b1bb29f6cfebf3be3bc4ad1f1296fb0a10a3043a79f34fbffe75d1621b4318319211cd420549459018ea3592f0d2f159247a6f874911d6d26eaaadda2478120
   languageName: node
   linkType: hard
 
@@ -23973,21 +23922,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.14.1, qs@npm:~6.14.0":
+"qs@npm:^6.14.1, qs@npm:^6.9.6, qs@npm:~6.14.0":
   version: 6.14.1
   resolution: "qs@npm:6.14.1"
   dependencies:
     side-channel: "npm:^1.1.0"
   checksum: 10c0/0e3b22dc451f48ce5940cbbc7c7d9068d895074f8c969c0801ac15c1313d1859c4d738e46dc4da2f498f41a9ffd8c201bd9fb12df67799b827db94cc373d2613
-  languageName: node
-  linkType: hard
-
-"qs@npm:^6.9.6":
-  version: 6.14.0
-  resolution: "qs@npm:6.14.0"
-  dependencies:
-    side-channel: "npm:^1.1.0"
-  checksum: 10c0/8ea5d91bf34f440598ee389d4a7d95820e3b837d3fd9f433871f7924801becaa0cd3b3b4628d49a7784d06a8aea9bc4554d2b6d8d584e2d221dc06238a42909c
   languageName: node
   linkType: hard
 
@@ -25519,14 +25459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sax@npm:>=0.6.0, sax@npm:^1.2.4":
-  version: 1.4.4
-  resolution: "sax@npm:1.4.4"
-  checksum: 10c0/acb642f2de02ad6ae157cbf91fb026acea80cdf92e88c0aec2aa350c7db3479f62a7365c34a58e3b70a72ce11fa856a02c38cfd27f49e83c18c9c7e1d52aee55
-  languageName: node
-  linkType: hard
-
-"sax@npm:^1.5.0":
+"sax@npm:>=0.6.0, sax@npm:^1.2.4, sax@npm:^1.5.0":
   version: 1.5.0
   resolution: "sax@npm:1.5.0"
   checksum: 10c0/bc3b60a7bfecd40b18256596e96b32df2488339ae1e00a77f842b568f0831228a16c3bd357ec500241ec0b9dc7a475a1286427795c4a8c50bb8e8878f3435dd8
@@ -27798,14 +27731,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^4.18.2, type-fest@npm:^4.21.0, type-fest@npm:^4.6.0":
-  version: 4.34.1
-  resolution: "type-fest@npm:4.34.1"
-  checksum: 10c0/4aa016be91f4225b772d77da91415cd25961a937f84e68d763b2dfeb936ef1671b039bbb0f75019affb8f591c26d65966024343aae75b17ab49db6f9c50c38a8
-  languageName: node
-  linkType: hard
-
-"type-fest@npm:^4.39.1":
+"type-fest@npm:^4.18.2, type-fest@npm:^4.21.0, type-fest@npm:^4.39.1, type-fest@npm:^4.6.0":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
   checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4


### PR DESCRIPTION
Upgrade Carbon icons and pictograms packages to latest versions to include changes from PRs such as https://github.com/carbon-design-system/carbon/pull/21895.

#### Changelog

**Changed**

- upgrade Carbon icons and pictogram dependencies to latest version
