### PR TITLE
chore(deps): update gatsby-theme-carbon dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "d3": "^7.9.0",
     "gatsby": "^5.13.5",
     "gatsby-plugin-sharp": "^5.13.1",
-    "gatsby-theme-carbon": "^4.3.52",
+    "gatsby-theme-carbon": "^4.3.53",
     "markdown-it": "^14.2.0",
     "prettier-config-carbon": "^0.11.0",
     "react": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2686,51 +2686,51 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.52.0":
-  version: 11.52.0
-  resolution: "@carbon/colors@npm:11.52.0"
+"@carbon/colors@npm:^11.53.0":
+  version: 11.53.0
+  resolution: "@carbon/colors@npm:11.53.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/7ae765a01c7439be22e305abe91af135a85754775c0039f1379c7f64f7022a4a3ca18608f612e956e978980ab089f64f37bb2c376cf04655a7ac222f2a6b78e0
+  checksum: 10c0/b9e94c9dc41f2e3bbae00ae3f3c5acffbfca975c94248b30e5ad2ac3fb208e166c16cb3a8dd85b9251f6f7603b5d2f368979aee586c13f4f3b3e63baef95992f
   languageName: node
   linkType: hard
 
-"@carbon/elements@npm:^11.91.0":
-  version: 11.91.0
-  resolution: "@carbon/elements@npm:11.91.0"
+"@carbon/elements@npm:^11.92.1":
+  version: 11.92.1
+  resolution: "@carbon/elements@npm:11.92.1"
   dependencies:
-    "@carbon/colors": "npm:^11.52.0"
-    "@carbon/grid": "npm:^11.56.0"
-    "@carbon/icons": "npm:^11.82.0"
-    "@carbon/layout": "npm:^11.53.0"
-    "@carbon/motion": "npm:^11.46.0"
-    "@carbon/themes": "npm:^11.75.0"
-    "@carbon/type": "npm:^11.61.0"
+    "@carbon/colors": "npm:^11.53.0"
+    "@carbon/grid": "npm:^11.57.0"
+    "@carbon/icons": "npm:^11.83.0"
+    "@carbon/layout": "npm:^11.54.0"
+    "@carbon/motion": "npm:^11.47.0"
+    "@carbon/themes": "npm:^11.76.1"
+    "@carbon/type": "npm:^11.62.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/05431b041c5a9eb7e0179571583737ed887a4a6f6e132fbd73a757a03d3b4591bec8388c13cc589d760e72604b9f4a122fcde52531ea3cbb577c75b13eca7475
+  checksum: 10c0/694b532aa2b56a88862a0dc89f69e5fb827cd75db154268cd57ee2efefbca5463adf40f3042d3dd8f7be783a6ac0ab2cc5c561f3c5a3ed4673430c79d0072f80
   languageName: node
   linkType: hard
 
-"@carbon/feature-flags@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "@carbon/feature-flags@npm:1.3.0"
+"@carbon/feature-flags@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "@carbon/feature-flags@npm:1.4.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/b8f3cb0e2d015afa2adcf8f01c8d3eb96c8f39208442d280460c07ce422e748d928804c3a7573ce27bd8e9af58da7bc4ad64701649595fc0337cf0a249a6a8b5
+  checksum: 10c0/2a5323a0bb2ac657a76272835951b31f5001047dd27ae2c208f0b76eba65b44dd9ab0fd865cd9cb1f8ca6b502448029c2b0a9af361fc06aaf0db2a5e57409acf
   languageName: node
   linkType: hard
 
-"@carbon/grid@npm:^11.56.0":
-  version: 11.56.0
-  resolution: "@carbon/grid@npm:11.56.0"
+"@carbon/grid@npm:^11.57.0":
+  version: 11.57.0
+  resolution: "@carbon/grid@npm:11.57.0"
   dependencies:
-    "@carbon/layout": "npm:^11.53.0"
+    "@carbon/layout": "npm:^11.54.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/a16a9e40e306812a52201014fb0e0df545fc125e94286f8465f4ce17e37978d978fa464347d5f11e04f5cd0487da4e9ab283d1c4bc73299753ad6149d1058716
+  checksum: 10c0/92b62a20f8cb91a4fb92884679e74c72a754b9434ff7bf66967bfcc65082e55c1c953b9a801b44488d29b4f8c3a9619d30d03cd9d16670df14d66a33d0f44ea1
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.28.5, @carbon/icon-helpers@npm:^10.76.0":
+"@carbon/icon-helpers@npm:^10.28.5":
   version: 10.76.0
   resolution: "@carbon/icon-helpers@npm:10.76.0"
   dependencies:
@@ -2761,19 +2761,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.82.0":
-  version: 11.82.0
-  resolution: "@carbon/icons-react@npm:11.82.0"
-  dependencies:
-    "@carbon/icon-helpers": "npm:^10.76.0"
-    "@ibm/telemetry-js": "npm:^1.5.0"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    react: ">=16"
-  checksum: 10c0/8a81897b8e03955c5dafbd3a9d09046423011ce14a95a71e369b793387ed9610545c918c13ea971b3010628358666d574bc0268003fe90f3027ea529e1613d1c
-  languageName: node
-  linkType: hard
-
 "@carbon/icons-react@npm:^11.83.0":
   version: 11.83.0
   resolution: "@carbon/icons-react@npm:11.83.0"
@@ -2787,43 +2774,30 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons@npm:^11.82.0":
-  version: 11.82.0
-  resolution: "@carbon/icons@npm:11.82.0"
+"@carbon/icons@npm:^11.83.0":
+  version: 11.83.0
+  resolution: "@carbon/icons@npm:11.83.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/2949bb1be4c4a55984f50ae05cf6303eb4aafeb3543aac66b6ec9e98f7a9dafdd3f0ce7ef945faff1cb569a5f2698b1afeefd41f2018f60ddfbf844c27843dfd
+  checksum: 10c0/3517dd0bbca2377f8278e3636c6d42342d60036a32f60c4255fcac43f6958d1c2777e0a8a5e4ed9df150926c662007445167705f2753da2114a52ba2b7570315
   languageName: node
   linkType: hard
 
-"@carbon/layout@npm:^11.53.0":
-  version: 11.53.0
-  resolution: "@carbon/layout@npm:11.53.0"
+"@carbon/layout@npm:^11.54.0":
+  version: 11.54.0
+  resolution: "@carbon/layout@npm:11.54.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/d5688bc0c277b3b649b64545c86d5e4d86b81d67fc90dedd754b35703d7bf8146673a5cdc0eb38dea23368e68716a2c124a3f86744bc65c6f8930f81f5b2653d
+  checksum: 10c0/6b90e6c1bc87d7b5573373095530a73c6552419938a3377d219013f7586c885c69a710504b7c73744e146ad68a45877e74935135519fa7d12362165383dfe1a1
   languageName: node
   linkType: hard
 
-"@carbon/motion@npm:^11.46.0":
-  version: 11.46.0
-  resolution: "@carbon/motion@npm:11.46.0"
+"@carbon/motion@npm:^11.47.0":
+  version: 11.47.0
+  resolution: "@carbon/motion@npm:11.47.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/154858b2d1eb0ad30ab97c83e4cb90e2d83b8577c9d5e20452281944914dededf7b32910973ec0badafd60638e931cd48862a438146232c5af54430368d4df6d
-  languageName: node
-  linkType: hard
-
-"@carbon/pictograms-react@npm:^11.104.0":
-  version: 11.104.0
-  resolution: "@carbon/pictograms-react@npm:11.104.0"
-  dependencies:
-    "@carbon/icon-helpers": "npm:^10.76.0"
-    "@ibm/telemetry-js": "npm:^1.5.0"
-    prop-types: "npm:^15.8.1"
-  peerDependencies:
-    react: ">=16"
-  checksum: 10c0/2c068f1e29d156775156c307a369bf53d090602e33da6a4dc326a923550c74f9b7a2a423fe858ea9ff0e8e0059893807f7500b97910905dfbc6165454d6dbc1c
+  checksum: 10c0/cb5b7fcd7be7ab07de85f7f560deab8c30de1a14cd9ed3df0f4e06712eee06c1fe93b2eba0b6d1b4c83e94772a330b5b8638021c69eaf48edc64d887a853d1a6
   languageName: node
   linkType: hard
 
@@ -2849,16 +2823,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.110.0":
-  version: 1.110.0
-  resolution: "@carbon/react@npm:1.110.0"
+"@carbon/react@npm:^1.111.1":
+  version: 1.111.1
+  resolution: "@carbon/react@npm:1.111.1"
   dependencies:
     "@babel/runtime": "npm:^7.27.3"
-    "@carbon/feature-flags": "npm:^1.3.0"
-    "@carbon/icons-react": "npm:^11.82.0"
-    "@carbon/layout": "npm:^11.53.0"
-    "@carbon/styles": "npm:^1.109.0"
-    "@carbon/utilities": "npm:^0.20.0"
+    "@carbon/feature-flags": "npm:^1.4.0"
+    "@carbon/icons-react": "npm:^11.83.0"
+    "@carbon/layout": "npm:^11.54.0"
+    "@carbon/styles": "npm:^1.110.1"
+    "@carbon/utilities": "npm:^0.21.0"
     "@floating-ui/react": "npm:^0.27.4"
     "@ibm/telemetry-js": "npm:^1.5.0"
     classnames: "npm:2.5.1"
@@ -2875,21 +2849,21 @@ __metadata:
     react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0 || ^19.0.0
     react-is: ^16.13.1 || ^17.0.2 || ^18.3.1 || ^19.0.0
     sass: ^1.33.0
-  checksum: 10c0/d728ff2198f530a3904180b45adbca232c1b6020a6b30b24f9d850639a7b0f0fb11c42d8947bd433fa61196e0bb15401787549ef5ab956a0cf51a33b8af899b3
+  checksum: 10c0/35709adc8438595b5ce4c67f13dda110f2f3c56da6581315c1f843977489329e8e97a8b98fb6f204ac824f54ff8cb0b334c22ae32f386ac9c265747693a9c9f9
   languageName: node
   linkType: hard
 
-"@carbon/styles@npm:^1.109.0":
-  version: 1.109.0
-  resolution: "@carbon/styles@npm:1.109.0"
+"@carbon/styles@npm:^1.110.1":
+  version: 1.110.1
+  resolution: "@carbon/styles@npm:1.110.1"
   dependencies:
-    "@carbon/colors": "npm:^11.52.0"
-    "@carbon/feature-flags": "npm:^1.3.0"
-    "@carbon/grid": "npm:^11.56.0"
-    "@carbon/layout": "npm:^11.53.0"
-    "@carbon/motion": "npm:^11.46.0"
-    "@carbon/themes": "npm:^11.75.0"
-    "@carbon/type": "npm:^11.61.0"
+    "@carbon/colors": "npm:^11.53.0"
+    "@carbon/feature-flags": "npm:^1.4.0"
+    "@carbon/grid": "npm:^11.57.0"
+    "@carbon/layout": "npm:^11.54.0"
+    "@carbon/motion": "npm:^11.47.0"
+    "@carbon/themes": "npm:^11.76.1"
+    "@carbon/type": "npm:^11.62.0"
     "@ibm/plex": "npm:6.4.1"
     "@ibm/plex-mono": "npm:1.1.0"
     "@ibm/plex-sans": "npm:1.1.0"
@@ -2905,7 +2879,7 @@ __metadata:
   peerDependenciesMeta:
     sass:
       optional: true
-  checksum: 10c0/a28946337e5d2f5ace4b26f479bc2c9173fad9955515235d56d07dbdd14e2e0fbec0cfe99538179c38b89651ba61af98bfe6f6392847b3634f2c7e9bc27c31b2
+  checksum: 10c0/dcab059799785bf8ced769ade015661428d39d2ade399e1971f517e7bf985404f8f19e6789b9e88219ae95d49b321d0acdf62f398a085937a0d93d90ca1b694e
   languageName: node
   linkType: hard
 
@@ -2938,37 +2912,37 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/themes@npm:^11.75.0":
-  version: 11.75.0
-  resolution: "@carbon/themes@npm:11.75.0"
+"@carbon/themes@npm:^11.76.1":
+  version: 11.76.1
+  resolution: "@carbon/themes@npm:11.76.1"
   dependencies:
-    "@carbon/colors": "npm:^11.52.0"
-    "@carbon/layout": "npm:^11.53.0"
-    "@carbon/type": "npm:^11.61.0"
+    "@carbon/colors": "npm:^11.53.0"
+    "@carbon/layout": "npm:^11.54.0"
+    "@carbon/type": "npm:^11.62.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
     color: "npm:^4.0.0"
-  checksum: 10c0/67f793f47c56a0311f1001ea42682a05ca756d173c029629b6b15eb13117f12dda2ae6fa248bfb15fec26b51e861ed7b821e56e3b1d10b6f5821c9b49cbc67d7
+  checksum: 10c0/aaeab7844615b43ff03d24ac271982b685daac350552f9429aa62e43e09e5cb6eeb8c848a2c0b0d3bc18b8508e8730607583444b2647514aa606919ba251878a
   languageName: node
   linkType: hard
 
-"@carbon/type@npm:^11.61.0":
-  version: 11.61.0
-  resolution: "@carbon/type@npm:11.61.0"
+"@carbon/type@npm:^11.62.0":
+  version: 11.62.0
+  resolution: "@carbon/type@npm:11.62.0"
   dependencies:
-    "@carbon/grid": "npm:^11.56.0"
-    "@carbon/layout": "npm:^11.53.0"
+    "@carbon/grid": "npm:^11.57.0"
+    "@carbon/layout": "npm:^11.54.0"
     "@ibm/telemetry-js": "npm:^1.5.0"
-  checksum: 10c0/089e1769dab61ad6cef97c0b7158c83f8c6c5c52ac4b83b585530cebb0c2a7926bc068b8c3a9a83e70a3c4db799b5bbcfabbcbadd4cfaf754dd28dba6ae73645
+  checksum: 10c0/33f34459f695e79237322928fa625c0b080ca1303720c895d472e8df60474287aeda7c0e44bbede461ddb0ad58fdda60e53580a8352036ed25d69c80c19190ea
   languageName: node
   linkType: hard
 
-"@carbon/utilities@npm:^0.20.0":
-  version: 0.20.0
-  resolution: "@carbon/utilities@npm:0.20.0"
+"@carbon/utilities@npm:^0.21.0":
+  version: 0.21.0
+  resolution: "@carbon/utilities@npm:0.21.0"
   dependencies:
     "@ibm/telemetry-js": "npm:^1.6.1"
     "@internationalized/number": "npm:^3.6.1"
-  checksum: 10c0/ebddfa4063def17c82ef259f806f046ad7fc80119608c3e7ed7f131062020d32d3834ad6b0a48ea9add02763831d5eb6f60bda4d2f01c3c19bbd57fa1cf6d1b3
+  checksum: 10c0/bba686d5cff2e6a662ed008d054de3d98781858416ca249873dad45a29cc9aaf006e653c39882ed90ae55b80c815e539661f2362665b0118b87feb5115ba9598
   languageName: node
   linkType: hard
 
@@ -9249,7 +9223,7 @@ __metadata:
     gatsby-plugin-sharp: "npm:^5.13.1"
     gatsby-plugin-sitemap: "npm:^6.13.1"
     gatsby-source-filesystem: "npm:^5.13.1"
-    gatsby-theme-carbon: "npm:^4.3.52"
+    gatsby-theme-carbon: "npm:^4.3.53"
     gatsby-transformer-sharp: "npm:^5.13.1"
     html-loader: "npm:^5.1.0"
     husky: "npm:^9.0.11"
@@ -15343,18 +15317,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"gatsby-theme-carbon@npm:^4.3.52":
-  version: 4.3.52
-  resolution: "gatsby-theme-carbon@npm:4.3.52"
+"gatsby-theme-carbon@npm:^4.3.53":
+  version: 4.3.53
+  resolution: "gatsby-theme-carbon@npm:4.3.53"
   dependencies:
     "@babel/core": "npm:^7.29.0"
     "@babel/plugin-proposal-class-properties": "npm:^7.18.6"
     "@babel/plugin-syntax-jsx": "npm:^7.28.6"
-    "@carbon/elements": "npm:^11.91.0"
-    "@carbon/grid": "npm:^11.56.0"
-    "@carbon/pictograms-react": "npm:^11.104.0"
-    "@carbon/react": "npm:^1.110.0"
-    "@carbon/themes": "npm:^11.75.0"
+    "@carbon/elements": "npm:^11.92.1"
+    "@carbon/grid": "npm:^11.57.0"
+    "@carbon/pictograms-react": "npm:^11.105.0"
+    "@carbon/react": "npm:^1.111.1"
+    "@carbon/themes": "npm:^11.76.1"
     "@garcia-enterprise/gatsby-plugin-sass-resources": "npm:^4.0.2"
     "@mdx-js/mdx": "npm:^3.1.1"
     "@mdx-js/react": "npm:^3.1.1"
@@ -15399,7 +15373,7 @@ __metadata:
     gatsby: ^5.13.3
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 10c0/34f75283b2d210840fa1baf79e7bb827cc09395f3b7fb5374fd209b3eade7c569a5dcbcb090aed2b0a8bce804bffc16584532c04d9e9924f2c651016d68b8c0e
+  checksum: 10c0/f69ad7222ca3ef43b6b08b4728baccc960785453a1d41375aae6cd52cfc3ad437e4e5990aea08bfa8f01d0eb00f6536753403e3d6f355bb830a7a7f17bdf9683
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates the gatsby-theme-carbon version (v4.3.53) that pulls in the patch carbon dependency updates
